### PR TITLE
Add per-thread allocation contexts (TLABs) to GC

### DIFF
--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/AllocContext.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/AllocContext.cs
@@ -1,0 +1,33 @@
+// This code is licensed under MIT license (see LICENSE for details)
+
+using System.Runtime.InteropServices;
+
+namespace Cosmos.Kernel.Core.Memory.GarbageCollector;
+
+/// <summary>
+/// Per-thread allocation context (Thread-Local Allocation Buffer).
+/// Stored inline on each <see cref="Scheduler.Thread"/> to provide contention-free allocation.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public unsafe struct AllocContext
+{
+    /// <summary>
+    /// Current allocation pointer within the TLAB. Advances toward <see cref="AllocLimit"/>.
+    /// </summary>
+    public byte* AllocPtr;
+
+    /// <summary>
+    /// End of the TLAB buffer. When <see cref="AllocPtr"/> reaches this, a refill is needed.
+    /// </summary>
+    public byte* AllocLimit;
+
+    /// <summary>
+    /// Cumulative bytes allocated by this thread (SOH objects).
+    /// </summary>
+    public ulong AllocBytes;
+
+    /// <summary>
+    /// Cumulative bytes allocated by this thread (pinned/LOH objects).
+    /// </summary>
+    public ulong AllocBytesUoh;
+}

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Alloc.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Alloc.cs
@@ -244,6 +244,161 @@ public static unsafe partial class GarbageCollector
         s_heapRangeDirty = true;
     }
 
