### PR TITLE
Patch Constructors

### DIFF
--- a/Liquip.Patcher.Tests/PlugPatcherTest_ObjectPlugs.cs
+++ b/Liquip.Patcher.Tests/PlugPatcherTest_ObjectPlugs.cs
@@ -68,13 +68,13 @@ public class PlugPatcherTest_ObjectPlugs
             targetAssembly.MainModule.Types.FirstOrDefault(t => t.Name == nameof(NativeWrapperObject));
         Assert.NotNull(targetType);
 
-        using StringWriter? stringWriter = new();
-        Console.SetOut(stringWriter);
-
         // Act: Apply the plug
         patcher.PatchAssembly(targetAssembly, plugAssembly);
 
         PlugUtils.Save(targetAssembly, "./", "targetCtorAssembly.dll");
+
+        using StringWriter? stringWriter = new();
+        Console.SetOut(stringWriter);
 
         object? instance = ExecuteConstructor(targetAssembly, "NativeWrapperObject");
 


### PR DESCRIPTION
See #1 

String writer was moved because it contained all the output of the patcher, that may interfere with the test (at least did while trying to implement this).