### PR TITLE
Add cross-GDB tool definitions for Windows debugging

### DIFF
--- a/setup/Cosmos.iss
+++ b/setup/Cosmos.iss
@@ -63,6 +63,9 @@ Source: "bundle\tools\windows\lld\*"; DestDir: "{app}\Tools\lld"; Flags: ignorev
 ; QEMU emulator (x64 and ARM64)
 Source: "bundle\tools\windows\qemu\*"; DestDir: "{app}\Tools\qemu"; Flags: ignoreversion recursesubdirs createallsubdirs
 
+; GDB multiarch debugger
+Source: "bundle\tools\windows\gdb\*"; DestDir: "{app}\Tools\gdb"; Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist
+
 ; VS Code extension
 Source: "bundle\extensions\*.vsix"; DestDir: "{app}\Extensions"; Flags: ignoreversion skipifsourcedoesntexist
 
@@ -232,6 +235,7 @@ begin
     AddToUserPath(ExpandConstant('{app}\Tools\x86_64-elf-tools\bin'));
     AddToUserPath(ExpandConstant('{app}\Tools\aarch64-elf-tools\bin'));
     AddToUserPath(ExpandConstant('{app}\Tools\qemu'));
+    AddToUserPath(ExpandConstant('{app}\Tools\gdb'));
     { Broadcast so new terminals pick up the PATH change immediately }
     BroadcastEnvironmentChange;
   end;
@@ -248,6 +252,7 @@ begin
     RemoveFromUserPath(ExpandConstant('{app}\Tools\x86_64-elf-tools\bin'));
     RemoveFromUserPath(ExpandConstant('{app}\Tools\aarch64-elf-tools\bin'));
     RemoveFromUserPath(ExpandConstant('{app}\Tools\qemu'));
+    RemoveFromUserPath(ExpandConstant('{app}\Tools\gdb'));
     { Broadcast so terminals pick up the PATH removal }
     BroadcastEnvironmentChange;
   end;

--- a/setup/Cosmos.iss
+++ b/setup/Cosmos.iss
@@ -235,7 +235,8 @@ begin
     AddToUserPath(ExpandConstant('{app}\Tools\x86_64-elf-tools\bin'));
     AddToUserPath(ExpandConstant('{app}\Tools\aarch64-elf-tools\bin'));
     AddToUserPath(ExpandConstant('{app}\Tools\qemu'));
-    AddToUserPath(ExpandConstant('{app}\Tools\gdb'));
+    { grumpycoder's gdb-multiarch zip extracts to gdb\bin — DLLs live there too }
+    AddToUserPath(ExpandConstant('{app}\Tools\gdb\bin'));
     { Broadcast so new terminals pick up the PATH change immediately }
     BroadcastEnvironmentChange;
   end;
@@ -252,7 +253,7 @@ begin
     RemoveFromUserPath(ExpandConstant('{app}\Tools\x86_64-elf-tools\bin'));
     RemoveFromUserPath(ExpandConstant('{app}\Tools\aarch64-elf-tools\bin'));
     RemoveFromUserPath(ExpandConstant('{app}\Tools\qemu'));
-    RemoveFromUserPath(ExpandConstant('{app}\Tools\gdb'));
+    RemoveFromUserPath(ExpandConstant('{app}\Tools\gdb\bin'));
     { Broadcast so terminals pick up the PATH removal }
     BroadcastEnvironmentChange;
   end;

--- a/src/Cosmos.Build.Patcher/build/Cosmos.Build.Patcher.targets
+++ b/src/Cosmos.Build.Patcher/build/Cosmos.Build.Patcher.targets
@@ -238,12 +238,13 @@
     <Message Importance="High" Condition="'$(PatcherExitCode)' == '0'"
              Text="Cosmos.Patcher successfully patched: '%(AssembliesToPatch.PatcherOutputPath)'" />
 
-    <!-- Copy PDB files for debug symbols -->
-    <!-- Copy main assembly PDB to cosmos folder -->
-    <Copy SourceFiles="$(OutputPath)$(AssemblyName).pdb"
-          DestinationFiles="$(IntermediateOutputPath)/cosmos/$(AssemblyName)_patched.pdb"
-          Condition="Exists('$(OutputPath)$(AssemblyName).pdb')"
-          SkipUnchangedFiles="true" />
+    <!-- NOTE: do NOT copy the original $(OutputPath)$(AssemblyName).pdb over the
+         patcher's output. Cosmos.Patcher already writes a matching Portable PDB
+         next to the patched .dll via Mono.Cecil's WriterParameters.WriteSymbols.
+         Copying the unpatched PDB here overwrites that matching PDB with one
+         whose MVID no longer matches the patched DLL — ILC then silently drops
+         all sequence points for the user project, killing DWARF source line
+         info and breaking source-level breakpoints under gdb. -->
 
     <!-- Write cache hash after successful patching -->
     <WriteLinesToFile File="$(_PatcherCacheFile)" Lines="$(_CurrentPatcherHash)" Overwrite="true" />

--- a/src/Cosmos.Tools/Commands/InfoCommand.cs
+++ b/src/Cosmos.Tools/Commands/InfoCommand.cs
@@ -14,15 +14,17 @@ public class InfoSettings : CommandSettings
     public bool Json { get; set; }
 }
 
