### PR TITLE
Enable GDB source debugging for framework code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,8 @@
       "request": "launch",
       "MIMode": "gdb",
       "sourceFileMap": {
-        "/_/src/runtime": "${workspaceFolder}/dotnet/runtime"
+        "/_/src/runtime": "${workspaceFolder}/dotnet/runtime",
+        "/_/": "${workspaceFolder}/"
       },
 
       "miDebuggerPath": "gdb",
@@ -46,7 +47,8 @@
       "request": "launch",
       "MIMode": "gdb",
       "sourceFileMap": {
-        "/_/src/runtime": "${workspaceFolder}/dotnet/runtime"
+        "/_/src/runtime": "${workspaceFolder}/dotnet/runtime",
+        "/_/": "${workspaceFolder}/"
       },
 
       "miDebuggerPath": "gdb-multiarch",

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,13 @@
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Embed PDB inside the DLL so ILC always has sequence-point info for
+         framework assemblies consumed from NuGet, enabling DWARF source-line
+         info and GDB source debugging for all Cosmos code. -->
+    <DebugType>embedded</DebugType>
+    <!-- Map repo-root paths to /_/ so DWARF source file paths are portable
+         across machines.  launch.json sourceFileMap reverses this mapping. -->
+    <PathMap>$(MSBuildThisFileDirectory)=/_/</PathMap>
     <NoWarn>$(NoWarn);1591;CS1998;NU1903;SYSLIB0011;</NoWarn>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>true</AppendRuntimeIdentifierToOutputPath>

--- a/src/Cosmos.Build.Templates/templates/cosmos-kernel/.vscode/launch.json
+++ b/src/Cosmos.Build.Templates/templates/cosmos-kernel/.vscode/launch.json
@@ -6,6 +6,9 @@
       "type": "cppdbg",
       "request": "launch",
       "MIMode": "gdb",
+      "sourceFileMap": {
+        "/_/": ""
+      },
       "miDebuggerPath": "gdb",
       "targetArchitecture": "x64",
       "program": "${workspaceFolder}/output-x64/KernelName.elf",
@@ -41,6 +44,9 @@
       "type": "cppdbg",
       "request": "launch",
       "MIMode": "gdb",
+      "sourceFileMap": {
+        "/_/": ""
+      },
       "miDebuggerPath": "gdb-multiarch",
       "targetArchitecture": "arm64",
       "program": "${workspaceFolder}/output-arm64/KernelName.elf",

--- a/src/Cosmos.Build.Templates/templates/cosmos-kernel/.vscode/launch.json
+++ b/src/Cosmos.Build.Templates/templates/cosmos-kernel/.vscode/launch.json
@@ -6,9 +6,6 @@
       "type": "cppdbg",
       "request": "launch",
       "MIMode": "gdb",
-      "sourceFileMap": {
-        "/_/": ""
-      },
       "miDebuggerPath": "gdb",
       "targetArchitecture": "x64",
       "program": "${workspaceFolder}/output-x64/KernelName.elf",
@@ -44,9 +41,6 @@
       "type": "cppdbg",
       "request": "launch",
       "MIMode": "gdb",
-      "sourceFileMap": {
-        "/_/": ""
-      },
       "miDebuggerPath": "gdb-multiarch",
       "targetArchitecture": "arm64",
       "program": "${workspaceFolder}/output-arm64/KernelName.elf",

--- a/src/Cosmos.Sdk/Sdk/Sdk.targets
+++ b/src/Cosmos.Sdk/Sdk/Sdk.targets
@@ -147,28 +147,22 @@
     </ItemGroup>
   </Target>
   
-  <!-- Extract Cosmos framework source files from NuGet packages to the build
-       output so GDB can display source when stepping into framework code.
-       The source files ship inside each NuGet package under cosmos-src/ and
-       the package props populate @(CosmosSourceRoot) items at restore time.
-       DWARF paths use the /_/ prefix (via PathMap), and the VS Code extension
-       maps /_/ -> this extraction directory via sourceFileMap. -->
-  <Target Name="ExtractCosmosDebugSources"
+  <!-- Write a source-map file so the VS Code extension can build GDB
+       sourceFileMap entries pointing directly into the NuGet cache.
+       No file copying — source stays where NuGet restored it.
+       Each CosmosSourceRoot carries a ProjectName metadata set by the
+       package's generated props (see Directory.MultiArch.targets). -->
+  <Target Name="WriteCosmosDebugSourceMap"
           AfterTargets="Build"
           Condition="'@(CosmosSourceRoot)' != ''">
-    <PropertyGroup>
-      <CosmosDebugSourceRoot>$(OutputPath)cosmos-sources/</CosmosDebugSourceRoot>
-    </PropertyGroup>
     <ItemGroup>
-      <_CosmosSourceFiles Include="%(CosmosSourceRoot.Identity)**/*.cs" />
+      <_SourceMapLine Include="/_/src/%(CosmosSourceRoot.ProjectName)|%(CosmosSourceRoot.Identity)src/%(CosmosSourceRoot.ProjectName)" />
     </ItemGroup>
