### PR TITLE
Implement basic Rhp allocation using MemoryOp

### DIFF
--- a/examples/KernelExample/Kernel.cs
+++ b/examples/KernelExample/Kernel.cs
@@ -42,6 +42,12 @@ internal unsafe class Program
         char* gccString = testGCC();
         Canvas.DrawString(gccString, 0, 56, Color.White);
 
+        char[] testChars = new char[] { 'R', 'h', 'p' };
+        string testString = new string(testChars);
+        testString += " string test";
+        Canvas.DrawString(testString, 0, 84, Color.White);
+        Serial.WriteString(testString + "\n");
+
         while (true) ;
     }
 }

--- a/examples/KernelExample/Kernel.cs
+++ b/examples/KernelExample/Kernel.cs
@@ -38,13 +38,11 @@ internal unsafe class Program
 
         Serial.WriteString("Hello from UART\n");
 
-
         char* gccString = testGCC();
         Canvas.DrawString(gccString, 0, 56, Color.White);
 
         char[] testChars = new char[] { 'R', 'h', 'p' };
         string testString = new string(testChars);
-        testString += " string test";
         Canvas.DrawString(testString, 0, 84, Color.White);
         Serial.WriteString(testString + "\n");
 

--- a/src/Cosmos.Kernel.Core/Cosmos.Kernel.Core.csproj
+++ b/src/Cosmos.Kernel.Core/Cosmos.Kernel.Core.csproj
@@ -4,7 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    
+
     <!-- Package Metadata -->
     <PackageId>Cosmos.Kernel.System.Core</PackageId>
     <Title>Cosmos Kernel Core</Title>
@@ -15,7 +15,4 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Cosmos.Kernel.Runtime\Cosmos.Kernel.Runtime.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Cosmos.Kernel.Core/Memory/MemoryOp.cs
+++ b/src/Cosmos.Kernel.Core/Memory/MemoryOp.cs
@@ -97,6 +97,29 @@ public static unsafe class MemoryOp
         }
     }
 
+    public static void MemMove(byte* dest, byte* src, int count)
+    {
+        if (dest == src || count == 0)
+        {
+            return;
+        }
+
+        if (dest < src)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                dest[i] = src[i];
+            }
+        }
+        else
+        {
+            for (int i = count - 1; i >= 0; i--)
+            {
+                dest[i] = src[i];
+            }
+        }
+    }
+
     public static bool MemCmp(uint* dest, uint* src, int count)
     {
         for (int i = 0; i < count; i++)

--- a/src/Cosmos.Kernel.Runtime/Cosmos.Kernel.Runtime.csproj
+++ b/src/Cosmos.Kernel.Runtime/Cosmos.Kernel.Runtime.csproj
@@ -14,4 +14,8 @@
     <!-- You can also do: <AsmFiles Include="/path/to/file.asm" /> -->
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\\Cosmos.Kernel.Core\\Cosmos.Kernel.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Cosmos.Kernel.Runtime/Stdllib.cs
+++ b/src/Cosmos.Kernel.Runtime/Stdllib.cs
@@ -223,7 +223,7 @@ namespace Internal.Runtime.CompilerHelpers
         {
             return RhpNewArray(pEEType, length);
         }
-        
+
         /*
                 [RuntimeExport("RhTypeCast_CheckCastAny")]
                 static unsafe object RhTypeCast_CheckCastAny(object obj, int typeHandle) { throw null; }

--- a/src/Cosmos.Kernel.Runtime/Stdllib.cs
+++ b/src/Cosmos.Kernel.Runtime/Stdllib.cs
@@ -209,27 +209,13 @@ namespace Internal.Runtime.CompilerHelpers
         [RuntimeExport("memmove")]
         private static unsafe void memmove(byte* dest, byte* src, UIntPtr len)
         {
-            uint n = (uint)len;
-            if (dest == src || n == 0)
-                return;
-
-            if (dest < src)
-            {
-                for (uint i = 0; i < n; i++)
-                    dest[i] = src[i];
-            }
-            else
-            {
-                for (uint i = n; i > 0; i--)
-                    dest[i - 1] = src[i - 1];
-            }
+            MemoryOp.MemMove(dest, src, (int)len);
         }
 
         [RuntimeExport("memset")]
         private static unsafe void memset(byte* dest, int value, UIntPtr len)
         {
-            for (uint i = 0; i < (uint)len; i++)
-                dest[i] = (byte)value;
+            MemoryOp.MemSet(dest, (byte)value, (int)len);
         }
 
         [RuntimeExport("RhNewString")]


### PR DESCRIPTION
## Summary
- integrate MemoryOp allocator into runtime
- implement basic Rhp helpers (RhpNewFast, RhpNewArray, RhpAssignRef) for string allocation
- reference Cosmos.Kernel.Core project in Cosmos.Kernel.Runtime
- drop Core's runtime reference to avoid circular build

## References
- https://github.com/dotnet/dotnet/blob/main/src/runtime/src/coreclr/nativeaot/Runtime/portable.cpp