### PR TITLE
Add canvas-based console and graphics HAL with System.Console plug

### DIFF
--- a/examples/KernelExample/Kernel.cs
+++ b/examples/KernelExample/Kernel.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Cosmos.Kernel.Boot.Limine;
 using Cosmos.Kernel.Core.Memory;
-using Cosmos.Kernel.System.Graphics;
+using Cosmos.Kernel.HAL;
 using Cosmos.Kernel.System.IO;
 
 internal unsafe class Program
@@ -23,27 +23,20 @@ internal unsafe class Program
     {
         MemoryOp.InitializeHeap(HHDM.Offset, 0x1000000);
         LimineFramebuffer* fb = Framebuffer.Response->Framebuffers[0];
-        Canvas.Address = (uint*)fb->Address;
-        Canvas.Pitch = (uint)fb->Pitch;
-        Canvas.Width = (uint)fb->Width;
-        Canvas.Height = (uint)fb->Height;
+        Screen.Init(fb->Address, (uint)fb->Width, (uint)fb->Height, (uint)fb->Pitch);
 
-        Canvas.ClearScreen(Color.Black);
-
-        Canvas.DrawString("CosmosOS booted.", 0, 0, Color.White);
+        Console.WriteLine("CosmosOS booted.");
 
         Serial.ComInit();
-
-        Canvas.DrawString("UART started.", 0, 28, Color.White);
-
+        Console.WriteLine("UART started.");
         Serial.WriteString("Hello from UART\n");
 
         char* gccString = testGCC();
-        Canvas.DrawString(gccString, 0, 56, Color.White);
+        Console.WriteLine(new string(gccString));
 
         char[] testChars = new char[] { 'R', 'h', 'p' };
         string testString = new string(testChars);
-        Canvas.DrawString(testString, 0, 84, Color.White);
+        Console.WriteLine(testString);
         Serial.WriteString(testString + "\n");
 
         while (true) ;

--- a/examples/KernelExample/KernelExample.csproj
+++ b/examples/KernelExample/KernelExample.csproj
@@ -52,7 +52,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Cosmos.Kernel.Boot.Limine\Cosmos.Kernel.Boot.Limine.csproj" />
     <ProjectReference Include="..\..\src\Cosmos.Kernel.Core\Cosmos.Kernel.Core.csproj" />
-    <ProjectReference Include="..\..\src\Cosmos.Kernel.System.Graphics\Cosmos.Kernel.System.Graphics.csproj" />
+    <ProjectReference Include="..\..\src\Cosmos.Kernel.HAL\Cosmos.Kernel.HAL.csproj" />
+    <ProjectReference Include="..\..\src\Cosmos.Kernel.Plugs\Cosmos.Kernel.Plugs.csproj" />
   </ItemGroup>
 
   <Target Name="CustomIlcArgs" BeforeTargets="WriteIlcRsp" DependsOnTargets="PrepareForILLink">

--- a/nativeaot-patcher.slnx
+++ b/nativeaot-patcher.slnx
@@ -20,6 +20,8 @@
     <Project Path="src/Cosmos.Patcher/Cosmos.Patcher.csproj" Type="Classic C#" />
     <Project Path="src/Cosmos.Sdk/Cosmos.Sdk.csproj" Type="Classic C#" />
     <Project Path="src\Cosmos.Kernel.Core\Cosmos.Kernel.Core.csproj" Type="Classic C#" />
+    <Project Path="src/Cosmos.Kernel.HAL/Cosmos.Kernel.HAL.csproj" Type="Classic C#" />
+    <Project Path="src/Cosmos.Kernel.Plugs/Cosmos.Kernel.Plugs.csproj" Type="Classic C#" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests\Cosmos.Tests.Build.Analyzer.Patcher\Cosmos.Tests.Build.Analyzer.Patcher.csproj" Type="Classic C#" />

--- a/src/Cosmos.Kernel.HAL/Cosmos.Kernel.HAL.csproj
+++ b/src/Cosmos.Kernel.HAL/Cosmos.Kernel.HAL.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>Cosmos.Kernel.HAL</PackageId>
+    <Title>Cosmos Kernel HAL</Title>
+    <Description>Hardware abstraction layer for Cosmos graphics initialization.</Description>
+    <PackageTags>cosmos;kernel;hal;graphics</PackageTags>
+    <RepositoryUrl>https://github.com/valentinbreiz/nativeaot-patcher</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/valentinbreiz/nativeaot-patcher</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Cosmos.Kernel.System.Graphics\Cosmos.Kernel.System.Graphics.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Cosmos.Kernel.HAL/Screen.cs
+++ b/src/Cosmos.Kernel.HAL/Screen.cs
@@ -1,0 +1,15 @@
+using Cosmos.Kernel.System.Graphics;
+
+namespace Cosmos.Kernel.HAL;
+
+public static unsafe class Screen
+{
+    public static void Init(void* address, uint width, uint height, uint pitch)
+    {
+        Canvas.Address = (uint*)address;
+        Canvas.Width = width;
+        Canvas.Height = height;
+        Canvas.Pitch = pitch;
+        Canvas.ClearScreen(Color.Black);
+    }
+}

--- a/src/Cosmos.Kernel.Plugs/Cosmos.Kernel.Plugs.csproj
+++ b/src/Cosmos.Kernel.Plugs/Cosmos.Kernel.Plugs.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>Cosmos.Kernel.Plugs</PackageId>
+    <Title>Cosmos Kernel Plugs</Title>
+    <Description>BCL plugs for Cosmos kernel including console redirection.</Description>
+    <PackageTags>cosmos;kernel;plugs;console</PackageTags>
+    <RepositoryUrl>https://github.com/valentinbreiz/nativeaot-patcher</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/valentinbreiz/nativeaot-patcher</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Cosmos.Build.API\Cosmos.Build.API.csproj" />
+    <ProjectReference Include="..\Cosmos.Kernel.System.Graphics\Cosmos.Kernel.System.Graphics.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Cosmos.Kernel.Plugs/System/ConsolePlug.cs
+++ b/src/Cosmos.Kernel.Plugs/System/ConsolePlug.cs
@@ -1,0 +1,15 @@
+using System;
+using Cosmos.Build.API.Attributes;
+using Cosmos.Kernel.System.Graphics;
+
+namespace Cosmos.Kernel.Plugs.System;
+
+[Plug(typeof(Console))]
+public static class ConsolePlug
+{
+    public static void Write(string value) => KernelConsole.Write(value);
+    public static void WriteLine(string value) => KernelConsole.WriteLine(value);
+    public static void Write(char value) => KernelConsole.Write(value);
+    public static void WriteLine(char value) => KernelConsole.WriteLine(value);
+    public static void WriteLine() => KernelConsole.WriteLine();
+}

--- a/src/Cosmos.Kernel.System.Graphics/KernelConsole.cs
+++ b/src/Cosmos.Kernel.System.Graphics/KernelConsole.cs
@@ -1,0 +1,61 @@
+namespace Cosmos.Kernel.System.Graphics;
+
+public static class KernelConsole
+{
+    private static int _cursorX;
+    private static int _cursorY;
+    private const int CharWidth = 16;
+    private const int CharHeight = 16;
+
+    public static void Write(string text)
+    {
+        foreach (char c in text)
+        {
+            Write(c);
+        }
+    }
+
+    public static void Write(char c)
+    {
+        if (c == '\n')
+        {
+            NewLine();
+            return;
+        }
+
+        Canvas.DrawChar(c, _cursorX, _cursorY, Color.White);
+        _cursorX += CharWidth;
+        if (_cursorX + CharWidth > Canvas.Width)
+        {
+            NewLine();
+        }
+    }
+
+    public static void WriteLine(string text)
+    {
+        Write(text);
+        NewLine();
+    }
+
+    public static void WriteLine(char c)
+    {
+        Write(c);
+        NewLine();
+    }
+
+    public static void WriteLine()
+    {
+        NewLine();
+    }
+
+    private static void NewLine()
+    {
+        _cursorX = 0;
+        _cursorY += CharHeight;
+        if (_cursorY + CharHeight > Canvas.Height)
+        {
+            Canvas.ClearScreen(Color.Black);
+            _cursorY = 0;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add KernelConsole to draw text via Canvas
- Introduce HAL Screen initializer for graphics memory setup
- Plug System.Console to KernelConsole and register new projects
- Update example kernel to use System.Console with Screen HAL

## Testing
- `dotnet test` *(fails: required .NET SDK version 9.0.200 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7834067d48328a33f11489d179836