### PR TITLE
🐛 Drop yasm from Inno Setup script

### DIFF
--- a/setup/Cosmos.iss
+++ b/setup/Cosmos.iss
@@ -55,7 +55,6 @@ Source: "bundle\packages\*.nupkg"; DestDir: "{app}\Packages"; Flags: ignoreversi
 Source: "bundle\tools\windows\llvm-tools\*"; DestDir: "{app}\Tools\llvm-tools"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 ; Build tools
-Source: "bundle\tools\windows\yasm\*"; DestDir: "{app}\Tools\yasm"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "bundle\tools\windows\xorriso\*"; DestDir: "{app}\Tools\xorriso"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 ; QEMU emulator (x64 and ARM64)
@@ -224,7 +223,6 @@ begin
   if CurStep = ssPostInstall then
   begin
     { Add tool directories to user PATH }
-    AddToUserPath(ExpandConstant('{app}\Tools\yasm'));
     AddToUserPath(ExpandConstant('{app}\Tools\xorriso'));
     AddToUserPath(ExpandConstant('{app}\Tools\llvm-tools\bin'));
     AddToUserPath(ExpandConstant('{app}\Tools\qemu'));
@@ -240,7 +238,6 @@ begin
   if CurUninstallStep = usPostUninstall then
   begin
     { Remove tool directories from user PATH }
-    RemoveFromUserPath(ExpandConstant('{app}\Tools\yasm'));
     RemoveFromUserPath(ExpandConstant('{app}\Tools\xorriso'));
     RemoveFromUserPath(ExpandConstant('{app}\Tools\llvm-tools\bin'));
     RemoveFromUserPath(ExpandConstant('{app}\Tools\qemu'));


### PR DESCRIPTION
## Summary

Hotfix for #335 — Windows installer was silently dropping after #334 because `setup/Cosmos.iss` still referenced the now-removed `bundle\tools\windows\yasm\*` path. iscc treats a missing `Source:` path as a fatal error, but `cosmos install --setup` reports the failure in-band (no non-zero exit), so the release workflow ran green and the v3.0.56 release ended up with no `CosmosSetup-*.exe` asset.

## Changes

- Drop the `bundle\tools\windows\yasm\*` `Source:` line.
- Drop the matching `AddToUserPath` / `RemoveFromUserPath` calls for `{app}\Tools\yasm`.

## Test plan

- [ ] Trigger Release workflow (or wait for the next `v*` tag) and confirm `CosmosSetup-<version>-windows.exe` appears in the release assets.
- [ ] Tail the Windows Installer job log: the `Build installer via cosmos install` step should now print `Windows installer -> iscc ... OK`.

## Follow-up (separate)

The iscc-FAILED-but-process-exits-zero behavior in `cosmos install --setup` should be tightened in a separate change — that's how this regression went unnoticed.

Closes #335