-public class InfoCommand : Command<InfoSettings>
+public class InfoCommand : AsyncCommand<InfoSettings>
 {
-    public override int Execute(CommandContext context, InfoSettings settings)
+    public override async Task<int> ExecuteAsync(CommandContext context, InfoSettings settings)
     {
         string platform = GetPlatformName();
         string arch = PlatformInfo.CurrentArch.ToString().ToLower();
         string packageManager = PlatformInfo.GetPackageManager();
         string displayBackend = GetDisplayBackend();
         string gdbCommand = GetGdbCommand();
+        string gdbCommandX64 = await ResolveToolPathAsync(ToolDefinitions.X64ElfGdb) ?? gdbCommand;
+        string gdbCommandArm64 = await ResolveToolPathAsync(ToolDefinitions.Aarch64ElfGdb) ?? gdbCommand;
         if (settings.Json)
         {
             Console.WriteLine("{");
@@ -31,7 +33,9 @@ public class InfoCommand : Command<InfoSettings>
             Console.WriteLine($"  \"arch\": \"{arch}\",");
             Console.WriteLine($"  \"packageManager\": \"{packageManager}\",");
             Console.WriteLine($"  \"qemuDisplay\": \"{displayBackend}\",");
-            Console.WriteLine($"  \"gdbCommand\": \"{gdbCommand}\"");
+            Console.WriteLine($"  \"gdbCommand\": \"{EscapeJson(gdbCommand)}\",");
+            Console.WriteLine($"  \"gdbCommandX64\": \"{EscapeJson(gdbCommandX64)}\",");
+            Console.WriteLine($"  \"gdbCommandArm64\": \"{EscapeJson(gdbCommandArm64)}\"");
             Console.WriteLine("}");
         }
         else
@@ -43,11 +47,18 @@ public class InfoCommand : Command<InfoSettings>
             AnsiConsole.MarkupLine($"  Architecture: [blue]{arch}[/]");
             AnsiConsole.MarkupLine($"  Package Manager: [blue]{packageManager}[/]");
             AnsiConsole.MarkupLine($"  QEMU Display: [blue]{displayBackend}[/]");
-            AnsiConsole.MarkupLine($"  GDB Command: [blue]{gdbCommand}[/]");
+            AnsiConsole.MarkupLine($"  GDB (x64): [blue]{Markup.Escape(gdbCommandX64)}[/]");
+            AnsiConsole.MarkupLine($"  GDB (ARM64): [blue]{Markup.Escape(gdbCommandArm64)}[/]");
             AnsiConsole.WriteLine();
         }
 
         return 0;
+    }
+
+    private static async Task<string?> ResolveToolPathAsync(CommandToolDefinition tool)
+    {
+        var status = await ToolChecker.CheckToolAsync(tool);
+        return status.Found ? status.Path : null;
     }
 
     private static string GetPlatformName()