+    // --- Raw variants (no s_totalAllocatedBytes increment) for TLAB refill ---
+
+    /// <summary>
+    /// Allocates from the free list without incrementing <see cref="s_totalAllocatedBytes"/>.
+    /// Used by TLAB refill to avoid double-counting (individual objects are counted at TLAB alloc time).
+    /// </summary>
+    private static void* AllocFromFreeListRaw(uint size)
+    {
+        if (!s_freeListsInitialized)
+        {
+            return null;
+        }
+
+        int sizeClass = -1;
+        uint classSize = MinSizeClass;
+        for (int i = 0; i < NumSizeClasses; i++, classSize <<= 1)
+        {
+            if (size <= classSize)
+            {
+                sizeClass = i;
+                break;
+            }
+        }
+
+        if (sizeClass < 0)
+        {
+            return null;
+        }
+
+        for (int i = sizeClass; i < NumSizeClasses; i++)
+        {
+            FreeBlock* block = s_freeLists[i];
+            if (block == null)
+            {
+                continue;
+            }
+
+            FreeBlock* prev = null;
+            while (block != null)
+            {
+                if (block->Size >= size)
+                {
+                    uint remainder = (uint)(block->Size - size);
+
+                    if (remainder != 0 && remainder < MinBlockSize)
+                    {
+                        prev = block;
+                        block = block->Next;
+                        continue;
+                    }
+
+                    if (prev != null)
+                    {
+                        prev->Next = block->Next;
+                    }
+                    else
+                    {
+                        s_freeLists[i] = block->Next;
+                    }
+
+                    if (remainder >= MinBlockSize)
+                    {
+                        FreeBlock* split = (FreeBlock*)((byte*)block + size);
+                        split->MethodTable = s_freeMethodTable;
+                        split->Size = (int)remainder;
+                        split->Next = null;
+                        AddToFreeList(split);
+                    }
+
+                    MemoryOp.MemSet((byte*)block, 0, (int)size);
+                    return block;
+                }
+
+                prev = block;
+                block = block->Next;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Bump allocation in a segment without incrementing <see cref="s_totalAllocatedBytes"/>.
+    /// Used by TLAB refill.
+    /// </summary>
+    private static void* BumpAllocInSegmentRaw(GCSegment* segment, uint size)
+    {
+        if (segment == null)
+        {
+            return null;
+        }
+
+        byte* newBump = segment->Bump + size;
+        if (newBump <= segment->End)
+        {
+            void* result = segment->Bump;
+            segment->Bump = newBump;
+            segment->UsedSize += size;
+            s_currentSegment = segment;
+            s_lastSegment = segment;
+            return result;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Slow allocation path without incrementing <see cref="s_totalAllocatedBytes"/>.
+    /// Walks segments and allocates a new one if needed. Used by TLAB refill.
+    /// </summary>
+    private static void* AllocateObjectSlowRaw(uint size)
+    {
+        if (s_segments == null)
+        {
+            return null;
+        }
+
+        if (s_lastSegment == null)
+        {
+            s_lastSegment = s_segments;
+        }
+
+        GCSegment* start = s_lastSegment;
+
+        for (GCSegment* seg = start; seg != null; seg = seg->Next)
+        {
+            void* result = BumpAllocInSegmentRaw(seg, size);
+            if (result != null)
+            {
+                return result;
+            }
+        }
+
+        for (GCSegment* seg = s_segments; seg != start; seg = seg->Next)
+        {
+            void* result = BumpAllocInSegmentRaw(seg, size);
+            if (result != null)
+            {
+                return result;
+            }
+        }
+
+        GCSegment* newSegment = AllocateSegment(size);
+        if (newSegment == null)
+        {
+            return null;
+        }
+
+        AppendSegment(newSegment);
+        s_lastSegment = newSegment;
+        s_currentSegment = newSegment;
+
+        return BumpAllocInSegmentRaw(newSegment, size);
+    }
+
     /// <summary>
     /// Inserts a free block into the appropriate size-class free list.
     /// </summary>

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Info.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Info.cs
@@ -1,6 +1,8 @@
 // This code is licensed under MIT license (see LICENSE for details)
 
 using System.Runtime.InteropServices;
+using Cosmos.Kernel.Core.Scheduler;
+using SchedulerThread = Cosmos.Kernel.Core.Scheduler.Thread;
 
 namespace Cosmos.Kernel.Core.Memory.GarbageCollector;
 
@@ -476,12 +478,63 @@ public static unsafe partial class GarbageCollector
 
     /// <summary>
     /// Returns the cumulative total of all bytes ever allocated through the GC.
-    /// This counter only increases and never decrements, matching the semantics of
-    /// <c>GC.GetTotalAllocatedBytes()</c> in dotnet.
+    /// Subtracts dead thread unused TLAB bytes for accuracy.
     /// </summary>
     public static ulong GetTotalAllocatedBytes()
     {
-        return s_totalAllocatedBytes;
+        ulong total = s_totalAllocatedBytes;
+        if (total > s_deadThreadsNonAllocBytes)
+        {
+            total -= s_deadThreadsNonAllocBytes;
+        }
+
+        return total;
+    }
+
+    /// <summary>
+    /// Returns a precise total of allocated bytes, subtracting both dead thread
+    /// unused bytes and live threads' current unused TLAB space.
+    /// </summary>
+    public static ulong GetTotalAllocatedBytesPrecise()
+    {
+        ulong total = s_totalAllocatedBytes;
+        ulong unused = s_deadThreadsNonAllocBytes;
+
+        // Subtract live threads' unused TLAB space
+        if (CosmosFeatures.SchedulerEnabled)
+        {
+            SchedulerThread?[]? threads = SchedulerManager.Threads;
+            if (threads != null)
+            {
+                int count = SchedulerManager.ThreadCount;
+                for (int i = 0; i < threads.Length && count > 0; i++)
+                {
+                    SchedulerThread? thread = threads[i];
+                    if (thread != null)
+                    {
+                        if (thread.AllocContext.AllocLimit != null && thread.AllocContext.AllocPtr != null)
+                        {
+                            unused += (ulong)(thread.AllocContext.AllocLimit - thread.AllocContext.AllocPtr);
+                        }
+
+                        count--;
+                    }
+                }
+            }
+        }
+
+        // Also subtract fallback context unused space
+        if (s_fallbackAllocContext.AllocLimit != null && s_fallbackAllocContext.AllocPtr != null)
+        {
+            unused += (ulong)(s_fallbackAllocContext.AllocLimit - s_fallbackAllocContext.AllocPtr);
+        }
+
+        if (total > unused)
+        {
+            total -= unused;
+        }
+
+        return total;
     }
 
     /// <summary>

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Tlab.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Tlab.cs
@@ -1,0 +1,181 @@
+// This code is licensed under MIT license (see LICENSE for details)
+
+using System.Runtime.CompilerServices;
+using Cosmos.Kernel.Core.CPU;
+using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.Core.Scheduler;
+using SchedulerThread = Cosmos.Kernel.Core.Scheduler.Thread;
+
+namespace Cosmos.Kernel.Core.Memory.GarbageCollector;
+
+/// <summary>
+/// Thread-Local Allocation Buffer (TLAB) management: refill, return, and per-thread context access.
+/// </summary>
+public static unsafe partial class GarbageCollector
+{
+    /// <summary>
+    /// Default TLAB size in bytes (8KB).
+    /// </summary>
+    private const uint TlabSize = 8192;
+
+    /// <summary>
+    /// Returns a reference to the current thread's allocation context.
+    /// Uses the scheduler's current thread when enabled, otherwise falls back to the static context.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ref AllocContext GetCurrentAllocContext()
+    {
+        // SchedulerManager.Enabled is false during early boot (before scheduler init),
+        // so we safely fall back to the static context. CosmosFeatures.SchedulerEnabled
+        // alone is a compile-time flag that doesn't guarantee _cpuStates is allocated.
+        if (CosmosFeatures.SchedulerEnabled && SchedulerManager.Enabled)
+        {
+            PerCpuState cpuState = SchedulerManager.GetCpuState(0);
+            if (cpuState?.CurrentThread != null)
+            {
+                return ref cpuState.CurrentThread.AllocContext;
+            }
+        }
+
+        return ref s_fallbackAllocContext;
+    }
+
+    /// <summary>
+    /// Refills a thread's TLAB from the GC heap (free list, then segment bump, then new segment).
+    /// Returns the unused gap from the old TLAB to the free list before acquiring a new buffer.
+    /// </summary>
+    /// <param name="ac">The allocation context to refill.</param>
+    /// <param name="size">Minimum allocation size that must fit in the new TLAB.</param>
+    /// <returns><c>true</c> if the TLAB was successfully refilled; otherwise, <c>false</c>.</returns>
+    internal static bool RefillAllocContext(ref AllocContext ac, uint size)
+    {
+        using (InternalCpu.DisableInterruptsScope())
+        {
+            // Return unused portion of old TLAB
+            StampUnusedTlab(ref ac);
+
+            // Determine TLAB request size: at least the requested size, ideally TlabSize
+            uint requestSize = size > TlabSize ? size : TlabSize;
+
+            // Try free list first (raw variant — already zeroes memory)
+            void* buffer = AllocFromFreeListRaw(requestSize);
+            if (buffer != null)
+            {
+                return SetupTlab(ref ac, buffer, requestSize);
+            }
+
+            // Try bump allocation from segments (raw variant — must zero)
+            buffer = BumpAllocInSegmentRaw(s_lastSegment, requestSize);
+            if (buffer != null)
+            {
+                MemoryOp.MemSet((byte*)buffer, 0, (int)requestSize);
+                return SetupTlab(ref ac, buffer, requestSize);
+            }
+
+            // Try slow path: walk segments, allocate new segment if needed
+            buffer = AllocateObjectSlowRaw(requestSize);
+            if (buffer != null)
+            {
+                MemoryOp.MemSet((byte*)buffer, 0, (int)requestSize);
+                return SetupTlab(ref ac, buffer, requestSize);
+            }
+
+            // If full TlabSize failed but we only need `size`, try exact size
+            if (requestSize > size)
+            {
+                buffer = AllocFromFreeListRaw(size);
+                if (buffer != null)
+                {
+                    return SetupTlab(ref ac, buffer, size);
+                }
+
+                buffer = AllocateObjectSlowRaw(size);
+                if (buffer != null)
+                {
+                    MemoryOp.MemSet((byte*)buffer, 0, (int)size);
+                    return SetupTlab(ref ac, buffer, size);
+                }
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Sets up a TLAB from an allocated buffer.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool SetupTlab(ref AllocContext ac, void* buffer, uint bufferSize)
+    {
+        ac.AllocPtr = (byte*)buffer;
+        ac.AllocLimit = (byte*)buffer + bufferSize;
+        return true;
+    }
+
+    /// <summary>
+    /// Returns a thread's TLAB to the GC heap. Stamps the unused gap as a FreeBlock
+    /// and resets the allocation pointers.
+    /// </summary>
+    /// <param name="ac">The allocation context to return.</param>
+    public static void ReturnAllocContext(ref AllocContext ac)
+    {
+        StampUnusedTlab(ref ac);
+        ac.AllocPtr = null;
+        ac.AllocLimit = null;
+    }
+
+    /// <summary>
+    /// Returns all live threads' TLABs to the GC heap. Called at the start of GC collection.
+    /// After this call, all threads have AllocPtr == AllocLimit == null and will refill on next alloc.
+    /// </summary>
+    internal static void ReturnAllAllocContexts()
+    {
+        if (CosmosFeatures.SchedulerEnabled)
+        {
+            SchedulerThread?[]? threads = SchedulerManager.Threads;
+            if (threads != null)
+            {
+                int count = SchedulerManager.ThreadCount;
+                for (int i = 0; i < threads.Length && count > 0; i++)
+                {
+                    SchedulerThread? thread = threads[i];
+                    if (thread != null)
+                    {
+                        ReturnAllocContext(ref thread.AllocContext);
+                        count--;
+                    }
+                }
+            }
+        }
+
+        ReturnAllocContext(ref s_fallbackAllocContext);
+    }
+
+    /// <summary>
+    /// Stamps the unused portion of a TLAB [AllocPtr, AllocLimit) as a FreeBlock
+    /// and adds it to the free list so it can be reused.
+    /// </summary>
+    private static void StampUnusedTlab(ref AllocContext ac)
+    {
+        if (ac.AllocPtr == null || ac.AllocLimit == null)
+        {
+            return;
+        }
+
+        uint gap = (uint)(ac.AllocLimit - ac.AllocPtr);
+        if (gap >= MinBlockSize)
+        {
+            FreeBlock* freeBlock = (FreeBlock*)ac.AllocPtr;
+            freeBlock->MethodTable = s_freeMethodTable;
+            freeBlock->Size = (int)gap;
+            freeBlock->Next = null;
+            AddToFreeList(freeBlock);
+        }
+        else if (gap > 0)
+        {
+            // Gap too small for a FreeBlock — zero it so sweep doesn't see
+            // stale MethodTable pointers and break early.
+            MemoryOp.MemSet(ac.AllocPtr, 0, (int)gap);
+        }
+    }
+}

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.cs
@@ -1,9 +1,11 @@
 // This code is licensed under MIT license (see LICENSE for details)
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Cosmos.Kernel.Core.CPU;
 using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.Core.Scheduler;
 using Internal.Runtime;
 
 namespace Cosmos.Kernel.Core.Memory.GarbageCollector;
@@ -173,6 +175,8 @@ public static unsafe partial class GarbageCollector
 
     /// <summary>
     /// Default segment size. Grows as needed.
+    /// Note: increasing this (e.g. 64KB) requires enabling ScanStaticRoots in MarkPhase
+    /// to prevent GC from collecting objects only reachable through static fields.
     /// </summary>
     private static uint s_maxSegmentSize = (uint)PageAllocator.PageSize;
 
@@ -259,6 +263,16 @@ public static unsafe partial class GarbageCollector
     /// Incremented on pinned allocation, decremented on pinned sweep free.
     /// </summary>
     private static ulong s_pinnedHeapObjectCount;
+
+    /// <summary>
+    /// Fallback allocation context used when the scheduler is not enabled (single-thread mode).
+    /// </summary>
+    private static AllocContext s_fallbackAllocContext;
+
+    /// <summary>
+    /// Cumulative unused TLAB bytes from dead threads. Subtracted from total allocation stats.
+    /// </summary>
+    private static ulong s_deadThreadsNonAllocBytes;
 
     // --- Properties ---
 
@@ -357,6 +371,9 @@ public static unsafe partial class GarbageCollector
             Serial.WriteNumber((uint)s_totalCollections + 1);
             Serial.WriteString("\n");
 
+            // Return all TLABs before collection — stamps unused gaps as FreeBlocks
+            ReturnAllAllocContexts();
+
             // Record pre-GC metrics
             s_lastGen0SizeBefore = GetGenerationSize(0);
             s_lastGen0FragmentationBefore = GetCurrentFragmentation(0);
@@ -407,7 +424,7 @@ public static unsafe partial class GarbageCollector
 
     /// <summary>
     /// Allocates memory for a managed object. Called by the runtime allocation helpers.
-    /// Tries free list, then bump allocation, then triggers a collection as a last resort.
+    /// Uses per-thread TLAB fast path for non-pinned allocations.
     /// </summary>
     /// <param name="size">Requested object size in bytes.</param>
     /// <param name="flags">Runtime allocation flags (e.g., pinned object heap).</param>
@@ -419,10 +436,17 @@ public static unsafe partial class GarbageCollector
             Initialize();
         }
 
-        // Check for pinned object allocation
+        // Pinned objects bypass TLABs
         if ((flags & GC_ALLOC_FLAGS.GC_ALLOC_PINNED_OBJECT_HEAP) != 0)
         {
-            return AllocPinnedObject(size, flags);
+            GCObject* pinned = AllocPinnedObject(size, flags);
+            if (pinned != null)
+            {
+                ref AllocContext pac = ref GetCurrentAllocContext();
+                pac.AllocBytesUoh += Align((uint)size);
+            }
+
+            return pinned;
         }
 
         uint allocSize = Align((uint)size);
@@ -431,37 +455,61 @@ public static unsafe partial class GarbageCollector
             allocSize = MinBlockSize;
         }
 
-        // Try free list allocation first
-        void* result = AllocFromFreeList(allocSize);
-        if (result != null)
+        // TLAB fast path
+        ref AllocContext ac = ref GetCurrentAllocContext();
+        byte* newPtr = ac.AllocPtr + allocSize;
+        if (newPtr <= ac.AllocLimit)
         {
+            byte* result = ac.AllocPtr;
+            ac.AllocPtr = newPtr;
+            ac.AllocBytes += allocSize;
+            s_totalAllocatedBytes += allocSize;
             return (GCObject*)result;
         }
 
-        // Try fast bump allocation from last segment
-        result = BumpAllocInSegment(s_lastSegment, allocSize);
-        if (result != null)
-        {
-            return (GCObject*)result;
-        }
+        // Slow path: refill TLAB and retry
+        return AllocObjectSlow(ref ac, allocSize);
+    }
 
-        // Slow path: walk segments from s_lastSegment and append if needed
-        result = AllocateObjectSlow(allocSize);
-        if (result != null)
+    /// <summary>
+    /// Slow path for object allocation: refills the TLAB, then retries. If all else fails, triggers GC.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static GCObject* AllocObjectSlow(ref AllocContext ac, uint allocSize)
+    {
+        if (RefillAllocContext(ref ac, allocSize))
         {
+            byte* result = ac.AllocPtr;
+            ac.AllocPtr += allocSize;
+            ac.AllocBytes += allocSize;
+            s_totalAllocatedBytes += allocSize;
             return (GCObject*)result;
         }
 
         // Last resort: collect and retry
         Collect();
 
-        result = AllocFromFreeList(allocSize);
-        if (result != null)
+        // Re-acquire ref after Collect (ReturnAllAllocContexts resets them)
+        ac = ref GetCurrentAllocContext();
+
+        if (RefillAllocContext(ref ac, allocSize))
         {
+            byte* result = ac.AllocPtr;
+            ac.AllocPtr += allocSize;
+            ac.AllocBytes += allocSize;
+            s_totalAllocatedBytes += allocSize;
             return (GCObject*)result;
         }
 
-        result = AllocateObjectSlow(allocSize);
-        return (GCObject*)result;
+        return null;
+    }
+
+    /// <summary>
+    /// Adds unused TLAB bytes from a dead thread to the cumulative counter.
+    /// Called from <see cref="SchedulerManager.ExitThread"/> before the thread is unregistered.
+    /// </summary>
+    public static void AddDeadThreadNonAllocBytes(ulong unused)
+    {
+        s_deadThreadsNonAllocBytes += unused;
     }
 }

--- a/src/Cosmos.Kernel.Core/Runtime/GC.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/GC.cs
@@ -1,4 +1,3 @@
-
 using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -191,9 +190,10 @@ internal static unsafe class GC
     [RuntimeExport("RhGetAllocatedBytesForCurrentThread")]
     internal static long RhGetAllocatedBytesForCurrentThread()
     {
-        // Per-thread allocation accounting is not tracked currently.
-        // Return 0 as a safe default.
-        return 0;
+        // Cumulative bytes allocated by this thread. Does not subtract unused TLAB space
+        // (that would cause the value to decrease on TLAB refill).
+        ref AllocContext ac = ref GarbageCollector.GetCurrentAllocContext();
+        return (long)(ac.AllocBytes + ac.AllocBytesUoh);
     }
 
     [RuntimeExport("RhGetTotalAllocatedBytes")]
@@ -211,8 +211,7 @@ internal static unsafe class GC
     [RuntimeExport("RhGetTotalAllocatedBytesPrecise")]
     internal static long RhGetTotalAllocatedBytesPrecise()
     {
-        // Without per-thread allocation contexts, the result is already precise.
-        return RhGetTotalAllocatedBytes();
+        return (long)GarbageCollector.GetTotalAllocatedBytesPrecise();
     }
 
     [RuntimeExport("RhRegisterForGCReporting")]

--- a/src/Cosmos.Kernel.Core/Scheduler/SchedulerManager.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/SchedulerManager.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Cosmos.Kernel.Core.CPU;
 using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.Core.Memory.GarbageCollector;
 
 namespace Cosmos.Kernel.Core.Scheduler;
 
@@ -233,6 +234,17 @@ public static class SchedulerManager
         using (CPU.InternalCpu.DisableInterruptsScope())
         {
             PerCpuState state = _cpuStates[cpuId];
+
+            // Return TLAB and track unused bytes before unregistering
+            if (GarbageCollector.IsEnabled)
+            {
+                unsafe
+                {
+                    ulong unused = (ulong)(thread.AllocContext.AllocLimit - thread.AllocContext.AllocPtr);
+                    GarbageCollector.AddDeadThreadNonAllocBytes(unused);
+                    GarbageCollector.ReturnAllocContext(ref thread.AllocContext);
+                }
+            }
 
             thread.State = ThreadState.Dead;
             _currentScheduler.OnThreadExit(state, thread);

--- a/src/Cosmos.Kernel.Core/Scheduler/Thread.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/Thread.cs
@@ -1,3 +1,5 @@
+using Cosmos.Kernel.Core.Memory.GarbageCollector;
+
 namespace Cosmos.Kernel.Core.Scheduler;
 
 /// <summary>
@@ -24,6 +26,9 @@ public unsafe class Thread : SchedulerExtensible
     public ulong TotalRuntime { get; set; }
     public ulong LastScheduledAt { get; set; }
     public ulong WakeupTime { get; set; }
+
+    // ===== GC Allocation Context (TLAB) =====
+    public AllocContext AllocContext;
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
     private object[][] _threadStaticStorage;
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.

--- a/tests/Kernels/Cosmos.Kernel.Tests.GarbageCollector/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.GarbageCollector/Kernel.cs
@@ -19,7 +19,7 @@ public class Kernel : Sys.Kernel
         Serial.WriteString("[GarbageCollector] BeforeRun() reached!\n");
         Serial.WriteString("[GarbageCollector] Starting tests...\n");
 
-        TR.Start("GarbageCollector Tests", expectedTests: 30);
+        TR.Start("GarbageCollector Tests", expectedTests: 35);
 
         // Garbage Collection Tests
         TR.Run("GC_IsEnabled", TestGCIsEnabled);
@@ -54,6 +54,13 @@ public class Kernel : Sys.Kernel
         TR.Run("GC_Info_GCSegmentSizeAndPercent", TestGCInfoGCSegmentSizeAndPercent);
         TR.Run("GC_Info_RhGetMemoryInfoWiring", TestGCInfoRhGetMemoryInfoWiring);
         TR.Run("GC_Variables", TestGCVariables);
+
+        // TLAB (Thread-Local Allocation Buffer) Tests
+        TR.Run("GC_TLAB_AllocBytesNonZero", TestTlabAllocBytesNonZero);
+        TR.Run("GC_TLAB_AllocBytesIncrease", TestTlabAllocBytesIncrease);
+        TR.Run("GC_TLAB_PreciseLessOrEqualTotal", TestTlabPreciseLessOrEqualTotal);
+        TR.Run("GC_TLAB_SurvivalAfterCollect", TestTlabSurvivalAfterCollect);
+        TR.Run("GC_TLAB_GapStampedOnCollect", TestTlabGapStampedOnCollect);
 
         TR.Finish();
 
@@ -707,6 +714,112 @@ public class Kernel : Sys.Kernel
             "GC.Info: GCCpuGroup must be false");
         Assert.Equal(false, (bool)vars["GCLargePages"],
             "GC.Info: GCLargePages must be false");
+    }
+
+    // ==================== TLAB (Thread-Local Allocation Buffer) Tests ====================
+
+    private static void TestTlabAllocBytesNonZero()
+    {
+        // After all previous tests, per-thread cumulative allocated bytes must be > 0
+        long threadBytes = GC.GetAllocatedBytesForCurrentThread();
+        Assert.True(threadBytes > 0,
+            "TLAB: GetAllocatedBytesForCurrentThread must be > 0 after allocations, got: " + threadBytes);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static byte[] AllocByteArray(int size)
+    {
+        return new byte[size];
+    }
+
+    private static void TestTlabAllocBytesIncrease()
+    {
+        // Allocating objects must increase the global total allocated bytes counter
+        long before = GC.GetTotalAllocatedBytes(precise: false);
+
+        // Allocate via NoInlining helper to prevent compiler elision
+        byte[] a1 = AllocByteArray(128);
+        byte[] a2 = AllocByteArray(256);
+        byte[] a3 = AllocByteArray(512);
+
+        long after = GC.GetTotalAllocatedBytes(precise: false);
+
+        // Keep references alive so they're not optimized away
+        Assert.True(a1 != null && a2 != null && a3 != null, "TLAB: allocations must not be null");
+        Assert.True(after > before,
+            "TLAB: GetTotalAllocatedBytes must increase after allocations");
+    }
+
+    private static void TestTlabPreciseLessOrEqualTotal()
+    {
+        // Precise total subtracts unused TLAB space; must be <= non-precise total
+        long total = GC.GetTotalAllocatedBytes(precise: false);
+        long precise = GC.GetTotalAllocatedBytes(precise: true);
+        Assert.True(total > 0, "TLAB: GetTotalAllocatedBytes must be > 0");
+        Assert.True(precise > 0, "TLAB: GetTotalAllocatedBytes(precise) must be > 0");
+        Assert.True(precise <= total,
+            "TLAB: precise (" + precise + ") must be <= non-precise (" + total + ")");
+    }
+
+    private static void TestTlabSurvivalAfterCollect()
+    {
+        // Allocate objects, trigger GC (which returns all TLABs), then verify
+        // objects survive and we can allocate again (TLAB refill works)
+        List<int> list = new List<int>();
+        for (int i = 0; i < 100; i++)
+        {
+            list.Add(i);
+        }
+
+        CoreGC.Collect();
+
+        // List must survive
+        Assert.Equal(100, list.Count, "TLAB: list count must survive GC");
+        Assert.Equal(99, list[99], "TLAB: list last element must survive GC");
+
+        // Post-GC allocation must work (TLAB refill after ReturnAllAllocContexts)
+        byte[] postGC = new byte[256];
+        postGC[0] = 0xAB;
+        Assert.Equal((byte)0xAB, postGC[0], "TLAB: allocation after GC must work");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AllocateTlabGarbage(int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            byte[] temp = new byte[64];
+            if (temp == null)
+            {
+                break;
+            }
+        }
+    }
+
+    private static void TestTlabGapStampedOnCollect()
+    {
+        // After GC, unused TLAB gaps are stamped as FreeBlocks.
+        // Verify that a collection doesn't corrupt the heap by allocating
+        // garbage, collecting, then allocating more and verifying correctness.
+        AllocateTlabGarbage(100);
+
+        CoreGC.GetStats(out int collsBefore, out int _);
+        int freed = CoreGC.Collect();
+        CoreGC.GetStats(out int collsAfter, out int _2);
+
+        Assert.Equal(collsBefore + 1, collsAfter,
+            "TLAB: exactly 1 collection recorded");
+        Assert.True(freed >= 0,
+            "TLAB: freed count must be >= 0");
+
+        // Allocate after collect to verify heap integrity (TLAB gaps properly handled)
+        int[] arr = new int[50];
+        for (int i = 0; i < 50; i++)
+        {
+            arr[i] = i * 3;
+        }
+
+        Assert.Equal(147, arr[49], "TLAB: post-collect allocation data integrity");
     }
 }
 

--- a/tests/Kernels/Cosmos.Kernel.Tests.Memory/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Memory/Kernel.cs
@@ -12,7 +12,7 @@ public unsafe class Kernel : Sys.Kernel
 {
     protected override void BeforeRun()
     {
-        TR.Start("Memory Tests", expectedTests: 63);
+        TR.Start("Memory Tests", expectedTests: 65);
 
         // Boxing/Unboxing Tests
         TR.Run("Boxing_Char", TestBoxingChar);
@@ -83,6 +83,10 @@ public unsafe class Kernel : Sys.Kernel
         TR.Run("MemCopy_0Bytes", TestMemCopy0Bytes);
         TR.Run("MemCopy_1Byte", TestMemCopy1Byte);
         TR.Run("MemMove_Overlap_DestBeforeSrc", TestMemMoveOverlapDestBeforeSrc);
+
+        // Per-thread allocation accounting (TLAB)
+        TR.Run("Memory_ThreadAllocBytesPositive", TestThreadAllocBytesPositive);
+        TR.Run("Memory_TotalAllocBytesPositive", TestTotalAllocBytesPositive);
 
         // Array.Copy Tests (uses SIMD via memmove/RhBulkMoveWithWriteBarrier)
         TR.Run("ArrayCopy_IntArray", TestArrayCopyIntArray);
@@ -565,6 +569,23 @@ public unsafe class Kernel : Sys.Kernel
         }
 
         Assert.True(sum == 6, "IEnumerable foreach on array");
+    }
+
+    // ==================== Per-Thread Allocation Tests ====================
+
+    private static void TestThreadAllocBytesPositive()
+    {
+        // GC.GetAllocatedBytesForCurrentThread() tracks per-thread TLAB allocations.
+        // After all the previous allocation tests, it must be > 0.
+        long threadBytes = GC.GetAllocatedBytesForCurrentThread();
+        Assert.True(threadBytes > 0, "Memory: per-thread allocated bytes must be > 0, got: " + threadBytes);
+    }
+
+    private static void TestTotalAllocBytesPositive()
+    {
+        // GC.GetTotalAllocatedBytes() must be > 0 after allocations
+        long total = GC.GetTotalAllocatedBytes(precise: false);
+        Assert.True(total > 0, "Memory: total allocated bytes must be > 0");
     }
 
     // ==================== Memory Copy Tests ====================

--- a/tests/Kernels/Cosmos.Kernel.Tests.Runtime/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Runtime/Kernel.cs
@@ -102,7 +102,7 @@
 // │ sqrt                                              │ Mth │  1 │   1 │ real │   1   │ 100  │ 100  │
 // │ ----- GC & Finalization ------------------------- │     │    │     │      │       │      │      │
 // │ RhCollect                                         │ GC  │  2 │   0 │ real │   1   │  33  │  50  │
-// │ RhGetAllocatedBytesForCurrentThread               │ GC  │  0 │   1 │ stub │   1   │  —   │ 100  │
+// │ RhGetAllocatedBytesForCurrentThread               │ GC  │  0 │   1 │ real │   1   │  —   │ 100  │
 // │ RhGetGcCollectionCount                            │ GC  │  2 │   1 │ real │   1   │  33  │ 100  │
 // │ RhGetGCDescSize                                   │ GC  │  1 │   1 │ real │   1   │  50  │ 100  │
 // │ RhGetGcTotalMemory                                │ GC  │  0 │   1 │ real │   1   │  —   │ 100  │
@@ -396,7 +396,7 @@ public unsafe class Kernel : Sys.Kernel
         // -- RhCollect --
         TR.Run("RhCollect_Smoke", Test_RhCollect_Smoke);
         // -- RhGetAllocatedBytesForCurrentThread --
-        TR.Run("RhGetAllocatedBytesForCurrentThread_ReturnsZero", Test_RhGetAllocatedBytesForCurrentThread_ReturnsZero);
+        TR.Run("RhGetAllocatedBytesForCurrentThread_NonNegative", Test_RhGetAllocatedBytesForCurrentThread_ReturnsZero);
         // -- RhGetGcCollectionCount --
         TR.Run("RhGetGcCollectionCount_Gen0_NonNegative", Test_RhGetGcCollectionCount_Gen0_NonNegative);
         // -- RhGetGCDescSize --
@@ -416,7 +416,7 @@ public unsafe class Kernel : Sys.Kernel
         // -- RhGetTotalAllocatedBytes --
         TR.Run("RhGetTotalAllocatedBytes_Positive", Test_RhGetTotalAllocatedBytes_Positive);
         // -- RhGetTotalAllocatedBytesPrecise --
-        TR.Run("RhGetTotalAllocatedBytesPrecise_MatchesNonPrecise", Test_RhGetTotalAllocatedBytesPrecise_MatchesNonPrecise);
+        TR.Run("RhGetTotalAllocatedBytesPrecise_LessOrEqualNonPrecise", Test_RhGetTotalAllocatedBytesPrecise_MatchesNonPrecise);
         // -- RhIsPromoted --
         TR.Run("RhIsPromoted_ReturnsFalse", Test_RhIsPromoted_ReturnsFalse);
         // -- RhIsServerGc --
@@ -1128,8 +1128,11 @@ public unsafe class Kernel : Sys.Kernel
     // -- RhGetAllocatedBytesForCurrentThread --
     private static void Test_RhGetAllocatedBytesForCurrentThread_ReturnsZero()
     {
+        // With per-thread allocation contexts (TLABs), this now returns the
+        // cumulative bytes allocated by the current thread minus unused TLAB space.
+        // After the kernel has booted and run prior tests, this must be > 0.
         long result = RuntimeGC.RhGetAllocatedBytesForCurrentThread();
-        Assert.Equal(0L, result, "RhGetAllocatedBytesForCurrentThread must return 0 (not tracked)");
+        Assert.True(result >= 0, "RhGetAllocatedBytesForCurrentThread must return >= 0");
     }
 
     // -- RhGetGcCollectionCount --
@@ -1202,9 +1205,12 @@ public unsafe class Kernel : Sys.Kernel
     // -- RhGetTotalAllocatedBytesPrecise --
     private static void Test_RhGetTotalAllocatedBytesPrecise_MatchesNonPrecise()
     {
+        // With TLABs, the precise variant subtracts live threads' unused TLAB space
+        // in addition to dead thread unused bytes. So precise <= normal.
         long precise = RuntimeGC.RhGetTotalAllocatedBytesPrecise();
         long normal = RuntimeGC.RhGetTotalAllocatedBytes();
-        Assert.Equal(normal, precise, "RhGetTotalAllocatedBytesPrecise must match RhGetTotalAllocatedBytes");
+        Assert.True(precise > 0, "RhGetTotalAllocatedBytesPrecise must be > 0 after allocations");
+        Assert.True(precise <= normal, "RhGetTotalAllocatedBytesPrecise must be <= RhGetTotalAllocatedBytes");
     }
 
     // -- RhIsPromoted --


### PR DESCRIPTION
## Summary

- Implement Thread-Local Allocation Buffers (TLABs) for the GC heap allocator, giving each thread its own bump-pointer buffer
- Eliminates contention on the shared segment bump pointer under multithreading
- Enables per-thread allocation accounting: `GC.GetAllocatedBytesForCurrentThread()` now returns real values instead of 0
- Fixes `GC.GetTotalAllocatedBytes(precise: true)` to subtract live TLAB unused space

### Key changes

| File | Change |
|------|--------|
| `AllocContext.cs` | **NEW** — 32-byte struct with AllocPtr, AllocLimit, AllocBytes, AllocBytesUoh |
| `GarbageCollector.Tlab.cs` | **NEW** — TLAB management: GetCurrentAllocContext, RefillAllocContext, ReturnAllAllocContexts |
| `GarbageCollector.cs` | Replace AllocObject with TLAB fast/slow path, return TLABs before GC collect |
| `GarbageCollector.Alloc.cs` | Raw alloc variants (no double-counting s_totalAllocatedBytes) for TLAB refill |
| `GarbageCollector.Info.cs` | GetTotalAllocatedBytesPrecise subtracts live TLAB unused space |
| `Thread.cs` | Add AllocContext field |
| `SchedulerManager.cs` | Return TLAB + track unused bytes on thread exit |
| `Runtime/GC.cs` | Fix RhGetAllocatedBytesForCurrentThread and RhGetTotalAllocatedBytesPrecise |

Closes #314