### PR TITLE
GCCBuildTask for unmanaged portable code.

### DIFF
--- a/examples/KernelExample/Kernel.cs
+++ b/examples/KernelExample/Kernel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Cosmos.Kernel.Boot.Limine;
 using Cosmos.Kernel.Core.Memory;
@@ -10,6 +11,10 @@ unsafe class Program
 {
     static readonly LimineFramebufferRequest Framebuffer = new();
     static readonly LimineHHDMRequest HHDM = new();
+
+    [MethodImpl(MethodImplOptions.InternalCall)]
+    [RuntimeImport("testGCC")]
+    extern static char* testGCC();
 
     [UnmanagedCallersOnly(EntryPoint = "kmain")]
     static void KernelMain() => Main();
@@ -31,6 +36,10 @@ unsafe class Program
         Canvas.DrawString("UART started.", 0, 28, Color.White);
 
         Serial.WriteString("Hello from UART\n");
+
+
+        char* gccString = testGCC();
+        Canvas.DrawString(gccString, 0, 56, Color.White);
 
         while (true) ;
     }

--- a/examples/KernelExample/KernelExample.csproj
+++ b/examples/KernelExample/KernelExample.csproj
@@ -18,6 +18,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <SelfContained>true</SelfContained>
     <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
@@ -25,6 +26,10 @@
   <ItemGroup>
     <AsmSearchPath Include="./src/Asm/" />
     <!-- You can also do: <AsmFiles Include="/path/to/file.asm" /> -->
+  </ItemGroup>
+
+  <ItemGroup>
+    <GCCProject Include="./src/C/" />
   </ItemGroup>
 
 <!--

--- a/examples/KernelExample/src/C/test.c
+++ b/examples/KernelExample/src/C/test.c
@@ -1,0 +1,7 @@
+typedef unsigned short char16_t;
+
+extern char16_t* testGCC()
+{
+    static char16_t hello[] = u"Hello from GCC";
+    return hello;
+}