--- a/src/Cosmos.Tools/Commands/InfoCommand.cs
+++ b/src/Cosmos.Tools/Commands/InfoCommand.cs
@@ -22,9 +22,8 @@ public class InfoCommand : AsyncCommand<InfoSettings>
         string arch = PlatformInfo.CurrentArch.ToString().ToLower();
         string packageManager = PlatformInfo.GetPackageManager();
         string displayBackend = GetDisplayBackend();
-        string gdbCommand = GetGdbCommand();
-        string gdbCommandX64 = await ResolveToolPathAsync(ToolDefinitions.X64ElfGdb) ?? gdbCommand;
-        string gdbCommandArm64 = await ResolveToolPathAsync(ToolDefinitions.Aarch64ElfGdb) ?? gdbCommand;
+        string gdbCommandX64 = await ResolveToolPathAsync(ToolDefinitions.X64ElfGdb) ?? "gdb";
+        string gdbCommandArm64 = await ResolveToolPathAsync(ToolDefinitions.Aarch64ElfGdb) ?? "gdb";
         if (settings.Json)
         {
             Console.WriteLine("{");
@@ -33,7 +32,6 @@ public class InfoCommand : AsyncCommand<InfoSettings>
             Console.WriteLine($"  \"arch\": \"{arch}\",");
             Console.WriteLine($"  \"packageManager\": \"{packageManager}\",");
             Console.WriteLine($"  \"qemuDisplay\": \"{displayBackend}\",");
-            Console.WriteLine($"  \"gdbCommand\": \"{EscapeJson(gdbCommand)}\",");
             Console.WriteLine($"  \"gdbCommandX64\": \"{EscapeJson(gdbCommandX64)}\",");
             Console.WriteLine($"  \"gdbCommandArm64\": \"{EscapeJson(gdbCommandArm64)}\"");
             Console.WriteLine("}");
@@ -89,33 +87,6 @@ public class InfoCommand : AsyncCommand<InfoSettings>
         }
 
         return "gtk";
-    }
-
-    private static string GetGdbCommand()
-    {
-        // On Linux, prefer gdb-multiarch for cross-architecture debugging
-        if (RuntimeInformation.IsOSPlatform(SysOSPlatform.Linux))
-        {
-            // Check if gdb-multiarch exists
-            string gdbMultiarchPath = "/usr/bin/gdb-multiarch";
-            if (File.Exists(gdbMultiarchPath))
-            {
-                return "gdb-multiarch";
-            }
-        }
-
-        // macOS and Windows typically just use 'gdb'
-        // Windows might need the full path if installed via MinGW
-        if (RuntimeInformation.IsOSPlatform(SysOSPlatform.Windows))
-        {
-            string mingwPath = @"C:\msys64\mingw64\bin\gdb.exe";
-            if (File.Exists(mingwPath))
-            {
-                return mingwPath;
-            }
-        }
-
-        return "gdb";
     }
 
     private static string? GetCosmosToolsPath()

--- a/src/Cosmos.Tools/Commands/InfoCommand.cs
+++ b/src/Cosmos.Tools/Commands/InfoCommand.cs
@@ -22,11 +22,7 @@ public class InfoCommand : AsyncCommand<InfoSettings>
         string arch = PlatformInfo.CurrentArch.ToString().ToLower();
         string packageManager = PlatformInfo.GetPackageManager();
         string displayBackend = GetDisplayBackend();
-        // Single multiarch GDB serves both architectures. Falls back to "gdb-multiarch"
-        // on PATH (Linux apt package) or "gdb" if neither is installed.
-        string gdbPath = await ResolveToolPathAsync(ToolDefinitions.GdbMultiarch) ?? "gdb-multiarch";
-        string gdbCommandX64 = gdbPath;
-        string gdbCommandArm64 = gdbPath;
+
         if (settings.Json)
         {
             Console.WriteLine("{");
@@ -35,8 +31,6 @@ public class InfoCommand : AsyncCommand<InfoSettings>
             Console.WriteLine($"  \"arch\": \"{arch}\",");
             Console.WriteLine($"  \"packageManager\": \"{packageManager}\",");
             Console.WriteLine($"  \"qemuDisplay\": \"{displayBackend}\",");
-            Console.WriteLine($"  \"gdbCommandX64\": \"{EscapeJson(gdbCommandX64)}\",");
-            Console.WriteLine($"  \"gdbCommandArm64\": \"{EscapeJson(gdbCommandArm64)}\"");
             Console.WriteLine("}");
         }
         else
