### PR TITLE
Remove invalid options from "cosmos new" command

### DIFF
--- a/src/Cosmos.Tools/Commands/NewCommand.cs
+++ b/src/Cosmos.Tools/Commands/NewCommand.cs
@@ -15,6 +15,7 @@ public class NewSettings : CommandSettings
     [Description("Output directory (defaults to current directory)")]
     public string? Output { get; set; }
 
+    /*
     [CommandOption("-a|--arch")]
     [Description("Target architecture (x64, arm64)")]
     [DefaultValue("x64")]
@@ -24,6 +25,7 @@ public class NewSettings : CommandSettings
     [Description("Include graphics support")]
     [DefaultValue(true)]
     public bool Graphics { get; set; } = true;
+    */
 }
 
 public class NewCommand : AsyncCommand<NewSettings>
@@ -34,8 +36,8 @@ public class NewCommand : AsyncCommand<NewSettings>
         AnsiConsole.MarkupLine("  [bold]Creating Cosmos Kernel Project[/]");
         AnsiConsole.WriteLine("  " + new string('-', 50));
         AnsiConsole.MarkupLine($"  Name: [blue]{settings.Name}[/]");
-        AnsiConsole.MarkupLine($"  Architecture: [blue]{settings.Arch}[/]");
-        AnsiConsole.MarkupLine($"  Graphics: [blue]{(settings.Graphics ? "Yes" : "No")}[/]");
+        // AnsiConsole.MarkupLine($"  Architecture: [blue]{settings.Arch}[/]");
+        // AnsiConsole.MarkupLine($"  Graphics: [blue]{(settings.Graphics ? "Yes" : "No")}[/]");
         AnsiConsole.WriteLine("  " + new string('-', 50));
         AnsiConsole.WriteLine();
 
@@ -45,9 +47,11 @@ public class NewCommand : AsyncCommand<NewSettings>
         {
             "new", "cosmos-kernel",
             "-n", settings.Name,
-            "-o", outputDir,
+            "-o", outputDir
+            /*
             "--TargetArch", settings.Arch,
             "--EnableGraphics", settings.Graphics.ToString().ToLower()
+            */
         };
 
         AnsiConsole.MarkupLine($"  [dim]Running: dotnet {string.Join(" ", args)}[/]");


### PR DESCRIPTION
**The reason why this was done is because of this error:**
```ansi
  Creating Cosmos Kernel Project
  --------------------------------------------------
  Name: tt
  Architecture: x64
  Graphics: Yes
  --------------------------------------------------

  [unning: dotnet new cosmos-kernel -n tt -o /home/plboiyt/cosmos/gen3/nativeaot-patcher/.test/tt --TargetArch x64 --EnableGraphics true

  Failed to create project: Error: Invalid option(s):
--TargetArch
   '--TargetArch' is not a valid option
x64
   'x64' is not a valid option
--EnableGraphics
   '--EnableGraphics' is not a valid option
true
   'true' is not a valid option

For more information, run:
   dotnet new cosmos-kernel -h

For details on the exit code, refer to https://aka.ms/templating-exit-codes#127


  If the template is not found, install it with:
    dotnet new install Cosmos.Build.Templates
```

The `dotnet new` template didn't support those options, the simplest fix was to remove the options from the `cosmos new` command until they are supported.