### PR TITLE
Add x64 keyboard interrupt handling

### DIFF
--- a/examples/KernelExample/Kernel.cs
+++ b/examples/KernelExample/Kernel.cs
@@ -6,6 +6,7 @@ using Cosmos.Kernel.Boot.Limine;
 using Cosmos.Kernel.Core.Memory;
 using Cosmos.Kernel.HAL;
 using Cosmos.Kernel.System.IO;
+using Cosmos.Kernel.System.Interrupts;
 
 internal unsafe class Program
 {
@@ -38,6 +39,10 @@ internal unsafe class Program
         string testString = new string(testChars);
         Console.WriteLine(testString);
         Serial.WriteString(testString + "\n");
+        InterruptManager.Initialize();
+        Console.WriteLine("Keyboard ready. Type a line:");
+        string line = Console.ReadLine();
+        Console.WriteLine("You typed: " + line);
 
         while (true) ;
     }

--- a/src/Cosmos.Kernel.Native.x86/Cosmos.Kernel.Native.x86.csproj
+++ b/src/Cosmos.Kernel.Native.x86/Cosmos.Kernel.Native.x86.csproj
@@ -4,7 +4,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    
+
     <!-- Package Metadata -->
     <PackageId>Cosmos.Kernel.Native.x86</PackageId>
     <Title>Cosmos Kernel x86 Native Assembly</Title>
@@ -18,5 +18,6 @@
   <ItemGroup>
     <Content Include="build\Cosmos.Kernel.Native.x86.props" PackagePath="build\" />
     <Content Include="IO\*.asm" PackagePath="build\IO" />
+    <Content Include="Cpu\*.asm" PackagePath="build\Cpu" />
   </ItemGroup>
 </Project>

--- a/src/Cosmos.Kernel.Native.x86/Cpu/Cpu.asm
+++ b/src/Cosmos.Kernel.Native.x86/Cpu/Cpu.asm
@@ -1,0 +1,22 @@
+section .text
+
+; Load Interrupt Descriptor Table
+; void _native_lidt(void* baseAddress, ushort size)
+; rdi = base address, rsi = size
+
+global _native_lidt
+_native_lidt:
+    sub     rsp, 16            ; allocate space for descriptor
+    mov     word [rsp], si     ; store size
+    mov     qword [rsp+2], rdi ; store base
+    lidt    [rsp]              ; load IDT
+    add     rsp, 16            ; clean stack
+    ret
+
+; Enable interrupts
+; void _native_sti()
+
+global _native_sti
+_native_sti:
+    sti
+    ret

--- a/src/Cosmos.Kernel.Native.x86/build/Cosmos.Kernel.Native.x86.props
+++ b/src/Cosmos.Kernel.Native.x86/build/Cosmos.Kernel.Native.x86.props
@@ -3,6 +3,7 @@
   <!-- Add any folder(s) where *.asm files exist -->
   <ItemGroup>
     <AsmSearchPath Include="$(MSBuildThisFileDirectory)/IO/" />
+    <AsmSearchPath Include="$(MSBuildThisFileDirectory)/Cpu/" />
     <!-- You can also do: <AsmFiles Include="/path/to/file.asm" /> -->
   </ItemGroup>
 </Project>

--- a/src/Cosmos.Kernel.Plugs/Cosmos.Kernel.Plugs.csproj
+++ b/src/Cosmos.Kernel.Plugs/Cosmos.Kernel.Plugs.csproj
@@ -15,5 +15,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Cosmos.Build.API\Cosmos.Build.API.csproj" />
     <ProjectReference Include="..\Cosmos.Kernel.System.Graphics\Cosmos.Kernel.System.Graphics.csproj" />
+    <ProjectReference Include="..\Cosmos.Kernel.System\Cosmos.Kernel.System.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Cosmos.Kernel.Plugs/System/ConsolePlug.cs
+++ b/src/Cosmos.Kernel.Plugs/System/ConsolePlug.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Text;
 using Cosmos.Build.API.Attributes;
 using Cosmos.Kernel.System.Graphics;