@@ -48,8 +42,6 @@ public class InfoCommand : AsyncCommand<InfoSettings>
             AnsiConsole.MarkupLine($"  Architecture: [blue]{arch}[/]");
             AnsiConsole.MarkupLine($"  Package Manager: [blue]{packageManager}[/]");
             AnsiConsole.MarkupLine($"  QEMU Display: [blue]{displayBackend}[/]");
-            AnsiConsole.MarkupLine($"  GDB (x64): [blue]{Markup.Escape(gdbCommandX64)}[/]");
-            AnsiConsole.MarkupLine($"  GDB (ARM64): [blue]{Markup.Escape(gdbCommandArm64)}[/]");
             AnsiConsole.WriteLine();
         }
 

--- a/src/Cosmos.Tools/Commands/InfoCommand.cs
+++ b/src/Cosmos.Tools/Commands/InfoCommand.cs
@@ -22,8 +22,11 @@ public class InfoCommand : AsyncCommand<InfoSettings>
         string arch = PlatformInfo.CurrentArch.ToString().ToLower();
         string packageManager = PlatformInfo.GetPackageManager();
         string displayBackend = GetDisplayBackend();
-        string gdbCommandX64 = await ResolveToolPathAsync(ToolDefinitions.X64ElfGdb) ?? "gdb";
-        string gdbCommandArm64 = await ResolveToolPathAsync(ToolDefinitions.Aarch64ElfGdb) ?? "gdb";
+        // Single multiarch GDB serves both architectures. Falls back to "gdb-multiarch"
+        // on PATH (Linux apt package) or "gdb" if neither is installed.
+        string gdbPath = await ResolveToolPathAsync(ToolDefinitions.GdbMultiarch) ?? "gdb-multiarch";
+        string gdbCommandX64 = gdbPath;
+        string gdbCommandArm64 = gdbPath;
         if (settings.Json)
         {
             Console.WriteLine("{");
@@ -87,31 +90,6 @@ public class InfoCommand : AsyncCommand<InfoSettings>
         }
 
         return "gtk";
-    }
-
-    private static string? GetCosmosToolsPath()
-    {
-        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        string toolsDir = Path.Combine(home, ".dotnet", "tools");
-
-        if (RuntimeInformation.IsOSPlatform(SysOSPlatform.Windows))
-        {
-            string exePath = Path.Combine(toolsDir, "cosmos.exe");
-            if (File.Exists(exePath))
-            {
-                return exePath;
-            }
-        }
-        else
-        {
-            string path = Path.Combine(toolsDir, "cosmos");
-            if (File.Exists(path))
-            {
-                return path;
-            }
-        }
-
-        return null;
     }
 
     private static string EscapeJson(string s)

--- a/src/Cosmos.Tools/Commands/InstallCommand.cs
+++ b/src/Cosmos.Tools/Commands/InstallCommand.cs
@@ -960,7 +960,8 @@ public class InstallCommand : AsyncCommand<InstallSettings>
         Path.Combine("x86_64-elf-tools", "bin"),
         Path.Combine("aarch64-elf-tools", "bin"),
         "qemu",
-        "gdb"
+        // grumpycoder's gdb-multiarch zip extracts to gdb\bin — DLLs live there too
+        Path.Combine("gdb", "bin")
     ];
 
     internal static bool AddToolsToWindowsPath(string toolsPath)