-    <Copy SourceFiles="@(_CosmosSourceFiles)"
-          DestinationFiles="@(_CosmosSourceFiles->'$(CosmosDebugSourceRoot)%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true"
-          Condition="'@(_CosmosSourceFiles)' != ''" />
+    <WriteLinesToFile File="$(OutputPath)cosmos-debug-sources.txt"
+                      Lines="@(_SourceMapLine)"
+                      Overwrite="true" />
     <Message Importance="High"
-             Text="📂 [Debug] Extracted @(_CosmosSourceFiles->Count()) source files to $(CosmosDebugSourceRoot)"
-             Condition="'@(_CosmosSourceFiles)' != ''" />
+             Text="📂 [Debug] Wrote source map: $(OutputPath)cosmos-debug-sources.txt" />
   </Target>
 
   <!-- Coverage instrumentation: inserts CoverageTracker.Hit(id) calls into src/ assembly methods.

--- a/src/Cosmos.Sdk/Sdk/Sdk.targets
+++ b/src/Cosmos.Sdk/Sdk/Sdk.targets
@@ -147,6 +147,30 @@
     </ItemGroup>
   </Target>
   
+  <!-- Extract Cosmos framework source files from NuGet packages to the build
+       output so GDB can display source when stepping into framework code.
+       The source files ship inside each NuGet package under cosmos-src/ and
+       the package props populate @(CosmosSourceRoot) items at restore time.
+       DWARF paths use the /_/ prefix (via PathMap), and the VS Code extension
+       maps /_/ -> this extraction directory via sourceFileMap. -->
+  <Target Name="ExtractCosmosDebugSources"
+          AfterTargets="Build"
+          Condition="'@(CosmosSourceRoot)' != ''">
+    <PropertyGroup>
+      <CosmosDebugSourceRoot>$(OutputPath)cosmos-sources/</CosmosDebugSourceRoot>
+    </PropertyGroup>
+    <ItemGroup>
+      <_CosmosSourceFiles Include="%(CosmosSourceRoot.Identity)**/*.cs" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_CosmosSourceFiles)"
+          DestinationFiles="@(_CosmosSourceFiles->'$(CosmosDebugSourceRoot)%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true"
+          Condition="'@(_CosmosSourceFiles)' != ''" />
+    <Message Importance="High"
+             Text="📂 [Debug] Extracted @(_CosmosSourceFiles->Count()) source files to $(CosmosDebugSourceRoot)"
+             Condition="'@(_CosmosSourceFiles)' != ''" />
+  </Target>
+
   <!-- Coverage instrumentation: inserts CoverageTracker.Hit(id) calls into src/ assembly methods.
        Only runs when CosmosCoverage=true. Must run after RunPatcher and before CompileWithIlc. -->
   <Target Name="InstrumentCoverage"

--- a/src/Directory.MultiArch.targets
+++ b/src/Directory.MultiArch.targets
@@ -45,6 +45,15 @@
       <Pack>true</Pack>
       <PackagePath>runtimes/linux-arm64/lib/$(_MultiArchTFM)/</PackagePath>
     </None>
+
+    <!-- Include C# source files for GDB source-level debugging.
+         PathMap maps repo paths to /_/ in PDBs/DWARF, so the package mirrors
+         that layout under cosmos-src/ for extraction at kernel build time. -->
+    <None Include="$(MSBuildProjectDirectory)/**/*.cs"
+          Exclude="$(MSBuildProjectDirectory)/obj/**;$(MSBuildProjectDirectory)/bin/**">
+      <Pack>true</Pack>
+      <PackagePath>cosmos-src/src/$(MSBuildProjectName)/</PackagePath>
+    </None>
   </ItemGroup>
 
   <!-- Generate props file for compile-time assembly resolution -->
@@ -75,6 +84,7 @@
       <Private>false</Private>
     </Reference>
     <CosmosMultiArchReference Include="%24(_$(_PropPrefix)AssemblyPath)" />
+    <CosmosSourceRoot Include="%24(MSBuildThisFileDirectory)../cosmos-src/" />
   </ItemGroup>
 </Project>]]></_MultiArchContent>
     </PropertyGroup>

--- a/src/Directory.MultiArch.targets
+++ b/src/Directory.MultiArch.targets
@@ -84,7 +84,9 @@
       <Private>false</Private>
     </Reference>
     <CosmosMultiArchReference Include="%24(_$(_PropPrefix)AssemblyPath)" />
-    <CosmosSourceRoot Include="%24(MSBuildThisFileDirectory)../cosmos-src/" />
+    <CosmosSourceRoot Include="%24(MSBuildThisFileDirectory)../cosmos-src/">
+      <ProjectName>$(AssemblyName)</ProjectName>
+    </CosmosSourceRoot>
   </ItemGroup>
 </Project>]]></_MultiArchContent>
     </PropertyGroup>


### PR DESCRIPTION
## Summary
- Embed PDB inside DLLs (`DebugType=embedded`) so ILC always has sequence-point info for framework assemblies consumed from NuGet
- Use deterministic `PathMap` so DWARF source paths are portable across machines
- Add `sourceFileMap` entries to launch.json (repo + template) to map `/_/` prefix back to workspace paths