### PR TITLE
Implement cmdline parsing.

### DIFF
--- a/examples/DevKernel/Bootloader/limine.conf
+++ b/examples/DevKernel/Bootloader/limine.conf
@@ -8,3 +8,4 @@ timeout: 0
 
     # Path to the kernel to boot. boot():/ represents the partition on which limine.conf is located.
     path: boot():/boot/DevKernel.elf
+    cmdline: arg1 arg2 "arg #3"

--- a/examples/DevKernel/Kernel.cs
+++ b/examples/DevKernel/Kernel.cs
@@ -35,6 +35,18 @@ public class Kernel : Sys.Kernel
         Console.WriteLine();
 
         Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine("Parameters:");
+        Console.ResetColor();
+
+        Console.ForegroundColor = ConsoleColor.Gray;
+        foreach (var param in Environment.GetCommandLineArgs())
+        {
+            Console.Write('\t');
+            Console.WriteLine(param);
+        }
+        Console.ResetColor();
+
+        Console.ForegroundColor = ConsoleColor.Cyan;
         Console.WriteLine("Cosmos booted successfully!");
         Console.ResetColor();
         Console.WriteLine("Type 'help' for available commands.");

--- a/src/Cosmos.Kernel.Core/Bridge/Export/LimineNative.cs
+++ b/src/Cosmos.Kernel.Core/Bridge/Export/LimineNative.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using Cosmos.Kernel.Boot.Limine;
+using Cosmos.Kernel.Core.Utilities;
 
 namespace Cosmos.Kernel.Core.Bridge;
 
@@ -34,5 +35,32 @@ public static unsafe class LimineNative
             return Limine.HHDM.Response->Offset;
         }
         return 0;
