### PR TITLE
Patch only assemblies with plugs

### DIFF
--- a/src/Cosmos.Build.Patcher/build/Patcher.Build.Unix.targets
+++ b/src/Cosmos.Build.Patcher/build/Patcher.Build.Unix.targets
@@ -23,7 +23,10 @@
 
     <Message Importance="High"
              Text="Cosmos.Patcher successfully patched: '%(AssembliesToPatch.PatcherOutputPath)'"
-             Condition="'$(PatcherExitCode)' == '0'" />
+             Condition="'$(PatcherExitCode)' == '0' and Exists('%(AssembliesToPatch.PatcherOutputPath)')" />
+    <Message Importance="High"
+             Text="Cosmos.Patcher skipped (no plugs): '%(AssembliesToPatch.Identity)'"
+             Condition="'$(PatcherExitCode)' == '0' and !Exists('%(AssembliesToPatch.PatcherOutputPath)')" />
 
   </Target>
 

--- a/src/Cosmos.Build.Patcher/build/Patcher.Build.Windows.targets
+++ b/src/Cosmos.Build.Patcher/build/Patcher.Build.Windows.targets
@@ -30,7 +30,10 @@
 
     <Message Importance="High"
              Text="✅ Cosmos.Patcher successfully patched: %(AssembliesToPatch.PatcherOutputPath)"
-             Condition="'$(PatcherExitCode)' == '0'" />
+             Condition="'$(PatcherExitCode)' == '0' and Exists('%(AssembliesToPatch.PatcherOutputPath)')" />
+    <Message Importance="High"
+             Text="Cosmos.Patcher skipped (no plugs): %(AssembliesToPatch.Identity)"
+             Condition="'$(PatcherExitCode)' == '0' and !Exists('%(AssembliesToPatch.PatcherOutputPath)')" />
   </Target>
 
 </Project>

--- a/src/Cosmos.Patcher/PatchCommand.cs
+++ b/src/Cosmos.Patcher/PatchCommand.cs
@@ -64,7 +64,13 @@ public sealed class PatchCommand : Command<PatchCommand.Settings>
                 Console.WriteLine($" - {plug}");
 
             PlugPatcher plugPatcher = new(new PlugScanner());
-            plugPatcher.PatchAssembly(targetAssembly, plugAssemblies);
+            bool patched = plugPatcher.PatchAssembly(targetAssembly, plugAssemblies);
+
+            if (!patched)
+            {
+                Console.WriteLine("No applicable plugs found. Skipping write.");
+                return 0;
+            }
 
             string finalPath = settings.OutputPath ??
                                Path.Combine(

--- a/tests/Cosmos.Tests.Patcher/PlugPatcherTest_ObjectPlugs.cs
+++ b/tests/Cosmos.Tests.Patcher/PlugPatcherTest_ObjectPlugs.cs
@@ -28,11 +28,12 @@ public class PlugPatcherTest_ObjectPlugs
         Assert.NotNull(targetType);
 
         // Act: Apply the plug
-        patcher.PatchAssembly(targetAssembly, plugAssembly);
+        bool patched = patcher.PatchAssembly(targetAssembly, plugAssembly);
 
         targetAssembly.Save("./", "targetObjectAssembly.dll");
 
         object result = ExecuteObject(targetAssembly, typeof(NativeWrapperObject).FullName, nameof(NativeWrapperObject.InstanceMethod), 10);
+        Assert.True(patched);
         Assert.Equal(20, result);
     }
 
@@ -87,7 +88,7 @@ public class PlugPatcherTest_ObjectPlugs
         Assert.NotNull(targetType);
 
         // Act: Apply the plug
-        patcher.PatchAssembly(targetAssembly, plugAssembly);
+        bool patched = patcher.PatchAssembly(targetAssembly, plugAssembly);
 
         targetAssembly.Save("./", "targetCtorAssembly.dll");
 
@@ -100,6 +101,7 @@ public class PlugPatcherTest_ObjectPlugs
 
         // Assert: Check the standard output for the constructor plug
         string output = stringWriter.ToString();
+        Assert.True(patched);
         Assert.Contains("Plugged ctor", output);
     }
 
@@ -126,9 +128,10 @@ public class PlugPatcherTest_ObjectPlugs
                     targetAssembly.MainModule.Types.FirstOrDefault(t => t.Name == nameof(NativeWrapperObject));
                 Assert.NotNull(targetType);
 
-                patcher.PatchAssembly(targetAssembly, plugAssembly);
+                bool patched = patcher.PatchAssembly(targetAssembly, plugAssembly);
                 targetAssembly.Save("./", "targetPropertyAssembly.dll");
                 Console.SetOut(output);
