### PR TITLE
Remove P/Invoke metadata when plugging methods

### DIFF
--- a/src/Cosmos.Patcher/PlugPatcher.cs
+++ b/src/Cosmos.Patcher/PlugPatcher.cs
@@ -447,6 +447,19 @@ public sealed class PlugPatcher
             }
         }
 
+        // Remove P/Invoke metadata so the runtime treats the method as managed
+        if (targetMethod.IsPInvokeImpl || targetMethod.PInvokeInfo is not null)
+        {
+            Console.WriteLine("[PatchMethod] Removing P/Invoke metadata");
+            targetMethod.PInvokeInfo = null;
+            targetMethod.Attributes &= ~MethodAttributes.PInvokeImpl;
+            targetMethod.ImplAttributes &= ~MethodImplAttributes.PreserveSig;
+            targetMethod.ImplAttributes &= ~MethodImplAttributes.InternalCall;
+            targetMethod.ImplAttributes &= ~MethodImplAttributes.Native;
+            targetMethod.ImplAttributes &= ~MethodImplAttributes.Unmanaged;
+            targetMethod.ImplAttributes &= ~MethodImplAttributes.Runtime;
+        }
+
         if (targetMethod.Body.Instructions.Count == 0 || targetMethod.Body.Instructions[^1].OpCode != OpCodes.Ret)
         {
             Console.WriteLine("[PatchMethod] Adding final RET instruction");

--- a/tests/Cosmos.Tests.Patcher/PlugPatcherTest_StaticPlugs.cs
+++ b/tests/Cosmos.Tests.Patcher/PlugPatcherTest_StaticPlugs.cs
@@ -93,6 +93,11 @@ public class PlugPatcherTest_StaticPlugs
         // Act
         patcher.PatchAssembly(targetAssembly, plugAssembly);
 
+        TypeDefinition targetType = targetAssembly.MainModule.Types.First(t => t.Name == nameof(TestClass));
+        MethodDefinition targetMethod = targetType.Methods.First(m => m.Name == "Add");
+        Assert.False(targetMethod.IsPInvokeImpl);
+        Assert.Null(targetMethod.PInvokeInfo);
+
         targetAssembly.Save("./", "targetAssembly.dll");
 
         object result = ExecuteObject(targetAssembly, "TestClass", "Add", 3, 4);


### PR DESCRIPTION
## Summary
- strip P/Invoke flags and info when methods are patched so they become regular managed methods
- verify in tests that the Add method no longer has P/Invoke metadata and returns the plugged result

## Testing
- `dotnet build tests/Cosmos.Tests.Patcher/Cosmos.Tests.Patcher.csproj --configuration Debug`
- `dotnet test ./tests/Cosmos.Tests.Patcher/Cosmos.Tests.Patcher.csproj --no-build --configuration Debug --logger "trx;LogFileName=Cosmos.Tests.Patcher.trx"`


------
https://chatgpt.com/codex/tasks/task_e_68a92c2f3bb4832881a89661439c9f90