### PR TITLE
Some code cleanup

### DIFF
--- a/src/Cosmos.Kernel.Runtime/Stdllib.cs
+++ b/src/Cosmos.Kernel.Runtime/Stdllib.cs
@@ -1,94 +1,6 @@
-#region A couple very basic things
-
 using System;
 using System.Runtime;
 using Cosmos.Kernel.Core.Memory;
-
-namespace System
-{
-    public sealed class AttributeUsageAttribute : Attribute
-    {
-        public AttributeUsageAttribute(AttributeTargets validOn) { }
-        public bool AllowMultiple { get; set; }
-        public bool Inherited { get; set; }
-    }
-
-    namespace Runtime.CompilerServices
-    {
-        public class RuntimeHelpers
-        {
-            public static unsafe int OffsetToStringData => sizeof(IntPtr) + sizeof(int);
-        }
-
-        public static class RuntimeFeature
-        {
-            public const string UnmanagedSignatureCallingConvention = nameof(UnmanagedSignatureCallingConvention);
-        }
-    }
-}
-
-namespace System.Runtime.InteropServices
-{
-    public class UnmanagedType { }
-
-    public class MarshalDirectiveException : Exception
-    {
-        public MarshalDirectiveException()
-        { }
-        public MarshalDirectiveException(string message) : base(message) { }
-    }
-
-    internal sealed class StructLayoutAttribute : Attribute
-    {
-        public StructLayoutAttribute(LayoutKind layoutKind)
-        {
-        }
-    }
-
-    public sealed class DllImportAttribute : Attribute
-    {
-        public string EntryPoint;
-        public CharSet CharSet;
-        public bool SetLastError;
-        public bool ExactSpelling;
-        public CallingConvention CallingConvention;
-        public bool BestFitMapping;
-        public bool PreserveSig;
-        public bool ThrowOnUnmappableChar;
-
-        public string Value { get; }
-
-        public DllImportAttribute(string dllName)
-        {
-            Value = dllName;
-        }
-    }
-
-    internal enum LayoutKind
-    {
-        Sequential = 0, // 0x00000008,
-        Explicit = 2, // 0x00000010,
-        Auto = 3, // 0x00000000,
-    }
-
-    public enum CharSet
-    {
-        None = 1,       // User didn't specify how to marshal strings.
-        Ansi = 2,       // Strings should be marshalled as ANSI 1 byte chars.
-        Unicode = 3,    // Strings should be marshalled as Unicode 2 byte chars.
-        Auto = 4,       // Marshal Strings in the right way for the target system.
-    }
-
-    public enum CallingConvention
-    {
-        Winapi = 1,
-        Cdecl = 2,
-        StdCall = 3,
-        ThisCall = 4,
-        FastCall = 5,
-    }
-}
-#endregion
 
 #region Things needed by ILC
 namespace System
@@ -137,7 +49,7 @@ namespace System
     }
 }
 
-namespace Internal.Runtime.CompilerHelpers
+namespace Cosmos.Kernel.Runtime
 {
     // A class that the compiler looks for that has helpers to initialize the
     // process. The compiler can gracefully handle the helpers not being present,
@@ -368,61 +280,5 @@ namespace Internal.Runtime.CompilerHelpers
                 [RuntimeExport("RhGetLastGCPercentTimeInGC")]
                 static int RhGetLastGCPercentTimeInGC(int generation) { throw null; }*/
     }
-
-    public static class ThrowHelpers
-    {
-        public static void ThrowNotImplementedException()
-        {
-            while (true) ;
-        }
-
-        public static void ThrowNullReferenceException()
-        {
-            while (true) ;
-        }
-
-        public static void ThrowIndexOutOfRangeException()
-        {
-            while (true) ;
-        }
-
-        public static void ThrowInvalidProgramException()
-        {
-            while (true) ;
-        }
-
-        public static void ThrowTypeLoadException()
-        {
-            while (true) ;
-        }
-
-        public static void ThrowTypeLoadExceptionWithArgument()
-        {
-            while (true) ;
-        }
-
-        public static void ThrowInvalidProgramExceptionWithArgument()
-        {
-            while (true) ;
-        }
-
-        public static void ThrowOverflowException()
-        {
-            while (true) ;
-        }
-    }
-}
-
-namespace Internal.Runtime
-{
-    internal abstract class ThreadStatics
-    {
-        public static unsafe object? GetThreadStaticBaseForType(TypeManagerSlot* pModuleData, int typeTlsIndex)
-        {
-            return null;
-        }
-    }
-
-    internal struct TypeManagerSlot { }
 }
 #endregion


### PR DESCRIPTION
Since Cosmos.Kernel.Runtime isn't the corelib we shouldn't define more types than needed to avoid clashes with the CoreLib (i was writing some code and got conflict errors because of some attributes defined here).