+using Cosmos.Kernel.System.Input;
 
 namespace Cosmos.Kernel.Plugs.System;
 
@@ -21,4 +23,31 @@ public class ConsolePlug
 
     [PlugMember]
     public static void WriteLine() => KernelConsole.WriteLine();
+
+    [PlugMember]
+    public static ConsoleKeyInfo ReadKey()
+    {
+        char c = KernelKeyboard.ReadChar();
+        return new ConsoleKeyInfo(c, ConsoleKey.NoName, false, false, false);
+    }
+
+    [PlugMember]
+    public static string ReadLine()
+    {
+        var buffer = new StringBuilder();
+        while (true)
+        {
+            char c = KernelKeyboard.ReadChar();
+            if (c == '\n' || c == '\r')
+            {
+                KernelConsole.WriteLine();
+                break;
+            }
+
+            buffer.Append(c);
+            KernelConsole.Write(c);
+        }
+
+        return buffer.ToString();
+    }
 }

--- a/src/Cosmos.Kernel.Runtime/Internal.cs
+++ b/src/Cosmos.Kernel.Runtime/Internal.cs
@@ -31,4 +31,15 @@ public static class Native
         [RuntimeImport("*", "_native_io_read_dword")]
         public static extern uint Read32(ushort Port);
     }
+
+    public static class Cpu
+    {
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        [RuntimeImport("*", "_native_lidt")]
+        public static extern unsafe void Lidt(void* baseAddress, ushort size);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        [RuntimeImport("*", "_native_sti")]
+        public static extern void Sti();
+    }
 }

--- a/src/Cosmos.Kernel.System/Input/KernelKeyboard.cs
+++ b/src/Cosmos.Kernel.System/Input/KernelKeyboard.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Cosmos.Kernel.System.Input;
+
+public static class KernelKeyboard
+{
+    private const int BufferSize = 128;
+    private static readonly char[] _buffer = new char[BufferSize];
+    private static int _head;
+    private static int _tail;
+
+    public static void AddChar(char c)
+    {
+        int next = (_tail + 1) & (BufferSize - 1);
+        if (next == _head)
+        {
+            // Buffer full, drop character
+            return;
+        }
+        _buffer[_tail] = c;
+        _tail = next;
+    }
+
+    public static bool TryReadChar(out char c)
+    {
+        if (_head == _tail)
+        {
+            c = default;
+            return false;
+        }
+        c = _buffer[_head];
+        _head = (_head + 1) & (BufferSize - 1);
+        return true;
+    }
+
+    public static char ReadChar()
+    {
+        while (!TryReadChar(out var c))
+        {
+            // Busy wait until character available
+        }
+        return c;
+    }
+}

--- a/src/Cosmos.Kernel.System/Input/KeyboardDriver.cs
+++ b/src/Cosmos.Kernel.System/Input/KeyboardDriver.cs
@@ -1,0 +1,33 @@
+using System.Runtime.InteropServices;
+using Cosmos.Kernel.Runtime;
+using Cosmos.Kernel.System.Interrupts;
+
+namespace Cosmos.Kernel.System.Input;
+
+public static unsafe class KeyboardDriver
+{
+    private const ushort DataPort = 0x60;
+
+    private static readonly char[] ScancodeMap = new char[128]
+    {
+        '\0','\x1B','1','2','3','4','5','6','7','8','9','0','-','=', '\b','\t',
+        'q','w','e','r','t','y','u','i','o','p','[',']','\n','\0','a','s','d','f','g','h','j','k','l',';','\'','`',
+        '\0','\\','z','x','c','v','b','n','m',',','.','/','\0','*','\0',' ','\0'
+    };
+
+    [UnmanagedCallersOnly]
+    public static void KeyboardIsr()
+    {
+        byte sc = Native.IO.Read8(DataPort);
+        char c = '\0';
+        if (sc < ScancodeMap.Length)
+        {
+            c = ScancodeMap[sc];
+        }
+        if (c != '\0')
+        {
+            KernelKeyboard.AddChar(c);
+        }
+        InterruptManager.SendEoi(1);
+    }
+}