+    }
+
+    /// <summary>
+    /// Wrapper to expose Limine cmdline pointer.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "__get_limine_cmd_line")]
+    public static byte* GetCmdLine()
+    {
+        if (Limine.ExecutableCmdline.Response != null)
+        {
+            return Limine.ExecutableCmdline.Response->Cmdline;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Wrapper to expose the <see cref="ArgvParser.BuildArgv"/> method, utility to parse byte* into argv style.
+    /// </summary>
+    /// <param name="input">Input pointer to be parsed</param>
+    /// <param name="argc">Pointer to Save the number of parameters</param>
+    /// <returns>The argv pointer</returns>
+    /// <remarks>The string "cosmos" is added as the parameter at index 0 in result, this is to take place of the exe.</remarks>
+    [UnmanagedCallersOnly(EntryPoint = "__build_argv")]
+    public static byte** __build_argv(byte* input, int* argc)
+    {
+        return ArgvParser.BuildArgv(input, argc);
     }
 }

--- a/src/Cosmos.Kernel.Core/Utilities/ArgvParser.cs
+++ b/src/Cosmos.Kernel.Core/Utilities/ArgvParser.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Reflection.Metadata;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.Core.Memory;
+using Cosmos.Kernel.Core.Memory.Heap;
+
+namespace Cosmos.Kernel.Core.Utilities;
+
+/// <summary>
+/// Utility class that expose helpers to parse cmdlines.
+/// </summary>
+public static unsafe class ArgvParser
+{
+    private const byte DoubleQuote = (byte)'"';
+    private const byte Backslash = (byte)'\\';
+    private static readonly byte[] s_cosmosBytes = [
+        (byte)'c', (byte)'o', (byte)'s', (byte)'m', (byte)'o', (byte)'s', 0
+    ];
+
+    private static byte* CosmosPtr
+    {
+        get
+        {
+            fixed (byte* p = s_cosmosBytes)
+            {
+                return p;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Utility to parse byte* into argv style.
+    /// </summary>
+    /// <param name="input">Input pointer to be parsed</param>
+    /// <param name="argc">Pointer to Save the number of parameters</param>
+    /// <returns>The argv pointer</returns>
+    /// <remarks>The string "cosmos" is added as the parameter at index 0 in result, this is to take place of the exe.</remarks>
+    public static byte** BuildArgv(byte* input, int* argc)
+    {
+        byte** result;
+
+        // If there is no input then return default argv
+        if (input == null)
+        {
+            result = NewArgb(0); //Only the default argument (the exe)
+            *argc = 1;
+            return result;
+        }
+
+        // Count input length
+        uint len = 0;
+        while (input[len] != 0)
+        {
+            len++;
+        }
+
+        if (len == 0)
+        {
+            result = NewArgb(0); //Only the default argument (the exe)
+            *argc = 1;
+            return result;
+        }
+
+
+        byte* argvBuffer = Heap.Alloc(len + 1);
+
+        MemoryOp.MemCopy(argvBuffer, input, (int)(len + 1));
+
+        uint count = PrepareBuffer(new(argvBuffer, (int)(len + 1)));
+
+        result = NewArgb(count);
+
+        int argcount = 1;
+
+        Span<byte> buffer = new(argvBuffer, (int)(1 + len));
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            if (buffer[i] == 0)
+            {
+                continue;
+            }
+
+            result[argcount++] = argvBuffer + i;
+
+            while (buffer[i] != 0)
+            {
+                i++;
+            }
+        }
+
+        result[argcount] = null;
+
+        *argc = argcount;
+
+        return result;
+    }
+
+    /// <summary>
+    /// Replace Spaces for Nulls and Count Number of parameters.
+    /// </summary>
+    /// <param name="buffer">Argv Buffer</param>
+    /// <returns>Number of parameters found in the buffer</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint PrepareBuffer(Span<byte> buffer)
+    {
+        uint count = 0;
+
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            while (buffer[i] != 0 && char.IsWhiteSpace((char)buffer[i]))
+            {
+                buffer[i] = 0;
+                i++;
+            }
+
+            if (buffer[i] == 0)
+            {
+                break;
+            }
+
+            if (buffer[i] == DoubleQuote)
+            {
+                // Move buffer one position down
+                Span<byte> slice = buffer.Slice(i + 1);
+                slice.CopyTo(buffer.Slice(i));
+
+                while (buffer[i] != 0)
+                {
+                    if (buffer[i] == DoubleQuote && buffer[i] != DoubleQuote)
+                    {
+                        slice = buffer.Slice(i + 1);
+                        slice.CopyTo(buffer.Slice(i));
+                        i++;
+                        break;
+                    }
+                    else if (buffer[i] == DoubleQuote && buffer[i] == DoubleQuote
+                        || buffer[i] == Backslash && buffer[i] == DoubleQuote
+                        || buffer[i] == Backslash && buffer[i] == Backslash)
+                    {
+                        // Remove starting '\' or '"'
+                        slice = buffer.Slice(i + 1);
+                        slice.CopyTo(buffer.Slice(i));
+                        i++;
+                    }
+                    else
+                    {
+                        i++;
+                    }
+                }
+                count++;
+            }
+            else
+            {
+                while (buffer[i] != 0 && !char.IsWhiteSpace((char)buffer[i]))
+                {
+                    i++;
+                }
+                i--;
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static byte** NewArgb(uint length)
+    {
+        byte** argv = (byte**)Heap.Alloc((length + 2) * (uint)sizeof(byte*));
+
+        argv[0] = CosmosPtr;
+
+        return argv;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static byte Peek(byte* ptr, int pos = 1)
+    {
+        return ptr[pos];
+    }
+}

--- a/src/Cosmos.Kernel.Core/Utilities/ArgvParser.cs
+++ b/src/Cosmos.Kernel.Core/Utilities/ArgvParser.cs
@@ -64,7 +64,6 @@ public static unsafe class ArgvParser
             return result;
         }
 
-
         byte* argvBuffer = Heap.Alloc(len + 1);
 
         MemoryOp.MemCopy(argvBuffer, input, (int)(len + 1));
@@ -174,11 +173,5 @@ public static unsafe class ArgvParser
         argv[0] = CosmosPtr;
 
         return argv;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static byte Peek(byte* ptr, int pos = 1)
-    {
-        return ptr[pos];
     }
 }

--- a/src/Cosmos.Kernel/Bootstrap/kmain.c
+++ b/src/Cosmos.Kernel/Bootstrap/kmain.c
@@ -69,8 +69,12 @@ void kmain()
     // === Phase 4: User Kernel ===
     __cosmos_serial_write("\n");
     __cosmos_serial_write("[KMAIN] Phase 4: User kernel\n");
-    char *argv[] = {"COSMOS", NULL};
-    __managed__Main(1, argv);
+    
+    int argc;
+    char **argv;
+
+    argv = __build_argv(__get_limine_cmd_line(), &argc);
+    __managed__Main(argc, argv);
 
     // Should never reach here
     __cosmos_serial_write("[KMAIN] ERROR: Main() returned unexpectedly!\n");

--- a/src/Cosmos.Kernel/Bootstrap/kmain.h
+++ b/src/Cosmos.Kernel/Bootstrap/kmain.h
@@ -36,6 +36,8 @@ extern void _native_arm64_disable_alignment_check(void);
 extern void acpi_early_init(void* rsdp_address, uint64_t hhdm_offset);
 extern void* __get_limine_rsdp_address(void);
 extern uint64_t __get_limine_hhdm_offset(void);
+extern char* __get_limine_cmd_line(void);
+extern char** __build_argv(char* input, int* argc);
 
 // Serial logging (C# functions)
 extern void __cosmos_serial_init(void);

--- a/tests/Kernels/Cosmos.Kernel.Tests.Memory/Bootloader/limine.conf
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Memory/Bootloader/limine.conf
@@ -8,3 +8,4 @@ timeout: 0
 
     # Path to the kernel to boot. boot():/ represents the partition on which limine.conf is located.
     path: boot():/boot/Cosmos.Kernel.Tests.Memory.elf
+    cmdline: arg1 arg2 arg3

--- a/tests/Kernels/Cosmos.Kernel.Tests.Memory/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Memory/Kernel.cs
@@ -12,7 +12,7 @@ public unsafe class Kernel : Sys.Kernel
 {
     protected override void BeforeRun()
     {
-        TR.Start("Memory Tests", expectedTests: 65);
+        TR.Start("Memory Tests", expectedTests: 68);
 
         // Boxing/Unboxing Tests
         TR.Run("Boxing_Char", TestBoxingChar);
@@ -87,6 +87,11 @@ public unsafe class Kernel : Sys.Kernel
         // Per-thread allocation accounting (TLAB)
         TR.Run("Memory_ThreadAllocBytesPositive", TestThreadAllocBytesPositive);
         TR.Run("Memory_TotalAllocBytesPositive", TestTotalAllocBytesPositive);
+
+        // Cmdline parsing — limine.conf passes "arg1 arg2 arg3"
+        TR.Run("Cmdline_ArgCount", TestCmdlineArgCount);
+        TR.Run("Cmdline_Argv0IsCosmos", TestCmdlineArgv0);
+        TR.Run("Cmdline_ArgValues", TestCmdlineArgValues);
 
         // Array.Copy Tests (uses SIMD via memmove/RhBulkMoveWithWriteBarrier)
         TR.Run("ArrayCopy_IntArray", TestArrayCopyIntArray);
@@ -1052,6 +1057,33 @@ public unsafe class Kernel : Sys.Kernel
                      arr[4] == 2 && arr[5] == 3 &&
                      arr[6] == 6 && arr[7] == 7;
         Assert.True(passed, "Array.Copy: overlapping regions");
+    }
+
+    // ==================== Cmdline Parsing Tests ====================
+    // Bootloader/limine.conf passes `cmdline: arg1 arg2 arg3`. These tests
+    // walk the full path: limine -> kmain -> __build_argv -> ArgvParser ->
+    // NativeAOT __managed__Main -> Environment.GetCommandLineArgs().
+
+    private static void TestCmdlineArgCount()
+    {
+        string[] args = Environment.GetCommandLineArgs();
+        Assert.Equal(4, args.Length, "Cmdline: argv0 + 3 parsed args");
+    }
+
+    private static void TestCmdlineArgv0()
+    {
+        string[] args = Environment.GetCommandLineArgs();
+        Assert.True(args.Length >= 1, "Cmdline: argv has argv[0]");
+        Assert.True(args[0] == "cosmos", "Cmdline: argv[0] is \"cosmos\"");
+    }
+
+    private static void TestCmdlineArgValues()
+    {
+        string[] args = Environment.GetCommandLineArgs();
+        Assert.True(args.Length >= 4, "Cmdline: argv has 3 parsed args");
+        Assert.True(args[1] == "arg1", "Cmdline: argv[1] == arg1");
+        Assert.True(args[2] == "arg2", "Cmdline: argv[2] == arg2");
+        Assert.True(args[3] == "arg3", "Cmdline: argv[3] == arg3");
     }
 
     private class SimpleStringComparer : IEqualityComparer<string>


### PR DESCRIPTION
Can either be accesed from `Environment.GetCommandLineArgs()`(this adds the exe as the first param) or the `string[] args` parameter in main (only the values present in cmdline).