--- a/src/Cosmos.Tools/Commands/InstallCommand.cs
+++ b/src/Cosmos.Tools/Commands/InstallCommand.cs
@@ -803,8 +803,8 @@ public class InstallCommand : AsyncCommand<InstallSettings>
 
     internal static string GetBundleDirName(ToolDefinition tool) => tool.Name switch
     {
-        "x86_64-elf-gcc" => "x86_64-elf-tools",
-        "aarch64-elf-gcc" or "aarch64-elf-as" => "aarch64-elf-tools",
+        "x86_64-elf-gcc" or "x86_64-elf-gdb" => "x86_64-elf-tools",
+        "aarch64-elf-gcc" or "aarch64-elf-as" or "aarch64-elf-gdb" => "aarch64-elf-tools",
         "qemu-system-x86_64" or "qemu-system-aarch64" => "qemu",
         "ld.lld" => "lld",
         _ => tool.Name

--- a/src/Cosmos.Tools/Commands/InstallCommand.cs
+++ b/src/Cosmos.Tools/Commands/InstallCommand.cs
@@ -803,10 +803,11 @@ public class InstallCommand : AsyncCommand<InstallSettings>
 
     internal static string GetBundleDirName(ToolDefinition tool) => tool.Name switch
     {
-        "x86_64-elf-gcc" or "x86_64-elf-gdb" => "x86_64-elf-tools",
-        "aarch64-elf-gcc" or "aarch64-elf-as" or "aarch64-elf-gdb" => "aarch64-elf-tools",
+        "x86_64-elf-gcc" => "x86_64-elf-tools",
+        "aarch64-elf-gcc" or "aarch64-elf-as" => "aarch64-elf-tools",
         "qemu-system-x86_64" or "qemu-system-aarch64" => "qemu",
         "ld.lld" => "lld",
+        "gdb-multiarch" => "gdb",
         _ => tool.Name
     };
 
@@ -958,7 +959,8 @@ public class InstallCommand : AsyncCommand<InstallSettings>
         "yasm", "xorriso", "lld",
         Path.Combine("x86_64-elf-tools", "bin"),
         Path.Combine("aarch64-elf-tools", "bin"),
-        "qemu"
+        "qemu",
+        "gdb"
     ];
 
     internal static bool AddToolsToWindowsPath(string toolsPath)

--- a/src/Cosmos.Tools/Platform/ToolChecker.cs
+++ b/src/Cosmos.Tools/Platform/ToolChecker.cs
@@ -120,7 +120,9 @@ public static class ToolChecker
                 // QEMU
                 AddPathVariants(possiblePaths, Path.Combine(cosmosToolsPath, "qemu"), command, ext);
 
-                // GDB (portable gdb-multiarch bundle)
+                // GDB (portable gdb-multiarch bundle) — grumpycoder's zip puts
+                // gdb-multiarch.exe under gdb\bin\ next to its DLLs.
+                AddPathVariants(possiblePaths, Path.Combine(cosmosToolsPath, "gdb", "bin"), command, ext);
                 AddPathVariants(possiblePaths, Path.Combine(cosmosToolsPath, "gdb"), command, ext);
 
                 // Named subdirectories for specific tools
@@ -245,6 +247,7 @@ public static class ToolChecker
                 Path.Combine(toolsBase, "x86_64-elf-tools", "bin"),
                 Path.Combine(toolsBase, "aarch64-elf-tools", "bin"),
                 Path.Combine(toolsBase, "qemu"),
+                Path.Combine(toolsBase, "gdb", "bin"),
                 Path.Combine(toolsBase, "gdb")
             };
             if (PlatformInfo.CurrentOS == OSPlatform.Windows)

--- a/src/Cosmos.Tools/Platform/ToolChecker.cs
+++ b/src/Cosmos.Tools/Platform/ToolChecker.cs
@@ -120,6 +120,9 @@ public static class ToolChecker
                 // QEMU
                 AddPathVariants(possiblePaths, Path.Combine(cosmosToolsPath, "qemu"), command, ext);
 