--- a/install-packages.ps1
+++ b/install-packages.ps1
@@ -6,8 +6,10 @@ $projects = @(
     'src\Cosmos.Build.Common\Cosmos.Build.Common.csproj',
     'src\Cosmos.Build.Ilc\Cosmos.Build.Ilc.csproj',
     'src\Cosmos.Build.Asm\Cosmos.Build.Asm.csproj',
-    'src\Cosmos.Build.Analyzer.Patcher.Package\Cosmos.Build.Analyzer.Patcher.Package.csproj'
-    'src\Cosmos.Sdk\Cosmos.Sdk.csproj'
+    'src\Cosmos.Build.Analyzer.Patcher.Package\Cosmos.Build.Analyzer.Patcher.Package.csproj',
+    'src\Cosmos.Build.GCC\Cosmos.Build.GCC.csproj',
+    'src\Cosmos.Sdk\Cosmos.Sdk.csproj',
+    'src\Cosmos.Kernel.Native.x86\Cosmos.Kernel.Native.x86.csproj'
 )
 foreach ($proj in $projects) {
     dotnet build "$PSScriptRoot\$proj" -c Release

--- a/src/Cosmos.Build.Common/build/Cosmos.Build.Common.targets
+++ b/src/Cosmos.Build.Common/build/Cosmos.Build.Common.targets
@@ -17,6 +17,9 @@
 
     <ItemGroup>
       <ObjFiles Include="$(IntermediateOutputPath)/cosmos/asm/*.obj" />
+      <!-- GCC produced object files -->
+      <ObjFiles Include="$(IntermediateOutputPath)/cosmos/cobj/*.obj" />
+      <ObjFiles Include="$(IntermediateOutputPath)/cosmos/cobj/*.o" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Cosmos.Build.GCC/Cosmos.Build.GCC.csproj
+++ b/src/Cosmos.Build.GCC/Cosmos.Build.GCC.csproj
@@ -1,0 +1,49 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <GenerateDependencyFile>true</GenerateDependencyFile>
+  <Version>3.0.2</Version>
+
+    <!-- This target will run when MSBuild is collecting the files to be packaged, and we'll implement it below. This property controls the dependency list for this packaging process, so by adding our custom property we hook ourselves into the process in a supported way. -->
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
+    <!-- This property tells MSBuild where the root folder of the package's build assets should be. Because we are not a library package, we should not pack to 'lib'. Instead, we choose 'tasks' by convention. -->
+    <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
+    <!-- NuGet does validation that libraries in a package are exposed as dependencies, but we _explicitly_ do not want that behavior for MSBuild tasks. They are isolated by design. Therefore we ignore this specific warning. -->
+    <NoWarn>NU5100</NoWarn>
+    <!-- Suppress NuGet warning NU5128. -->
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" ExcludeAssets="Runtime"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="build\Cosmos.Build.GCC.props" PackagePath="build\" />
+    <Content Include="build\*.targets" PackagePath="build\" />
+  </ItemGroup>
+
+  <!-- This is the target we defined above. It's purpose is to add all of our PackageReference and ProjectReference's runtime assets to our package output.  -->
+  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">
+    <ItemGroup>
+      <!-- The TargetPath is the path inside the package that the source file will be placed. This is already precomputed in the ReferenceCopyLocalPaths items' DestinationSubPath, so reuse it here. -->
+      <BuildOutputInPackage
+          Include="@(ReferenceCopyLocalPaths)"
+          TargetPath="%(ReferenceCopyLocalPaths.DestinationSubPath)" />
+    </ItemGroup>
+  </Target>
+  
+  <!-- This target adds the generated deps.json file to our package output -->
+  <Target Name="AddBuildDependencyFileToBuiltProjectOutputGroupOutput"
+          BeforeTargets="BuiltProjectOutputGroup"
+          Condition=" '$(GenerateDependencyFile)' == 'true'">
+
+    <ItemGroup>
+      <BuiltProjectOutputGroupOutput
+          Include="$(ProjectDepsFilePath)"
+          TargetPath="$(ProjectDepsFileName)"
+          FinalOutputPath="$(ProjectDepsFilePath)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/Cosmos.Build.GCC/Tasks/GCCBuildTask.cs
+++ b/src/Cosmos.Build.GCC/Tasks/GCCBuildTask.cs
@@ -1,0 +1,200 @@
+// This code is licensed under MIT license (see LICENSE for details)
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Cosmos.Build.GCC.Tasks;
+
+public sealed class GCCBuildTask : ToolTask
+{
+    [Required] public string? GCCPath { get; set; }
+    [Required] public string? SourceFiles { get; set; }
+    [Required] public string? OutputPath { get; set; }
+    [Required] public string? OutputFile { get; set; }
+    
+    // Optional additional compiler flags
+    public string? CompilerFlags { get; set; }
+    
+    // ILC path for linking
+    public string? IlcPath { get; set; }
+
+    protected override MessageImportance StandardErrorLoggingImportance => MessageImportance.Normal;
+
+    protected override string GenerateFullPathToTool() =>
+        GCCPath!;    protected override string GenerateCommandLineCommands()
+    {
+        var sb = new StringBuilder();
+        
+        // Compile to object file, not a shared library
+        sb.Append(" -c ");
+        
+        // Add output flag
+        sb.Append($" -o {Path.Combine(OutputPath!, OutputFile)} ");
+        
+        // Add any user-provided compiler flags
+        if (!string.IsNullOrEmpty(CompilerFlags))
+        {
+            sb.Append($" {CompilerFlags} ");
+        }
+        
+        // Include all source files
+        var sourceFilePaths = Directory.GetFiles(SourceFiles!, "*.c", SearchOption.TopDirectoryOnly);
+        sb.Append(string.Join(" ", sourceFilePaths));
+
+        return sb.ToString();
+    }    public override bool Execute()
+    {
+        Log.LogMessage(MessageImportance.High, "Running Cosmos.GCC Build Task...");
+        Log.LogMessage(MessageImportance.High, $"Tool Path: {GCCPath}");
+        Log.LogMessage(MessageImportance.High, $"Source Directory: {SourceFiles}");
+        Log.LogMessage(MessageImportance.High, $"Output Path: {OutputPath}");
+        Log.LogMessage(MessageImportance.High, $"Output File: {OutputFile}");
+
+        if (!Directory.Exists(OutputPath))
+        {
+            Log.LogMessage(MessageImportance.Low, $"[Debug] Creating output directory: {OutputPath}");
+            Directory.CreateDirectory(OutputPath!);
+        }
+
+        // Check if source directory exists and contains C files
+        if (!Directory.Exists(SourceFiles))
+        {
+            Log.LogError($"Source directory {SourceFiles} does not exist");
+            return false;
+        }
+
+        var sourceFilePaths = Directory.GetFiles(SourceFiles!, "*.c", SearchOption.TopDirectoryOnly);
+        if (sourceFilePaths.Length == 0)
+        {
+            Log.LogWarning($"No C files found in directory {SourceFiles}");
+            return true; // Not an error, just nothing to compile
+        }
+
+        Log.LogMessage(MessageImportance.Normal, $"Found {sourceFilePaths.Length} C files to compile");
+        
+        // Execute the GCC command for each C file
+        using SHA1? hasher = SHA1.Create();
+        
+        foreach (string file in sourceFilePaths)
+        {
+            // Compute hash of file contents for a deterministic output filename
+            using FileStream stream = File.OpenRead(file);
+            byte[] fileHash = hasher.ComputeHash(stream);
+            string fileHashString = BitConverter.ToString(fileHash).Replace("-", "").ToLower();
+            
+            // Set file-specific output name
+            string baseName = Path.GetFileNameWithoutExtension(file);
+            // Produce Windows-friendly .obj extension so the linker (which currently searches for *.obj) can pick them up
+            var objExt = Path.DirectorySeparatorChar == '\\' ? ".obj" : ".o";
+            string outputName = $"{baseName}-{fileHashString.Substring(0, 8)}{objExt}";
+            string outputPath = Path.Combine(OutputPath!, outputName);
+            
+            // Build and execute the command for this file
+            StringBuilder sb = new();
+            sb.Append(" -c ");  // Compile to object file
+            sb.Append($" -o {outputPath} ");
+            
+            // Add any user-provided compiler flags
+            if (!string.IsNullOrEmpty(CompilerFlags))
+            {
+                sb.Append($" {CompilerFlags} ");
+            }
+            
+            // Add the source file
+            sb.Append($" {file} ");
+              // Execute GCC for this file
+            string commandLineArguments = sb.ToString();
+            Log.LogMessage(MessageImportance.Normal, $"Compiling {file} with args: {commandLineArguments}");
+            
+            // Validate GCC path exists
+            if (!File.Exists(GenerateFullPathToTool()) && !TestGCCInPath())
+            {
+                Log.LogError($"x86_64-elf-gcc not found at {GenerateFullPathToTool()}. Please install the x86_64-elf cross-compiler.");
+                return false;
+            }
+            
+            if (!ExecuteCommand(GenerateFullPathToTool(), commandLineArguments))
+            {
+                Log.LogError($"Failed to compile {file}");
+                return false;
+            }
+        }
+        
+        Log.LogMessage(MessageImportance.High, "✅ GCCBuildTask completed successfully.");
+        return true;
+    }
+
+    protected override string ToolName => "Cosmos.GCC";
+    
+    private bool TestGCCInPath()
+    {
+        try
+        {
+            // If GCCPath is just the executable name, test if it's in the PATH
+            if (Path.GetFileName(GCCPath!) == GCCPath)
+            {
+                var psi = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = GCCPath,
+                    Arguments = "--version",
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                };
+                
+                using var process = new System.Diagnostics.Process();
+                process.StartInfo = psi;
+                process.Start();
+                process.WaitForExit();
+                
+                return process.ExitCode == 0;
+            }
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+    
+    private bool ExecuteCommand(string toolPath, string arguments)
+    {
+        // Create process start info
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = toolPath,
+            Arguments = arguments,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        // Start the process
+        using var process = new System.Diagnostics.Process();
+        process.StartInfo = psi;
+        process.OutputDataReceived += (sender, e) => 
+        {
+            if (!string.IsNullOrEmpty(e.Data))
+                Log.LogMessage(MessageImportance.Normal, e.Data);
+        };
+        process.ErrorDataReceived += (sender, e) => 
+        {
+            if (!string.IsNullOrEmpty(e.Data))
+                Log.LogError(e.Data);
+        };
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        process.WaitForExit();
+
+        return process.ExitCode == 0;
+    }
+}

--- a/src/Cosmos.Build.GCC/build/Cosmos.Build.GCC.props
+++ b/src/Cosmos.Build.GCC/build/Cosmos.Build.GCC.props
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <CosmosGCCFrameworkPath>$(IntermediateOutputPath)cosmos-gcc\</CosmosGCCFrameworkPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+    <GCCPath Condition="'$(GCCPath)' == '' OR !Exists('$(GCCPath)')">/usr/bin/gcc</GCCPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+    <!-- Default Windows GCC path - can be overridden in project file -->
+    <GCCPath Condition="'$(GCCPath)' == '' OR !Exists('$(GCCPath)')">gcc</GCCPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Corrected task assembly file name (was Cosmos.GCC.Build.dll) -->
+    <CosmosGCCTasksAssembly
+      Condition="'$(CosmosGCCTasksAssembly)' == '' OR !Exists('$(CosmosGCCTasksAssembly)')">$(MSBuildThisFileDirectory)\..\tasks\netstandard2.0\Cosmos.Build.GCC.dll</CosmosGCCTasksAssembly>
+  </PropertyGroup>
+
+  <UsingTask TaskName="Cosmos.Build.GCC.Tasks.GCCBuildTask" AssemblyFile="$(CosmosGCCTasksAssembly)"/>
+</Project>

--- a/src/Cosmos.Build.GCC/build/Cosmos.Build.GCC.targets
+++ b/src/Cosmos.Build.GCC/build/Cosmos.Build.GCC.targets
@@ -1,0 +1,67 @@
+<Project>
+  <Import Project="GCC.Build.Unix.targets" Condition="'$(OS)' != 'Windows_NT'"/>
+  <Import Project="GCC.Build.Windows.targets" Condition="'$(OS)' == 'Windows_NT'"/>
+
+  <Target Name="FindCSourceFilesForGCC" BeforeTargets="BuildGCC">
+    <PropertyGroup>
+      <TargetArchitecture Condition="$(RuntimeIdentifier) != ''">$(RuntimeIdentifier.Split('-')[1])</TargetArchitecture>
+    </PropertyGroup>
+
+    <!-- Exclude Folders/Files that doesn't exists -->
+    <ItemGroup>
+      <NonExistentPaths Include="@(GCCProject)" Condition="!Exists('%(FullPath)')" />
+      <GCCProject Remove="@(NonExistentPaths)" />
+    </ItemGroup>
+
+    <Warning Text="Folder does not exists: %(NonExistentPaths.Identity)" Condition="@(NonExistentPaths) != ''" />
+
+    <!-- Override Folders For Architecture Specific Ones -->
+    <ItemGroup Condition="'$(TargetArchitecture)' != ''">
+      <GCCProjectWithArch Include="@(GCCProject)" Condition="Exists('%(FullPath)/$(TargetArchitecture)/')" />
+      <GCCProject Remove="@(GCCProjectWithArch)"/>
+      <GCCProject Include="@(GCCProjectWithArch->'%(FullPath)/$(TargetArchitecture)/')"/>
+    </ItemGroup>
+
+    <Message Text="⚙️  [GCC] Found C project directories: @(GCCProject)" Importance="High" />
+  </Target>  <!-- Target to compile C files with GCC -->  <Target Name="BuildGCC" AfterTargets="BuildYasm" DependsOnTargets="FindCSourceFilesForGCC;GetGCC">
+    <PropertyGroup>
+      <GCCOutputPath>$(IntermediateOutputPath)cosmos/cobj/</GCCOutputPath>
+      <!-- Default compiler flags for generating position-independent code suitable for kernel -->
+      <GCCCompilerFlags Condition="'$(GCCCompilerFlags)' == ''">-O2 -fno-stack-protector -nostdinc -fno-builtin</GCCCompilerFlags>
+      <!-- Add architecture-specific flags based on target -->
+      <GCCCompilerFlags Condition="'$(TargetArchitecture)' == 'x64'">$(GCCCompilerFlags) -m64 -mcmodel=kernel -ffreestanding</GCCCompilerFlags>
+    </PropertyGroup>
+    
+    <!-- Create / clean output directory -->
+    <MakeDir Directories="$(GCCOutputPath)" Condition="!Exists('$(GCCOutputPath)')" />
+    <!-- Always remove all previous GCC-produced object files to avoid linking stale objects -->
+    <ItemGroup>
+      <OldGccObjs Include="$(GCCOutputPath)*.obj" />
+      <OldGccObjs Include="$(GCCOutputPath)*.o" />
+    </ItemGroup>
+    <Delete Files="@(OldGccObjs)" Condition="@(OldGccObjs) != ''" />
+    
+    <!-- Process each GCC project directory separately -->
+    <Message 
+      Text="⚙️  [GCC] Processing C project: %(GCCProject.Identity)" 
+      Importance="High" />
+    
+    <!-- Compile each project to multiple object files -->
+    <GCCBuildTask
+      GCCPath="$(GCCPath)"
+      SourceFiles="%(GCCProject.Identity)"
+      OutputPath="$(GCCOutputPath)"
+      OutputFile="dummy.o"
+      CompilerFlags="$(GCCCompilerFlags)" />
+    
+    <Message Text="✅ [GCC] C files compiled to object files in: $(GCCOutputPath)" Importance="High" />
+  </Target>
+  <!-- Clean target to remove the gcc object files folder -->
+  <Target Name="CleanGCC" BeforeTargets="Clean">
+    <PropertyGroup>
+      <GCCOutputPath>$(IntermediateOutputPath)cosmos/cobj/</GCCOutputPath>
+    </PropertyGroup>
+
+    <RemoveDir Directories="$(GCCOutputPath)" />
+  </Target>
+</Project>

--- a/src/Cosmos.Build.GCC/build/GCC.Build.Unix.targets
+++ b/src/Cosmos.Build.GCC/build/GCC.Build.Unix.targets
@@ -1,0 +1,9 @@
+<Project>  <Target Name="GetGCC" Condition="'$(OS)' != 'Windows_NT'">
+    <!-- Always use gcc as the tool path -->
+    <PropertyGroup>
+      <GCCPath>gcc</GCCPath>
+    </PropertyGroup>
+    
+    <Message Text="Using GCC for kernel compilation: $(GCCPath)" Importance="High" />
+  </Target>
+</Project>

--- a/src/Cosmos.Build.GCC/build/GCC.Build.Windows.targets
+++ b/src/Cosmos.Build.GCC/build/GCC.Build.Windows.targets
@@ -1,0 +1,10 @@
+<Project>  
+  <Target Name="GetGCC" Condition="'$(OS)' == 'Windows_NT'">
+    <!-- Always use x86_64-elf-gcc as the tool path -->
+    <PropertyGroup>
+      <GCCPath>x86_64-elf-gcc</GCCPath>
+    </PropertyGroup>
+
+    <Message Text="Using GCC for kernel compilation: $(GCCPath)" Importance="High" />
+  </Target>
+</Project>

--- a/src/Cosmos.Kernel.Runtime/Stdllib.cs
+++ b/src/Cosmos.Kernel.Runtime/Stdllib.cs
@@ -106,7 +106,7 @@ namespace System
             public RuntimeExportAttribute(string entry) { }
         }
 
-        internal sealed class RuntimeImportAttribute : Attribute
+        public sealed class RuntimeImportAttribute : Attribute
         {
             public string DllName { get; }
             public string EntryPoint { get; }

--- a/src/Cosmos.Kernel.System.Graphics/Canvas.cs
+++ b/src/Cosmos.Kernel.System.Graphics/Canvas.cs
@@ -90,4 +90,9 @@ public unsafe class Canvas
     {
         PCScreenFont.PutString(text, x, y, color, Color.Transparent);
     }
+
+    public static unsafe void DrawString(char* text, int x, int y, uint color)
+    {
+        PCScreenFont.PutString(text, x, y, color, Color.Transparent);
+    }
 }

--- a/src/Cosmos.Kernel.System.Graphics/Fonts/PSFFont.cs
+++ b/src/Cosmos.Kernel.System.Graphics/Fonts/PSFFont.cs
@@ -74,6 +74,14 @@ public static unsafe class PCScreenFont
         }
     }
 