+                Assert.True(patched);
                 // Test Get
                 object getResult = ExecutePropertyGet(targetAssembly, typeof(NativeWrapperObject).FullName, nameof(NativeWrapperObject.InstanceProperty));
                 Assert.Equal("Plugged Goodbye World", getResult);

--- a/tests/Cosmos.Tests.Patcher/PlugPatcherTest_SkipUnpluggedAssembly.cs
+++ b/tests/Cosmos.Tests.Patcher/PlugPatcherTest_SkipUnpluggedAssembly.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using Cosmos.Patcher;
+using Cosmos.Tests.NativeWrapper;
+using Mono.Cecil;
+using Xunit;
+using System.Linq;
+
+namespace Cosmos.Tests.Patcher;
+
+public class PlugPatcherTest_SkipUnpluggedAssembly
+{
+    private static AssemblyDefinition CreateMockAssembly<T>()
+    {
+        string assemblyPath = typeof(T).Assembly.Location;
+        return AssemblyDefinition.ReadAssembly(assemblyPath);
+    }
+
+    [Fact]
+    public void PatchAssembly_ShouldSkipWhenNoMatchingPlugs()
+    {
+        PlugScanner scanner = new();
+        PlugPatcher patcher = new(scanner);
+
+        AssemblyDefinition targetAssembly = CreateMockAssembly<NativeWrapperObject>();
+        AssemblyDefinition plugAssembly = CreateMockAssembly<PlugPatcherTest_SkipUnpluggedAssembly>();
+
+        TypeDefinition targetType = targetAssembly.MainModule.Types.First(t => t.FullName == typeof(NativeWrapperObject).FullName);
+        MethodDefinition method = targetType.Methods.First(m => m.Name == nameof(NativeWrapperObject.InstanceMethod));
+        string ilBefore = string.Join(";", method.Body.Instructions.Select(i => i.ToString()));
+
+        bool patched = patcher.PatchAssembly(targetAssembly, plugAssembly);
+
+        string ilAfter = string.Join(";", method.Body.Instructions.Select(i => i.ToString()));
+        Assert.False(patched);
+        Assert.Equal(ilBefore, ilAfter);
+    }
+}

--- a/tests/Cosmos.Tests.Patcher/PlugPatcherTest_StaticPlugs.cs
+++ b/tests/Cosmos.Tests.Patcher/PlugPatcherTest_StaticPlugs.cs
@@ -56,7 +56,7 @@ public class PlugPatcherTest_StaticPlugs
         AssemblyDefinition plugAssembly = CreateMockAssembly<TestClassPlug>();
 
         // Act
-        patcher.PatchAssembly(targetAssembly, plugAssembly);
+        bool patched = patcher.PatchAssembly(targetAssembly, plugAssembly);
 
         // Assert
         TypeDefinition targetType = targetAssembly.MainModule.Types.FirstOrDefault(t => t.Name == nameof(TestClass));
@@ -64,6 +64,7 @@ public class PlugPatcherTest_StaticPlugs
 
         Assert.NotNull(targetType); // Ensure the target type exists
         Assert.NotNull(plugType); // Ensure the plug type exists
+        Assert.True(patched);
 
         foreach (MethodDefinition plugMethod in plugType.Methods)
         {
@@ -91,12 +92,14 @@ public class PlugPatcherTest_StaticPlugs
         AssemblyDefinition plugAssembly = CreateMockAssembly<TestClassPlug>();
 
         // Act
-        patcher.PatchAssembly(targetAssembly, plugAssembly);
+        bool patched2 = patcher.PatchAssembly(targetAssembly, plugAssembly);
 
         TypeDefinition targetType = targetAssembly.MainModule.Types.First(t => t.Name == nameof(TestClass));
         MethodDefinition targetMethod = targetType.Methods.First(m => m.Name == "Add");
         Assert.False(targetMethod.IsPInvokeImpl);
         Assert.Null(targetMethod.PInvokeInfo);
+
+        Assert.True(patched2);
 
         targetAssembly.Save("./", "targetAssembly.dll");
 


### PR DESCRIPTION
## Summary
- skip patching assemblies that have no matching plug targets
- CLI omits writing output when no plugs apply
- build targets report when patching is skipped

## Testing
- `/usr/lib/dotnet9/dotnet test tests/Cosmos.Tests.Patcher/Cosmos.Tests.Patcher.csproj`
- `/usr/lib/dotnet9/dotnet test tests/Cosmos.Tests.Scanner/Cosmos.Tests.Scanner.csproj`
- `/usr/lib/dotnet9/dotnet test tests/Cosmos.Tests.Build.Asm/Cosmos.Tests.Build.Asm.csproj`
- `/usr/lib/dotnet9/dotnet test tests/Cosmos.Tests.Build.Analyzer.Patcher/Cosmos.Tests.Build.Analyzer.Patcher.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a9e823ccd48328a0a880deffa5b5ee