+                // GDB (portable gdb-multiarch bundle)
+                AddPathVariants(possiblePaths, Path.Combine(cosmosToolsPath, "gdb"), command, ext);
+
                 // Named subdirectories for specific tools
                 foreach (string dir in new[] { "lld", "xorriso", "yasm" })
                 {
@@ -241,7 +244,8 @@ public static class ToolChecker
                 Path.Combine(toolsBase, "lld"),
                 Path.Combine(toolsBase, "x86_64-elf-tools", "bin"),
                 Path.Combine(toolsBase, "aarch64-elf-tools", "bin"),
-                Path.Combine(toolsBase, "qemu")
+                Path.Combine(toolsBase, "qemu"),
+                Path.Combine(toolsBase, "gdb")
             };
             if (PlatformInfo.CurrentOS == OSPlatform.Windows)
             {

--- a/src/Cosmos.Tools/Platform/ToolDefinition.cs
+++ b/src/Cosmos.Tools/Platform/ToolDefinition.cs
@@ -202,34 +202,27 @@ public static class ToolDefinitions
         MacOSInstall = new() { Method = "package", BrewPackages = ["qemu"] }
     };
 
-    public static readonly CommandToolDefinition X64ElfGdb = new()
+    // Portable gdb-multiarch built with libexpat (XML target description support).
+    // Required for QEMU system-mode kernel debugging — without expat, GDB falls back
+    // to a hardcoded register layout and rejects QEMU's extended register set with
+    // "remote 'g' packet reply is too long" or "Truncated register" errors.
+    // Linux: ships in apt as gdb-multiarch (with expat).
+    // Windows: bundled cross-elf GDBs from lordmilko/mmozeiko lack expat — use
+    // grumpycoder's purpose-built portable gdb-multiarch zip (~28 MB, includes all
+    // required DLLs, hosted on Compiler Explorer's CDN).
+    public static readonly CommandToolDefinition GdbMultiarch = new()
     {
-        Name = "x86_64-elf-gdb",
-        DisplayName = "x64 GDB",
-        Description = "GDB debugger for x64 bare-metal kernels (bundled with x86_64-elf-tools)",
-        WindowsCommands = ["x86_64-elf-gdb"],
-        LinuxCommands = ["gdb-multiarch", "gdb"],
-        MacOSCommands = ["x86_64-elf-gdb", "gdb"],
+        Name = "gdb-multiarch",
+        DisplayName = "GDB (multiarch)",
+        Description = "Multi-architecture GDB debugger for x64 and ARM64 kernels",
+        WindowsCommands = ["gdb-multiarch"],
+        LinuxCommands = ["gdb-multiarch"],
+        MacOSCommands = ["gdb-multiarch", "x86_64-elf-gdb", "aarch64-elf-gdb"],
         VersionArg = "--version",
         Required = false,
-        WindowsInstall = new() { Method = "download", DownloadUrl = "https://github.com/lordmilko/i686-elf-tools/releases/download/13.2.0/x86_64-elf-tools-windows.zip" },
+        WindowsInstall = new() { Method = "download", DownloadUrl = "https://static.grumpycoder.net/pixel/gdb-multiarch-windows/gdb-multiarch-16.3.zip" },
         LinuxInstall = new() { Method = "package", AptPackages = ["gdb-multiarch"], DnfPackages = ["gdb"], PacmanPackages = ["gdb"] },
         MacOSInstall = new() { Method = "package", BrewPackages = ["x86_64-elf-gdb"] }
-    };
-
-    public static readonly CommandToolDefinition Aarch64ElfGdb = new()
-    {
-        Name = "aarch64-elf-gdb",
-        DisplayName = "ARM64 GDB",
-        Description = "GDB debugger for ARM64 bare-metal kernels (bundled with aarch64-elf-tools)",
-        WindowsCommands = ["aarch64-none-elf-gdb"],
-        LinuxCommands = ["gdb-multiarch", "aarch64-linux-gnu-gdb", "gdb"],
-        MacOSCommands = ["aarch64-elf-gdb", "gdb"],
-        VersionArg = "--version",
-        Required = false,
-        WindowsInstall = new() { Method = "download", DownloadUrl = "https://github.com/mmozeiko/build-gcc-arm/releases/download/gcc-v15.2.0/gcc-v15.2.0-aarch64-none-elf.7z" },
-        LinuxInstall = new() { Method = "package", AptPackages = ["gdb-multiarch"], DnfPackages = ["gdb"], PacmanPackages = ["gdb"] },
-        MacOSInstall = new() { Method = "package", BrewPackages = ["aarch64-elf-gdb"] }
     };
 
     public static readonly FileToolDefinition QemuEfiArm64 = new()