+    public static void PutString(char* str, int x, int y, uint fg, uint bg)
+    {
+        for (int i = 0; str[i] != 0; i++)
+        {
+            PutChar(str[i], x + (i * 16), y, fg, bg);
+        }
+    }
+
     public static void PutChar(
         ushort c, int cx, int cy,
         uint fg, uint bg)

--- a/src/Cosmos.Sdk/Sdk/Sdk.props
+++ b/src/Cosmos.Sdk/Sdk/Sdk.props
@@ -3,7 +3,7 @@
     <UsingCosmosSdk>true</UsingCosmosSdk>
     <!-- Ilc  -->
     <IlcDependsOn>RunPatcher;$(IlcDependsOn);PrepareForILLink</IlcDependsOn>
-    <LinkTargetDependsOn>CompileWithIlc;BuildYasm;$(LinkTargetDependsOn)</LinkTargetDependsOn>
+    <LinkTargetDependsOn>CompileWithIlc;BuildYasm;BuildGCC;$(LinkTargetDependsOn)</LinkTargetDependsOn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,5 +16,6 @@
     <PackageReference Include="Cosmos.Build.Ilc" Version="1.0.0"/>
     <PackageReference Include="Cosmos.Build.Asm" Version="3.0.0"/>
     <PackageReference Include="Cosmos.Build.Patcher" Version="3.0.0"/>
+  <PackageReference Include="Cosmos.Build.GCC" Version="3.0.2"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
CLANG on Windows can have issues.

Windows GCC cross compiler can be found [here](https://github.com/lordmilko/i686-elf-tools/releases/tag/13.2.0).