### PR TITLE
🐛 Invalidate ToolResolver cache after `cosmos install` downloads

### DIFF
--- a/src/Cosmos.Tools/Commands/InstallCommand.cs
+++ b/src/Cosmos.Tools/Commands/InstallCommand.cs
@@ -194,6 +194,14 @@ public class InstallCommand : AsyncCommand<InstallSettings>
             AnsiConsole.MarkupLine(pathOk ? "[green]OK[/]" : "[yellow]SKIPPED[/]");
         }
 
+        // Pre-install ResolveAsync calls cached system-tool hits while the bundle
+        // was still missing. Drop them so the verification below sees the freshly
+        // extracted bundle binaries instead of the stale pre-download resolution.
+        if (anyDownloaded)
+        {
+            ToolResolver.InvalidateCache();
+        }
+
         List<CommandToolDefinition> requiredReleaseTools = ToolDefinitions.GetAllTools()
             .OfType<CommandToolDefinition>()
             .Where(static t => t.Required && t.ReleaseAsset != null)

--- a/src/Cosmos.Tools/Platform/ToolResolver.cs
+++ b/src/Cosmos.Tools/Platform/ToolResolver.cs
@@ -36,6 +36,17 @@ public static class ToolResolver
         return ResolveUncachedAsync(tool, overridePath, cacheKey);
     }
 
+    /// <summary>
+    /// Drop all cached resolutions. Call this after side-effects that change
+    /// what `ResolveAsync` would return — e.g. `cosmos install` downloading a
+    /// bundle that didn't exist when the pre-install check resolved a tool to
+    /// a system path.
+    /// </summary>
+    public static void InvalidateCache()
+    {
+        s_cache.Clear();
+    }
+
     private static async Task<ResolvedTool> ResolveUncachedAsync(
         CommandToolDefinition tool, string? overridePath, string cacheKey)
     {


### PR DESCRIPTION
## Summary

Hotfix for #337 — Windows ARM64 CI fails the `cosmos install --tools --auto` step because the post-install verification hits a stale `ToolResolver` cache entry from before the bundle was downloaded.

The pre-install resolution accepted the chocolatey clang at `C:\Program Files\LLVM\bin\clang.exe` (whose `--version` returns nothing parseable on the Windows ARM64 emulation layer) as `ResolvedTool(systemPath, System, version=null)` — and cached it. After the bundle was downloaded, the verification loop hit the cache, saw `Version == null`, and reported clang/ld.lld as missing.

## Changes

- `ToolResolver.InvalidateCache()` — public method to clear `s_cache`.
- `InstallCommand.RunInstallToolsFlowAsync`: after `AddToolsToWindowsPath`, call `ToolResolver.InvalidateCache()` whenever any download succeeded, so the verification re-resolves against the freshly-extracted bundle (which now has `<toolsBase>/<asset>/VERSION` for `pinnedVersion` to read and `bin/clang.exe` for `FindInBundle` to land on).

## Test plan

- [ ] CI on this branch: Windows ARM64 .NET Tests job passes the `🔧 Install Build Tools` step.
- [ ] CI: Linux + macOS jobs still pass (latent bug — they didn't fail before because their system clang's `--version` parses cleanly).
- [ ] Local fresh Windows install via the Inno Setup .exe still works (this PR doesn't touch that path).

Closes #337