--- a/src/Cosmos.Kernel.System/Interrupts/Idt.cs
+++ b/src/Cosmos.Kernel.System/Interrupts/Idt.cs
@@ -1,0 +1,44 @@
+using System.Runtime.InteropServices;
+using Cosmos.Kernel.Runtime;
+
+namespace Cosmos.Kernel.System.Interrupts;
+
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+public struct IdtEntry
+{
+    public ushort OffsetLow;
+    public ushort Selector;
+    public byte Ist;
+    public byte TypeAttr;
+    public ushort OffsetMid;
+    public uint OffsetHigh;
+    public uint Zero;
+}
+
+public static unsafe class Idt
+{
+    private static readonly IdtEntry[] Entries = new IdtEntry[256];
+
+    public static void SetEntry(int vector, void* handler)
+    {
+        ulong addr = (ulong)handler;
+        Entries[vector] = new IdtEntry
+        {
+            OffsetLow = (ushort)(addr & 0xFFFF),
+            Selector = 0x08,
+            Ist = 0,
+            TypeAttr = 0x8E,
+            OffsetMid = (ushort)((addr >> 16) & 0xFFFF),
+            OffsetHigh = (uint)(addr >> 32),
+            Zero = 0
+        };
+    }
+
+    public static void Load()
+    {
+        fixed (IdtEntry* ptr = Entries)
+        {
+            Native.Cpu.Lidt(ptr, (ushort)(sizeof(IdtEntry) * Entries.Length - 1));
+        }
+    }
+}

--- a/src/Cosmos.Kernel.System/Interrupts/InterruptManager.cs
+++ b/src/Cosmos.Kernel.System/Interrupts/InterruptManager.cs
@@ -1,0 +1,17 @@
+using Cosmos.Kernel.Runtime;
+using Cosmos.Kernel.System.Input;
+
+namespace Cosmos.Kernel.System.Interrupts;
+
+public static unsafe class InterruptManager
+{
+    public static void Initialize()
+    {
+        Idt.SetEntry(0x21, (void*)(delegate* unmanaged<void>)&KeyboardDriver.KeyboardIsr);
+        Pic.Initialize();
+        Idt.Load();
+        Native.Cpu.Sti();
+    }
+
+    public static void SendEoi(byte irq) => Pic.SendEoi(irq);
+}

--- a/src/Cosmos.Kernel.System/Interrupts/Pic.cs
+++ b/src/Cosmos.Kernel.System/Interrupts/Pic.cs
@@ -1,0 +1,36 @@
+using Cosmos.Kernel.Runtime;
+
+namespace Cosmos.Kernel.System.Interrupts;
+
+public static class Pic
+{
+    private const byte ICW1 = 0x11;
+    private const byte ICW4 = 0x01;
+    private const ushort MasterCmd = 0x20;
+    private const ushort MasterData = 0x21;
+    private const ushort SlaveCmd = 0xA0;
+    private const ushort SlaveData = 0xA1;
+
+    public static void Initialize()
+    {
+        Native.IO.Write8(MasterCmd, ICW1);
+        Native.IO.Write8(SlaveCmd, ICW1);
+        Native.IO.Write8(MasterData, 0x20);
+        Native.IO.Write8(SlaveData, 0x28);
+        Native.IO.Write8(MasterData, 0x04);
+        Native.IO.Write8(SlaveData, 0x02);
+        Native.IO.Write8(MasterData, ICW4);
+        Native.IO.Write8(SlaveData, ICW4);
+        Native.IO.Write8(MasterData, 0xFD);
+        Native.IO.Write8(SlaveData, 0xFF);
+    }
+
+    public static void SendEoi(byte irq)
+    {
+        if (irq >= 8)
+        {
+            Native.IO.Write8(SlaveCmd, 0x20);
+        }
+        Native.IO.Write8(MasterCmd, 0x20);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce CPU helpers for loading IDT and enabling interrupts
- add IDT and PIC setup to route keyboard IRQs
- implement keyboard driver ISR that fills KernelKeyboard buffer
- centralize interrupt setup in a dedicated manager instead of the keyboard driver
- invoke interrupt manager and keyboard console input from example kernel
