### PR TITLE
Ignore non-decorated plug members in tests

### DIFF
--- a/tests/Cosmos.Tests.NativeWrapper/NativeWrapperPlug.cs
+++ b/tests/Cosmos.Tests.NativeWrapper/NativeWrapperPlug.cs
@@ -13,5 +13,5 @@ public class TestClassPlug
     {
     }
 
-    public static int ManagedAdd(int a, int b) => a * b;
+    public static int ManagedAdd(int a, int b) => a + b;
 }

--- a/tests/Cosmos.Tests.NativeWrapper/NativeWrapperPlug.cs
+++ b/tests/Cosmos.Tests.NativeWrapper/NativeWrapperPlug.cs
@@ -12,4 +12,6 @@ public class TestClassPlug
     public static void OutputDebugString(object aThis)
     {
     }
+
+    public static int ManagedAdd(int a, int b) => a * b;
 }


### PR DESCRIPTION
## Summary
- Skip methods without `PlugMemberAttribute` when validating plug patching
- Add `ManagedAdd` plug method without attribute for negative testing
- Verify that methods lacking plug attributes remain unpatched

## Testing
- `dotnet test tests/Cosmos.Tests.Patcher/Cosmos.Tests.Patcher.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a55b10e6608328b3a3460ae0f3c712