@@ -260,7 +253,6 @@ public static class ToolDefinitions
         QemuX64,
         QemuArm64,
         QemuEfiArm64,
-        X64ElfGdb,
-        Aarch64ElfGdb
+        GdbMultiarch
     ];
 }

--- a/src/Cosmos.Tools/Platform/ToolDefinition.cs
+++ b/src/Cosmos.Tools/Platform/ToolDefinition.cs
@@ -202,6 +202,36 @@ public static class ToolDefinitions
         MacOSInstall = new() { Method = "package", BrewPackages = ["qemu"] }
     };
 
+    public static readonly CommandToolDefinition X64ElfGdb = new()
+    {
+        Name = "x86_64-elf-gdb",
+        DisplayName = "x64 GDB",
+        Description = "GDB debugger for x64 bare-metal kernels (bundled with x86_64-elf-tools)",
+        WindowsCommands = ["x86_64-elf-gdb"],
+        LinuxCommands = ["gdb-multiarch", "gdb"],
+        MacOSCommands = ["x86_64-elf-gdb", "gdb"],
+        VersionArg = "--version",
+        Required = false,
+        WindowsInstall = new() { Method = "download", DownloadUrl = "https://github.com/lordmilko/i686-elf-tools/releases/download/13.2.0/x86_64-elf-tools-windows.zip" },
+        LinuxInstall = new() { Method = "package", AptPackages = ["gdb-multiarch"], DnfPackages = ["gdb"], PacmanPackages = ["gdb"] },
+        MacOSInstall = new() { Method = "package", BrewPackages = ["x86_64-elf-gdb"] }
+    };
+
+    public static readonly CommandToolDefinition Aarch64ElfGdb = new()
+    {
+        Name = "aarch64-elf-gdb",
+        DisplayName = "ARM64 GDB",
+        Description = "GDB debugger for ARM64 bare-metal kernels (bundled with aarch64-elf-tools)",
+        WindowsCommands = ["aarch64-none-elf-gdb"],
+        LinuxCommands = ["gdb-multiarch", "aarch64-linux-gnu-gdb", "gdb"],
+        MacOSCommands = ["aarch64-elf-gdb", "gdb"],
+        VersionArg = "--version",
+        Required = false,
+        WindowsInstall = new() { Method = "download", DownloadUrl = "https://github.com/mmozeiko/build-gcc-arm/releases/download/gcc-v15.2.0/gcc-v15.2.0-aarch64-none-elf.7z" },
+        LinuxInstall = new() { Method = "package", AptPackages = ["gdb-multiarch"], DnfPackages = ["gdb"], PacmanPackages = ["gdb"] },
+        MacOSInstall = new() { Method = "package", BrewPackages = ["aarch64-elf-gdb"] }
+    };
+
     public static readonly FileToolDefinition QemuEfiArm64 = new()
     {
         Name = "QEMU EFI (ARM64)",
@@ -229,6 +259,8 @@ public static class ToolDefinitions
         Aarch64ElfAs,
         QemuX64,
         QemuArm64,
-        QemuEfiArm64
+        QemuEfiArm64,
+        X64ElfGdb,
+        Aarch64ElfGdb
     ];
 }


### PR DESCRIPTION
The lordmilko x86_64-elf-tools and mmozeiko aarch64-none-elf packages already ship GDB binaries (x86_64-elf-gdb, aarch64-none-elf-gdb), but cosmos info only reported a generic 'gdb' command. On Windows, the chocolatey gdb is i386-only and rejects QEMU's 64-bit register data with "Truncated register 55 in remote 'g' packet".

Add X64ElfGdb and Aarch64ElfGdb tool definitions and emit per-arch gdbCommandX64/gdbCommandArm64 paths from cosmos info so the VS Code extension can pick the right cross-GDB. Both map to the existing toolchain bundles so no extra downloads happen.

Needed by https://github.com/valentinbreiz/CosmosVsCodeExtension/pull/2

Fixes #292 