### PR TITLE
Test runner: per-suite QEMU profile matrix

### DIFF
--- a/.github/workflows/kernel-test-results.yml
+++ b/.github/workflows/kernel-test-results.yml
@@ -46,33 +46,76 @@ jobs:
       - name: 📊 Parse Test Results
         id: parse
         run: |
-          parse_xml() {
-            local file=$1
-            if [ -f "$file" ]; then
-              tests=$(grep -oP 'tests="\K[^"]+' "$file" | head -1)
-              failures=$(grep -oP 'failures="\K[^"]+' "$file" | head -1)
-              skipped=$(grep -oP 'skipped="\K[^"]+' "$file" | head -1)
-              time=$(grep -oP 'time="\K[^"]+' "$file" | head -1)
-              actual_tests=$(grep -c '<testcase' "$file" || echo "0")
-              passed=$((actual_tests - failures - skipped))
-              if [ "$failures" != "0" ]; then
-                status="❌ Failed"
-              elif [ "$actual_tests" -lt "$tests" ]; then
-                status="❌ Failed"
-              else
-                status="✅ Passed"
-              fi
-              echo "$tests|$passed|$failures|$skipped|${time}s|$status"
-            else
-              echo "0|0|0|0|N/A|⚠️ No results"
-            fi
-          }
+          # Bucket testcases by their leading [profile] prefix so suites that
+          # opt into multiple QEMU profiles (tests/profiles.json) get a per-
+          # matrix-cell breakdown alongside the per-arch totals. Suites that
+          # don't use profiles render a single row per arch unchanged.
+          python3 << 'PY' > results-table.md
+          import os, re, xml.etree.ElementTree as ET
 
-          x64_result=$(parse_xml "results-x64/test-results-${{ inputs.suite_id }}-x64.xml")
-          arm64_result=$(parse_xml "results-arm64/test-results-${{ inputs.suite_id }}-arm64.xml")
+          PROF_RE = re.compile(r'^\[([^\]]+)\]\s+')
 
-          echo "x64_result=$x64_result" >> $GITHUB_OUTPUT
-          echo "arm64_result=$arm64_result" >> $GITHUB_OUTPUT
+          def parse(path):
+              if not os.path.exists(path):
+                  return None
+              root = ET.parse(path).getroot()
+              buckets = {}
+              for c in root.findall('.//testcase'):
+                  m = PROF_RE.match(c.get('name', ''))
+                  prof = m.group(1) if m else '_default_'
+                  b = buckets.setdefault(prof, {'tests':0,'failed':0,'skipped':0,'time':0.0})
+                  b['tests'] += 1
+                  if c.find('failure') is not None: b['failed'] += 1
+                  if c.find('skipped') is not None: b['skipped'] += 1
+                  try:
+                      b['time'] += float(c.get('time') or 0)
+                  except ValueError:
+                      pass
+              overall = {
+                  'tests':   sum(b['tests']   for b in buckets.values()),
+                  'failed':  sum(b['failed']  for b in buckets.values()),
+                  'skipped': sum(b['skipped'] for b in buckets.values()),
+                  'time':    sum(b['time']    for b in buckets.values()),
+              }
+              return overall, buckets
+
+          def status(d):
+              return '❌ Failed' if d['failed'] > 0 else '✅ Passed'
+
+          def row(arch, prof, d):
+              passed = d['tests'] - d['failed'] - d['skipped']
+              return f"| {arch} | {prof} | {d['tests']} | {passed} | {d['failed']} | {d['skipped']} | {d['time']:.2f}s | {status(d)} |"
+
+          suite_id = "${{ inputs.suite_id }}"
+          rows = []
+          any_profiles = False
+          for arch in ('x64', 'arm64'):
+              result = parse(f'results-{arch}/test-results-{suite_id}-{arch}.xml')
+              if result is None:
+                  rows.append(f"| {arch} | _all_ | 0 | 0 | 0 | 0 | N/A | ⚠️ No results |")
+                  continue
+              overall, buckets = result
+              # Single un-prefixed bucket → suite doesn't use profiles, just one row.
+              if list(buckets.keys()) == ['_default_']:
+                  rows.append(row(arch, '_all_', overall))
+              else:
+                  any_profiles = True
+                  rows.append(row(arch, '_all_', overall))
+                  for name in sorted(buckets):
+                      rows.append(row(arch, name, buckets[name]))
+
+          profile_col = 'Profile' if any_profiles else 'Scope'
+          header = f"| Architecture | {profile_col} | Tests | Passed | Failed | Skipped | Time | Status |\n|---|---|---|---|---|---|---|---|"
+          print('\n'.join([header] + rows))
+          PY
+
+          # Stash the rendered table for the comment step. Use a delimiter form
+          # so newlines survive the round-trip through $GITHUB_OUTPUT.
+          {
+            echo 'results_table<<EOF'
+            cat results-table.md
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
 
       - name: 💬 Post PR Comment
         uses: actions/github-script@v7
@@ -83,8 +126,7 @@ jobs:
             const suiteName = '${{ inputs.suite_name }}';
             const suiteId = '${{ inputs.suite_id }}';
             const kernelSrcUrl = 'https://github.com/${{ github.repository }}/blob/${{ inputs.head_ref }}/${{ inputs.kernel_path }}/Kernel.cs';
-            const x64 = '${{ steps.parse.outputs.x64_result }}'.split('|');
-            const arm64 = '${{ steps.parse.outputs.arm64_result }}'.split('|');
+            const resultsTable = `${{ steps.parse.outputs.results_table }}`;
             const runId = '${{ github.run_id }}';
             const repo = '${{ github.repository }}';
             const owner = context.repo.owner;
@@ -104,21 +146,19 @@ jobs:
               return `https://github.com/${repo}/actions/runs/${runId}`;
             };
 
-            const body = `## 🧪 ${suiteName} Tests
-
-            | Architecture | Tests | Passed | Failed | Skipped | Duration | Status |
-            |--------------|-------|--------|--------|---------|----------|--------|
-            | x64 | ${x64[0]} | ${x64[1]} | ${x64[2]} | ${x64[3]} | ${x64[4]} | ${x64[5]} |
-            | arm64 | ${arm64[0]} | ${arm64[1]} | ${arm64[2]} | ${arm64[3]} | ${arm64[4]} | ${arm64[5]} |
-
-            ### 📎 Artifacts
-            | Architecture | Test Results | UART Log | Kernel ISO |
-            |--------------|--------------|----------|------------|
-            | x64 | [XML](${getArtifactUrl('test-results-' + suiteId + '-x64')}) | [Log](${getArtifactUrl('uart-log-' + suiteId + '-x64')}) | [ISO](${getArtifactUrl(suiteName + '-Test-ISO-x64')}) |
-            | arm64 | [XML](${getArtifactUrl('test-results-' + suiteId + '-arm64')}) | [Log](${getArtifactUrl('uart-log-' + suiteId + '-arm64')}) | [ISO](${getArtifactUrl(suiteName + '-Test-ISO-arm64')}) |
-
-            📋 [View full test summary](https://github.com/${repo}/actions/runs/${runId}) | 📄 [Kernel.cs](${kernelSrcUrl})
-            `;
+            const body = [
+              `## 🧪 ${suiteName} Tests`,
+              '',
+              resultsTable,
+              '',
+              '### 📎 Artifacts',
+              '| Architecture | Test Results | UART Log | Kernel ISO |',
+              '|--------------|--------------|----------|------------|',
+              `| x64 | [XML](${getArtifactUrl('test-results-' + suiteId + '-x64')}) | [Log](${getArtifactUrl('uart-log-' + suiteId + '-x64')}) | [ISO](${getArtifactUrl(suiteName + '-Test-ISO-x64')}) |`,
+              `| arm64 | [XML](${getArtifactUrl('test-results-' + suiteId + '-arm64')}) | [Log](${getArtifactUrl('uart-log-' + suiteId + '-arm64')}) | [ISO](${getArtifactUrl(suiteName + '-Test-ISO-arm64')}) |`,
+              '',
+              `📋 [View full test summary](https://github.com/${repo}/actions/runs/${runId}) | 📄 [Kernel.cs](${kernelSrcUrl})`
+            ].join('\n');
 
             const marker = `## 🧪 ${suiteName} Tests`;
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/kernel-tests.yml
+++ b/.github/workflows/kernel-tests.yml
@@ -299,6 +299,29 @@ jobs:
       event_name: ${{ github.event_name }}
       head_ref: ${{ github.head_ref || github.ref_name }}
 
+  # ── Pci ───────────────────────────────────────────────────────────────────────
+  pci-tests:
+    needs: setup
+    uses: ./.github/workflows/kernel-test-run.yml
+    with:
+      suite_name: Pci
+      suite_id: pci
+      kernel_path: tests/Kernels/Cosmos.Kernel.Tests.Pci
+      timeout_x64: 60
+      timeout_arm64: 90
+      step_timeout_minutes: 5
+
+  pci-results:
+    needs: pci-tests
+    if: always()
+    uses: ./.github/workflows/kernel-test-results.yml
+    with:
+      suite_name: Pci
+      suite_id: pci
+      kernel_path: tests/Kernels/Cosmos.Kernel.Tests.Pci
+      event_name: ${{ github.event_name }}
+      head_ref: ${{ github.head_ref || github.ref_name }}
+
   # ── Storage ───────────────────────────────────────────────────────────────────
   storage-tests:
     needs: setup
@@ -326,7 +349,7 @@ jobs:
   test-summary:
     name: Test Summary
     runs-on: ubuntu-24.04
-    needs: [ helloworld-results, memory-results, typecasting-results, timer-results, network-results, runtime-results, threading-results, math-results, graphic-results, power-results, garbagecollector-results, storage-results ]
+    needs: [ helloworld-results, memory-results, typecasting-results, timer-results, network-results, runtime-results, threading-results, math-results, graphic-results, power-results, garbagecollector-results, pci-results, storage-results ]
     if: always()
     steps:
       - name: 📊 Generate Summary
@@ -357,6 +380,7 @@ jobs:
           add_row "Graphic"          "${{ needs.graphic-tests.result }}"
           add_row "Power"            "${{ needs.power-tests.result }}"
           add_row "GarbageCollector" "${{ needs.garbagecollector-tests.result }}"
+          add_row "Pci"              "${{ needs.pci-tests.result }}"
           add_row "Storage"          "${{ needs.storage-tests.result }}"
 
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/src/Cosmos.Tools/Launcher/QemuLauncher.cs
+++ b/src/Cosmos.Tools/Launcher/QemuLauncher.cs
@@ -16,21 +16,25 @@ public sealed class QemuLaunchOptions
     /// <summary>Adds the test-runner port forwards (UDP 5556, TCP 5558) needed by network tests.</summary>
     public bool EnableNetworkTesting { get; init; }
     /// <summary>
-    /// Raw disk images to attach as AHCI/SATA drives. The launcher adds a
-    /// single <c>ich9-ahci</c> controller and one <c>ide-hd</c> per path on
-    /// successive ports (<c>bus=ahci0.0</c>, <c>ahci0.1</c>, ...), so the AHCI
-    /// driver enumerates all of them via one PCI scan. Honoured on both x64
-    /// (q35) and ARM64 (virt).
+    /// Disks to attach. Each <see cref="DiskAttachment"/> carries the image
+    /// path, the controller type (ahci or nvme), and an optional comma-prefixed
+    /// suffix appended to the QEMU <c>-device</c> line — used by test profiles
+    /// to toggle things like <c>msix=off</c> or <c>msix_qsize=1</c>. AHCI disks
+    /// share one <c>ich9-ahci</c> controller across successive ports; NVMe
+    /// disks each get a dedicated <c>nvme</c> controller. Honoured on x64 (q35)
+    /// and ARM64 (virt).
     /// </summary>
-    public IReadOnlyList<string> AhciDiskPaths { get; init; } = Array.Empty<string>();
+    public IReadOnlyList<DiskAttachment> Disks { get; init; } = Array.Empty<DiskAttachment>();
 
     /// <summary>
-    /// Raw disk images to attach as NVMe drives. The launcher adds one
-    /// <c>nvme</c> PCIe controller per path (each with a unique <c>id</c> and
-    /// <c>serial</c>) so the NVMe driver binds to every controller via PCI
-    /// scan. Honoured on both x64 (q35) and ARM64 (virt).
+    /// Extra <c>-M</c> machine properties spliced after the architecture
+    /// defaults (e.g. <c>{"gic-version", "2"}</c> on ARM64 to force GICv2).
+    /// Empty by default. Caller is responsible for passing properties that
+    /// match the active architecture; nothing here filters on that.
     /// </summary>
-    public IReadOnlyList<string> NvmeDiskPaths { get; init; } = Array.Empty<string>();
+    public IReadOnlyDictionary<string, string> MachineOptions { get; init; }
+        = new Dictionary<string, string>();
+
     /// <summary>
     /// When false (default, dev path), x64 launches with <c>-no-shutdown</c> so a guest-initiated
     /// ACPI _S5 / panic just pauses the VM and the user can inspect it. When true (test path),
@@ -39,6 +43,26 @@ public sealed class QemuLaunchOptions
     /// </summary>
     public bool AllowGuestShutdown { get; init; }
     public IReadOnlyList<string> ExtraArgs { get; init; } = Array.Empty<string>();
+}
+
+public enum DiskKind
+{
+    Ahci,
+    Nvme
+}
+
+/// <summary>
+/// One disk image to expose to the guest. <see cref="ExtraDeviceOptions"/> is
+/// appended verbatim to the QEMU <c>-device</c> line (without the leading
+/// comma — the launcher inserts that), so a profile can pass things like
+/// <c>"msix=off"</c> or <c>"msix_qsize=1"</c> to exercise the kernel's
+/// interrupt-fallback paths.
+/// </summary>
+public sealed record DiskAttachment
+{
+    public required string Path { get; init; }
+    public required DiskKind Kind { get; init; }
+    public string ExtraDeviceOptions { get; init; } = string.Empty;
 }
 
 public sealed record QemuLaunchPlan(string BinaryPath, string Arguments, ToolSource Source);
@@ -131,7 +155,9 @@ public static class QemuLauncher
 
     private static void AppendX64Args(StringBuilder args, QemuLaunchOptions options)
     {
-        args.Append($"-M q35 -cpu max -m {options.MemoryMb}M");
+        args.Append("-M q35");
+        AppendMachineOptions(args, options.MachineOptions);
+        args.Append($" -cpu max -m {options.MemoryMb}M");
         // Explicit CD drive with bootindex=0 so SeaBIOS picks the ISO over
         // any attached HDDs whose 0xAA55 MBR signature would otherwise
         // satisfy the BIOS and hang when their boot code is empty (the case
@@ -156,7 +182,9 @@ public static class QemuLauncher
         // through its data dir search, which our `-L "<exe>/../share/qemu"`
         // (added above when Source==Bundle) points at the bundle's
         // edk2-aarch64-code.fd. No separate firmware-lookup logic needed.
-        args.Append($"-M virt,highmem=off -cpu cortex-a72 -m {options.MemoryMb}M");
+        args.Append("-M virt,highmem=off");
+        AppendMachineOptions(args, options.MachineOptions);
+        args.Append($" -cpu cortex-a72 -m {options.MemoryMb}M");
         args.Append(" -bios edk2-aarch64-code.fd");
         args.Append($" -cdrom \"{options.IsoPath}\"");
         args.Append(" -boot d -no-reboot");
@@ -165,30 +193,71 @@ public static class QemuLauncher
         AppendStorageArgs(args, options);
     }
 
+    private static void AppendMachineOptions(StringBuilder args, IReadOnlyDictionary<string, string> opts)
+    {
+        foreach (KeyValuePair<string, string> kv in opts)
+        {
+            args.Append(',');
+            args.Append(kv.Key);
+            args.Append('=');
+            args.Append(kv.Value);
+        }
+    }
+
     /// <summary>
     /// Attach AHCI/SATA + NVMe disks. AHCI disks share one <c>ich9-ahci</c>
     /// controller and consume successive ports; NVMe disks each get a
     /// dedicated <c>nvme</c> controller so the guest exercises multi-controller
-    /// binding.
+    /// binding. Per-disk <see cref="DiskAttachment.ExtraDeviceOptions"/> is
+    /// appended after the standard device properties so profiles can flip
+    /// things like <c>msix=off</c>.
     /// </summary>
     private static void AppendStorageArgs(StringBuilder args, QemuLaunchOptions options)
     {
-        if (options.AhciDiskPaths.Count > 0)
+        int ahciIndex = 0;
+        int nvmeIndex = 0;
+        bool ahciControllerEmitted = false;
+
+        foreach (DiskAttachment disk in options.Disks)
         {
-            args.Append(" -device ich9-ahci,id=ahci0");
-            for (int i = 0; i < options.AhciDiskPaths.Count; i++)
+            switch (disk.Kind)
             {
-                string path = options.AhciDiskPaths[i];
-                args.Append($" -drive file=\"{path}\",if=none,id=ahcidisk{i},format=raw");
-                args.Append($" -device ide-hd,drive=ahcidisk{i},bus=ahci0.{i}");
+                case DiskKind.Ahci:
+                    if (!ahciControllerEmitted)
+                    {
+                        args.Append(" -device ich9-ahci,id=ahci0");
+                        ahciControllerEmitted = true;
+                    }
+                    args.Append($" -drive file=\"{disk.Path}\",if=none,id=ahcidisk{ahciIndex},format=raw");
+                    args.Append($" -device ide-hd,drive=ahcidisk{ahciIndex},bus=ahci0.{ahciIndex}");
+                    AppendDeviceOptions(args, disk.ExtraDeviceOptions);
+                    ahciIndex++;
+                    break;
+
+                case DiskKind.Nvme:
+                    args.Append($" -drive file=\"{disk.Path}\",if=none,id=nvmedisk{nvmeIndex},format=raw");
+                    args.Append($" -device nvme,id=nvme{nvmeIndex},drive=nvmedisk{nvmeIndex},serial=cosmos-nvme-{nvmeIndex}");
+                    AppendDeviceOptions(args, disk.ExtraDeviceOptions);
+                    nvmeIndex++;
+                    break;
             }
         }
-        for (int i = 0; i < options.NvmeDiskPaths.Count; i++)
+    }
+
+    private static void AppendDeviceOptions(StringBuilder args, string extra)
+    {
+        if (string.IsNullOrWhiteSpace(extra))
         {
-            string path = options.NvmeDiskPaths[i];
-            args.Append($" -drive file=\"{path}\",if=none,id=nvmedisk{i},format=raw");
-            args.Append($" -device nvme,id=nvme{i},drive=nvmedisk{i},serial=cosmos-nvme-{i}");
+            return;
         }
+        // Allow callers to pass "msix=off" or ",msix=off" — normalize to a
+        // single leading comma so it splices cleanly onto the -device line.
+        string trimmed = extra.Trim();
+        if (!trimmed.StartsWith(','))
+        {
+            args.Append(',');
+        }
+        args.Append(trimmed);
     }
 
     public static ProcessStartInfo ToProcessStartInfo(QemuLaunchPlan plan)

--- a/tests/Cosmos.TestRunner.Engine/Engine.cs
+++ b/tests/Cosmos.TestRunner.Engine/Engine.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -8,6 +9,7 @@ using System.Threading.Tasks;
 using Cosmos.TestRunner.Engine.Hosts;
 using Cosmos.TestRunner.Engine.OutputHandlers;
 using Cosmos.TestRunner.Engine.Protocol;
+using Cosmos.Tools.Launcher;
 
 namespace Cosmos.TestRunner.Engine;
 
@@ -58,7 +60,7 @@ public partial class Engine
     }
 
     /// <summary>
-    /// Main execution flow: Build → Launch → Monitor → Results
+    /// Main execution flow: Build → (per profile) Launch → Monitor → Results → Aggregate
     /// </summary>
     public async Task<TestResults> ExecuteAsync()
     {
@@ -83,15 +85,39 @@ public partial class Engine
             string isoPath = await BuildKernelAsync();
             Console.WriteLine($"[Engine] Build complete: {isoPath}");
 
-            // Step 2: Launch QEMU and monitor execution
-            Console.WriteLine("[Engine] Launching QEMU...");
-            var qemuResult = await LaunchAndMonitorAsync(isoPath);
-            Console.WriteLine($"[Engine] QEMU execution complete (Exit: {qemuResult.ExitCode}, TimedOut: {qemuResult.TimedOut})");
+            // Step 2: Run the kernel once per QEMU profile the suite opts into
+            // (CosmosTestProfile + CosmosTestModifier items in the csproj,
+            // resolved against tests/profiles.json). A suite that opts into
+            // nothing gets a single anonymous profile.
+            IReadOnlyList<TestProfile> profiles = TestProfileLoader.LoadFor(_config.KernelProjectPath, _config.Architecture);
+            if (profiles.Count > 1)
+            {
+                Console.WriteLine($"[Engine] {profiles.Count} QEMU profiles declared: {string.Join(", ", profiles.Select(p => p.Name))}");
+            }
 
-            // Step 3: Parse results from UART log
-            Console.WriteLine("[Engine] Parsing test results...");
-            var results = ParseResults(qemuResult);
-            results.SuiteName = suiteName;
+            TestResults results = new()
+            {
+                SuiteName = suiteName,
+                Architecture = _config.Architecture
+            };
+
+            for (int p = 0; p < profiles.Count; p++)
+            {
+                TestProfile profile = profiles[p];
+                if (!profile.IsDefault)
+                {
+                    Console.WriteLine($"[Engine] === Profile {p + 1}/{profiles.Count}: {profile.Name} ===");
+                }
+
+                Console.WriteLine("[Engine] Launching QEMU...");
+                QemuRunResult qemuResult = await LaunchAndMonitorAsync(isoPath, profile);
+                Console.WriteLine($"[Engine] QEMU execution complete (Exit: {qemuResult.ExitCode}, TimedOut: {qemuResult.TimedOut})");
+
+                Console.WriteLine("[Engine] Parsing test results...");
+                TestResults profileResults = ParseResults(qemuResult);
+                MergeProfileResults(results, profileResults, profile);
+            }
+
             results.TotalDuration = stopwatch.Elapsed;
 
             Console.WriteLine($"[Engine] Results: {results.PassedTests}/{results.TotalTests} passed");
@@ -160,54 +186,34 @@ public partial class Engine
     // the kernel knows which destructive test already fired.
     private const int MaxBoots = 4;
 
-    private async Task<QemuRunResult> LaunchAndMonitorAsync(string isoPath)
+    private async Task<QemuRunResult> LaunchAndMonitorAsync(string isoPath, TestProfile profile)
     {
-        // Setup UART log path
+        // Setup UART log path. When several profiles run back-to-back, each
+        // gets its own log file so a failure in one doesn't lose the other's
+        // output and the per-profile boot-N derivatives stay disjoint.
         string baseUartLogPath = _config.UartLogPath;
         if (string.IsNullOrEmpty(baseUartLogPath))
         {
+            string baseName = profile.IsDefault ? "uart.log" : $"uart-{profile.Name}.log";
             baseUartLogPath = Path.Combine(
                 Path.GetDirectoryName(isoPath) ?? ".",
-                "uart.log"
+                baseName
             );
+        }
+        else if (!profile.IsDefault)
+        {
+            string dir = Path.GetDirectoryName(baseUartLogPath) ?? ".";
+            string stem = Path.GetFileNameWithoutExtension(baseUartLogPath);
+            string ext = Path.GetExtension(baseUartLogPath);
+            baseUartLogPath = Path.Combine(dir, $"{stem}-{profile.Name}{ext}");
         }
 
         // Detect if this is a network test kernel
         bool enableNetworkTesting = _config.KernelProjectPath.Contains("Network", StringComparison.OrdinalIgnoreCase);
 
-        // Detect if this is a storage test kernel — attach two AHCI/SATA
-        // disks (sharing one ich9-ahci controller across two SATA ports) +
-        // two NVMe controllers so the suite exercises multi-port AHCI
-        // enumeration AND multi-controller NVMe binding. Each disk is a
-        // fresh 256 MiB sparse raw image. Both arches honour the disk paths
-        // via QemuLauncher; the storage suite skips per-device tests if a
-        // device fails to bind.
-        const int StorageDiskCountPerType = 2;
-        string[] ahciDiskPaths = Array.Empty<string>();
-        string[] nvmeDiskPaths = Array.Empty<string>();
-        if (_config.KernelProjectPath.Contains("Storage", StringComparison.OrdinalIgnoreCase))
-        {
-            string suite = Path.GetFileName(_config.KernelProjectPath.TrimEnd('/', '\\'));
-            ahciDiskPaths = new string[StorageDiskCountPerType];
-            nvmeDiskPaths = new string[StorageDiskCountPerType];
-            for (int i = 0; i < StorageDiskCountPerType; i++)
-            {
-                ahciDiskPaths[i] = Path.Combine(Path.GetTempPath(), $"cosmos-test-disk-{suite}-{_config.Architecture}-ahci{i}.img");
-                nvmeDiskPaths[i] = Path.Combine(Path.GetTempPath(), $"cosmos-test-disk-{suite}-{_config.Architecture}-nvme{i}.img");
-            }
-            foreach (string path in ahciDiskPaths.Concat(nvmeDiskPaths))
-            {
-                if (File.Exists(path))
-                {
-                    File.Delete(path);
-                }
-                using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
-                {
-                    fs.SetLength(256L * 1024 * 1024);
-                }
-                Console.WriteLine($"[Engine] Created test disk: {path} (256 MiB sparse)");
-            }
-        }
+        // Allocate fresh 256 MiB sparse raw images per profile so back-to-back
+        // profile runs don't see each other's writes.
+        IReadOnlyList<DiskAttachment> disks = CreateProfileDisks(profile);
 
         var combinedLog = new StringBuilder();
         QemuRunResult? lastResult = null;
@@ -223,7 +229,7 @@ public partial class Engine
             }
 
             QemuRunResult result = await _qemuHost.RunKernelAsync(
-                bootIsoPath, bootLogPath, _config.TimeoutSeconds, _config.ShouldShowDisplay, enableNetworkTesting, ahciDiskPaths, nvmeDiskPaths);
+                bootIsoPath, bootLogPath, _config.TimeoutSeconds, _config.ShouldShowDisplay, enableNetworkTesting, disks, profile.MachineOptions);
 
             combinedLog.Append(result.UartLog);
             lastResult = result;
@@ -258,6 +264,88 @@ public partial class Engine
             ErrorMessage = lastResult?.ErrorMessage ?? string.Empty,
             SuiteMarkerSeen = lastResult?.SuiteMarkerSeen ?? false
         };
+    }
+
+    private IReadOnlyList<DiskAttachment> CreateProfileDisks(TestProfile profile)
+    {
+        if (profile.Disks.Count == 0)
+        {
+            return Array.Empty<DiskAttachment>();
+        }
+
+        string suite = Path.GetFileName(_config.KernelProjectPath.TrimEnd('/', '\\'));
+        string profileTag = profile.IsDefault ? "default" : profile.Name;
+        var attachments = new List<DiskAttachment>(profile.Disks.Count);
+
+        for (int i = 0; i < profile.Disks.Count; i++)
+        {
+            TestProfileDisk disk = profile.Disks[i];
+            string kindTag = disk.Kind == DiskKind.Ahci ? "ahci" : "nvme";
+            string path = Path.Combine(
+                Path.GetTempPath(),
+                $"cosmos-test-disk-{suite}-{_config.Architecture}-{profileTag}-{kindTag}{i}.img");
+
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+            using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
+            {
+                fs.SetLength(256L * 1024 * 1024);
+            }
+            Console.WriteLine($"[Engine] Created test disk: {path} (256 MiB sparse)");
+
+            attachments.Add(new DiskAttachment
+            {
+                Path = path,
+                Kind = disk.Kind,
+                ExtraDeviceOptions = disk.FormatOptions()
+            });
+        }
+        return attachments;
+    }
+
+    /// <summary>
+    /// Fold one profile's parsed results into the suite-wide aggregate. Test
+    /// names get a `[profile]` prefix so the same logical test from different
+    /// profiles stays distinguishable, and TestNumber is renumbered across the
+    /// combined list so output handlers see a contiguous sequence.
+    /// </summary>
+    private void MergeProfileResults(TestResults aggregate, TestResults profileResults, TestProfile profile)
+    {
+        string prefix = profile.IsDefault ? string.Empty : $"[{profile.Name}] ";
+        bool isFirstProfile = aggregate.Tests.Count == 0 && aggregate.ExpectedTestCount == 0;
+
+        foreach (TestResult t in profileResults.Tests)
+        {
+            t.TestNumber = aggregate.Tests.Count + 1;
+            if (prefix.Length > 0)
+            {
+                t.TestName = prefix + t.TestName;
+            }
+            aggregate.Tests.Add(t);
+        }
+
+        aggregate.ExpectedTestCount += profileResults.ExpectedTestCount;
+        aggregate.UartLog += profileResults.UartLog;
+        aggregate.CoverageHitMethodIds.AddRange(profileResults.CoverageHitMethodIds);
+
+        if (profileResults.TimedOut)
+        {
+            aggregate.TimedOut = true;
+        }
+        if (!string.IsNullOrEmpty(profileResults.ErrorMessage))
+        {
+            aggregate.ErrorMessage = string.IsNullOrEmpty(aggregate.ErrorMessage)
+                ? profileResults.ErrorMessage
+                : $"{aggregate.ErrorMessage}; {profileResults.ErrorMessage}";
+        }
+
+        // The aggregate is "completed" only when every profile in the suite
+        // emitted its end-marker. Seed with the first profile, then AND.
+        aggregate.SuiteCompleted = isFirstProfile
+            ? profileResults.SuiteCompleted
+            : aggregate.SuiteCompleted && profileResults.SuiteCompleted;
     }
 
     /// <summary>

--- a/tests/Cosmos.TestRunner.Engine/Hosts/IQemuHost.cs
+++ b/tests/Cosmos.TestRunner.Engine/Hosts/IQemuHost.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Cosmos.Tools.Launcher;
 
 namespace Cosmos.TestRunner.Engine;
 
@@ -22,10 +23,10 @@ public interface IQemuHost
     /// <param name="timeoutSeconds">Maximum time to run (default 30s)</param>
     /// <param name="showDisplay">Show QEMU display window (default false = headless)</param>
     /// <param name="enableNetworkTesting">Enable UDP test server for network tests (default false)</param>
-    /// <param name="ahciDiskPaths">Raw disk images to attach as AHCI/SATA drives (default null = no AHCI disks). One <c>ich9-ahci</c> controller carries them on successive ports.</param>
-    /// <param name="nvmeDiskPaths">Raw disk images to attach as NVMe drives (default null = no NVMe disks). Each path gets its own <c>nvme</c> controller, exercising multi-controller binding.</param>
+    /// <param name="disks">Per-profile disk attachments. AHCI entries share one <c>ich9-ahci</c> controller; NVMe entries each get their own <c>nvme</c> controller. Per-disk extra device options (e.g. <c>msix=off</c>) flow through.</param>
+    /// <param name="machineOptions">Extra <c>-M</c> properties (e.g. <c>{"gic-version", "2"}</c> on ARM64). Caller is responsible for passing arch-appropriate keys.</param>
     /// <returns>Exit code and UART log content</returns>
-    Task<QemuRunResult> RunKernelAsync(string isoPath, string uartLogPath, int timeoutSeconds = 30, bool showDisplay = false, bool enableNetworkTesting = false, IReadOnlyList<string>? ahciDiskPaths = null, IReadOnlyList<string>? nvmeDiskPaths = null);
+    Task<QemuRunResult> RunKernelAsync(string isoPath, string uartLogPath, int timeoutSeconds = 30, bool showDisplay = false, bool enableNetworkTesting = false, IReadOnlyList<DiskAttachment>? disks = null, IReadOnlyDictionary<string, string>? machineOptions = null);
 }
 
 /// <summary>

--- a/tests/Cosmos.TestRunner.Engine/Hosts/QemuARM64Host.cs
+++ b/tests/Cosmos.TestRunner.Engine/Hosts/QemuARM64Host.cs
@@ -30,7 +30,7 @@ public class QemuARM64Host : IQemuHost
         // uefiFirmwarePath ignored — QemuLauncher.ResolveArm64Firmware() handles it.
     }
 
-    public async Task<QemuRunResult> RunKernelAsync(string isoPath, string uartLogPath, int timeoutSeconds = 30, bool showDisplay = false, bool enableNetworkTesting = false, IReadOnlyList<string>? ahciDiskPaths = null, IReadOnlyList<string>? nvmeDiskPaths = null)
+    public async Task<QemuRunResult> RunKernelAsync(string isoPath, string uartLogPath, int timeoutSeconds = 30, bool showDisplay = false, bool enableNetworkTesting = false, IReadOnlyList<DiskAttachment>? disks = null, IReadOnlyDictionary<string, string>? machineOptions = null)
     {
         if (!File.Exists(isoPath))
         {
@@ -65,8 +65,8 @@ public class QemuARM64Host : IQemuHost
                 Headless = !showDisplay,
                 SerialOutputFile = uartLogPath,
                 EnableNetworkTesting = enableNetworkTesting,
-                AhciDiskPaths = ahciDiskPaths ?? Array.Empty<string>(),
-                NvmeDiskPaths = nvmeDiskPaths ?? Array.Empty<string>(),
+                Disks = disks ?? Array.Empty<DiskAttachment>(),
+                MachineOptions = machineOptions ?? new Dictionary<string, string>(),
                 AllowGuestShutdown = true
             });
         }

--- a/tests/Cosmos.TestRunner.Engine/Hosts/QemuX64Host.cs
+++ b/tests/Cosmos.TestRunner.Engine/Hosts/QemuX64Host.cs
@@ -26,7 +26,7 @@ public class QemuX64Host : IQemuHost
         _memoryMb = memoryMb;
     }
 
-    public async Task<QemuRunResult> RunKernelAsync(string isoPath, string uartLogPath, int timeoutSeconds = 30, bool showDisplay = false, bool enableNetworkTesting = false, IReadOnlyList<string>? ahciDiskPaths = null, IReadOnlyList<string>? nvmeDiskPaths = null)
+    public async Task<QemuRunResult> RunKernelAsync(string isoPath, string uartLogPath, int timeoutSeconds = 30, bool showDisplay = false, bool enableNetworkTesting = false, IReadOnlyList<DiskAttachment>? disks = null, IReadOnlyDictionary<string, string>? machineOptions = null)
     {
         if (!File.Exists(isoPath))
         {
@@ -59,8 +59,8 @@ public class QemuX64Host : IQemuHost
             SerialOutputFile = uartLogPath,
             EnableNetworkTesting = enableNetworkTesting,
             AllowGuestShutdown = true,
-            AhciDiskPaths = ahciDiskPaths ?? Array.Empty<string>(),
-            NvmeDiskPaths = nvmeDiskPaths ?? Array.Empty<string>()
+            Disks = disks ?? Array.Empty<DiskAttachment>(),
+            MachineOptions = machineOptions ?? new Dictionary<string, string>()
         });
         var startInfo = QemuLauncher.ToProcessStartInfo(plan);
         if (_qemuBinaryOverride is not null)

--- a/tests/Cosmos.TestRunner.Engine/OutputHandlers/OutputHandlerXml.cs
+++ b/tests/Cosmos.TestRunner.Engine/OutputHandlers/OutputHandlerXml.cs
@@ -105,26 +105,32 @@ public class OutputHandlerXml : OutputHandlerBase
 
         writer.WriteEndElement(); // properties
 
-        // Individual test cases
+        // Individual test cases. Filter every string attribute through
+        // FilterInvalidXmlChars before emission — even though ParseTestStart
+        // now drops messages with control chars in the name, defending the
+        // writer keeps a malformed UART corruption from ever truncating the
+        // XML mid-suite (which loses ALL profiles' results, not just the
+        // corrupted one).
         foreach (var test in results.Tests)
         {
             writer.WriteStartElement("testcase");
-            writer.WriteAttributeString("name", test.TestName);
+            writer.WriteAttributeString("name", FilterInvalidXmlChars(test.TestName));
             writer.WriteAttributeString("classname", _suiteName);
             writer.WriteAttributeString("time", (test.DurationMs / 1000.0).ToString("F3"));
 
             if (test.Status == TestStatus.Failed)
             {
+                string msg = FilterInvalidXmlChars(test.ErrorMessage);
                 writer.WriteStartElement("failure");
-                writer.WriteAttributeString("message", test.ErrorMessage);
+                writer.WriteAttributeString("message", msg);
                 writer.WriteAttributeString("type", "TestFailure");
-                writer.WriteString(test.ErrorMessage);
+                writer.WriteString(msg);
                 writer.WriteEndElement(); // failure
             }
             else if (test.Status == TestStatus.Skipped)
             {
                 writer.WriteStartElement("skipped");
-                writer.WriteAttributeString("message", test.ErrorMessage);
+                writer.WriteAttributeString("message", FilterInvalidXmlChars(test.ErrorMessage));
                 writer.WriteEndElement(); // skipped
             }
 

--- a/tests/Cosmos.TestRunner.Engine/Protocol/UartMessageParser.cs
+++ b/tests/Cosmos.TestRunner.Engine/Protocol/UartMessageParser.cs
@@ -169,6 +169,20 @@ public class UartMessageParser
         int testNumber = BitConverter.ToUInt16(payload, 0);
         string testName = Encoding.UTF8.GetString(payload, 2, payload.Length - 2);
 
+        // Defensive: a non-protocol byte sequence in UART (e.g. an IRQ handler
+        // calling Serial.WriteString mid-frame) can interleave with a real
+        // TestStart in a way that produces a false-positive magic match here,
+        // and the resulting "name" carries control characters (0x00..0x1F)
+        // that downstream XML emission rejects. Drop messages whose name
+        // contains anything below 0x20 — real test names are ASCII identifiers.
+        for (int i = 0; i < testName.Length; i++)
+        {
+            if (testName[i] < 0x20)
+            {
+                return;
+            }
+        }
+
         TestResult? existingTest = results.Tests.Find(t => t.TestNumber == testNumber);
         if (existingTest != null)
         {

--- a/tests/Cosmos.TestRunner.Engine/TestProfile.cs
+++ b/tests/Cosmos.TestRunner.Engine/TestProfile.cs
@@ -1,0 +1,388 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Xml.Linq;
+using Cosmos.Tools.Launcher;
+
+namespace Cosmos.TestRunner.Engine;
+
+/// <summary>
+/// One QEMU launch configuration, possibly composed from a base hardware
+/// profile and a single device/machine modifier. Profiles and modifiers are
+/// declared globally in <c>tests/profiles.json</c>; a suite opts in via
+/// <c>&lt;CosmosTestProfile/&gt;</c> and <c>&lt;CosmosTestModifier/&gt;</c>
+/// items in its csproj. The engine cross-products the two and emits one
+/// <see cref="TestProfile"/> per matrix cell.
+/// </summary>
+public sealed record TestProfile
+{
+    /// <summary>Display label used to prefix test names — base profile name, or "profile+modifier".</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Disks to attach for this profile, with any modifier options already merged in.</summary>
+    public IReadOnlyList<TestProfileDisk> Disks { get; init; } = Array.Empty<TestProfileDisk>();
+
+    /// <summary>Extra <c>-M</c> machine properties (e.g. <c>{"gic-version", "2"}</c>). Merged from base profile + applied modifier.</summary>
+    public IReadOnlyDictionary<string, string> MachineOptions { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>True when this is the synthetic single-profile fallback used by suites that opt into nothing.</summary>
+    public bool IsDefault { get; init; }
+
+    public static TestProfile Default => new() { Name = string.Empty, IsDefault = true };
+}
+
+/// <summary>
+/// One disk entry: backend type and a dictionary of QEMU properties spliced
+/// onto the <c>-device</c> line.
+/// </summary>
+public sealed record TestProfileDisk
+{
+    public required DiskKind Kind { get; init; }
+    public IReadOnlyDictionary<string, string> Options { get; init; } = new Dictionary<string, string>();
+
+    public string FormatOptions()
+    {
+        if (Options.Count == 0)
+        {
+            return string.Empty;
+        }
+        var sb = new StringBuilder();
+        bool first = true;
+        foreach (KeyValuePair<string, string> kv in Options)
+        {
+            if (!first)
+            {
+                sb.Append(',');
+            }
+            sb.Append(kv.Key);
+            sb.Append('=');
+            sb.Append(kv.Value);
+            first = false;
+        }
+        return sb.ToString();
+    }
+}
+
+/// <summary>
+/// A named overlay of QEMU options that compose with a profile to produce a
+/// variant. Two orthogonal axes:
+///   * <see cref="DeviceOptions"/> — per-disk-kind overrides (e.g. NVMe MSI-X).
+///   * <see cref="MachineOptions"/> — <c>-M</c> properties (e.g. GIC version).
+/// <see cref="Architectures"/> gates the modifier to one or more arches; null
+/// means any. A modifier is silently skipped for a profile when its arch
+/// doesn't match or when it has only device options none of which target a
+/// device kind in the profile.
+/// </summary>
+internal sealed record TestModifier
+{
+    public required string Name { get; init; }
+    public IReadOnlyList<string>? Architectures { get; init; }
+    public IReadOnlyDictionary<DiskKind, IReadOnlyDictionary<string, string>> DeviceOptions { get; init; }
+        = new Dictionary<DiskKind, IReadOnlyDictionary<string, string>>();
+    public IReadOnlyDictionary<string, string> MachineOptions { get; init; } = new Dictionary<string, string>();
+
+    public bool AppliesTo(TestProfile profile, string architecture)
+    {
+        if (Architectures != null && !Architectures.Contains(architecture, StringComparer.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // Machine-only modifier — applies regardless of disks.
+        if (DeviceOptions.Count == 0)
+        {
+            return MachineOptions.Count > 0;
+        }
+
+        foreach (TestProfileDisk disk in profile.Disks)
+        {
+            if (DeviceOptions.ContainsKey(disk.Kind))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public TestProfile ApplyTo(TestProfile baseProfile)
+    {
+        var newDisks = new List<TestProfileDisk>(baseProfile.Disks.Count);
+        foreach (TestProfileDisk disk in baseProfile.Disks)
+        {
+            if (!DeviceOptions.TryGetValue(disk.Kind, out IReadOnlyDictionary<string, string>? extras))
+            {
+                newDisks.Add(disk);
+                continue;
+            }
+
+            var merged = new Dictionary<string, string>(disk.Options);
+            foreach (KeyValuePair<string, string> kv in extras)
+            {
+                merged[kv.Key] = kv.Value;
+            }
+            newDisks.Add(disk with { Options = merged });
+        }
+
+        var mergedMachine = new Dictionary<string, string>(baseProfile.MachineOptions);
+        foreach (KeyValuePair<string, string> kv in MachineOptions)
+        {
+            mergedMachine[kv.Key] = kv.Value;
+        }
+
+        return new TestProfile
+        {
+            Name = $"{baseProfile.Name}+{Name}",
+            Disks = newDisks,
+            MachineOptions = mergedMachine
+        };
+    }
+}
+
+/// <summary>
+/// Resolves the per-suite profile list by:
+/// 1. Loading the global catalog (profiles + modifiers) from the nearest
+///    <c>profiles.json</c> walking upward from the suite directory.
+/// 2. Reading <c>CosmosTestProfile</c> + <c>CosmosTestModifier</c> items from
+///    the suite's csproj.
+/// 3. Cross-producting them: for each requested profile, emit the baseline
+///    plus one variant per applicable modifier (gated on architecture and
+///    on at least one device-kind match for device-targeting modifiers).
+/// A suite that opts into nothing falls back to a single anonymous profile.
+/// </summary>
+public static class TestProfileLoader
+{
+    private const string CatalogFileName = "profiles.json";
+
+    public static IReadOnlyList<TestProfile> LoadFor(string kernelProjectPath, string architecture)
+    {
+        SuiteOptIn optIn = ReadSuiteOptIn(kernelProjectPath);
+        if (optIn.Profiles.Count == 0 && optIn.Modifiers.Count == 0)
+        {
+            return new[] { TestProfile.Default };
+        }
+
+        if (optIn.Profiles.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Suite at '{kernelProjectPath}' declares CosmosTestModifier items but no CosmosTestProfile. " +
+                "A modifier needs a base profile to compose with.");
+        }
+
+        string catalogPath = FindCatalog(kernelProjectPath)
+            ?? throw new InvalidOperationException(
+                $"Suite at '{kernelProjectPath}' declares profile/modifier items but no '{CatalogFileName}' was found in any ancestor directory.");
+
+        Catalog catalog = LoadCatalog(catalogPath);
+
+        var resolvedProfiles = new List<TestProfile>(optIn.Profiles.Count);
+        foreach (string name in optIn.Profiles)
+        {
+            if (!catalog.Profiles.TryGetValue(name, out TestProfile? profile))
+            {
+                throw new InvalidOperationException(
+                    $"Suite at '{kernelProjectPath}' requested profile '{name}' which is not defined in '{catalogPath}'. " +
+                    $"Known profiles: {string.Join(", ", catalog.Profiles.Keys)}.");
+            }
+            resolvedProfiles.Add(profile);
+        }
+
+        var resolvedModifiers = new List<TestModifier>(optIn.Modifiers.Count);
+        foreach (string name in optIn.Modifiers)
+        {
+            if (!catalog.Modifiers.TryGetValue(name, out TestModifier? mod))
+            {
+                throw new InvalidOperationException(
+                    $"Suite at '{kernelProjectPath}' requested modifier '{name}' which is not defined in '{catalogPath}'. " +
+                    $"Known modifiers: {(catalog.Modifiers.Count == 0 ? "(none)" : string.Join(", ", catalog.Modifiers.Keys))}.");
+            }
+            resolvedModifiers.Add(mod);
+        }
+
+        var matrix = new List<TestProfile>();
+        foreach (TestProfile profile in resolvedProfiles)
+        {
+            matrix.Add(profile);
+            foreach (TestModifier mod in resolvedModifiers)
+            {
+                if (mod.AppliesTo(profile, architecture))
+                {
+                    matrix.Add(mod.ApplyTo(profile));
+                }
+            }
+        }
+        return matrix;
+    }
+
+    private readonly record struct SuiteOptIn(IReadOnlyList<string> Profiles, IReadOnlyList<string> Modifiers);
+
+    private static SuiteOptIn ReadSuiteOptIn(string kernelProjectPath)
+    {
+        string? csproj = Directory.EnumerateFiles(kernelProjectPath, "*.csproj").FirstOrDefault();
+        if (csproj == null)
+        {
+            return new SuiteOptIn(Array.Empty<string>(), Array.Empty<string>());
+        }
+
+        XDocument doc;
+        try
+        {
+            doc = XDocument.Load(csproj);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to parse '{csproj}': {ex.Message}", ex);
+        }
+
+        // MSBuild csprojs may or may not declare a default xmlns. LocalName
+        // matching ignores that wrinkle.
+        return new SuiteOptIn(
+            CollectIncludes(doc, "CosmosTestProfile"),
+            CollectIncludes(doc, "CosmosTestModifier"));
+    }
+
+    private static IReadOnlyList<string> CollectIncludes(XDocument doc, string elementName)
+    {
+        var result = new List<string>();
+        foreach (XElement el in doc.Descendants().Where(e => e.Name.LocalName == elementName))
+        {
+            string? include = el.Attribute("Include")?.Value;
+            if (!string.IsNullOrWhiteSpace(include))
+            {
+                result.Add(include.Trim());
+            }
+        }
+        return result;
+    }
+
+    private static string? FindCatalog(string startDir)
+    {
+        DirectoryInfo? dir = new DirectoryInfo(Path.GetFullPath(startDir));
+        while (dir != null)
+        {
+            string candidate = Path.Combine(dir.FullName, CatalogFileName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+            dir = dir.Parent;
+        }
+        return null;
+    }
+
+    private sealed record Catalog(
+        IReadOnlyDictionary<string, TestProfile> Profiles,
+        IReadOnlyDictionary<string, TestModifier> Modifiers);
+
+    private static Catalog LoadCatalog(string path)
+    {
+        string json = File.ReadAllText(path);
+        ProfilesFile? parsed = JsonSerializer.Deserialize<ProfilesFile>(json, JsonOpts);
+        if (parsed?.Profiles == null || parsed.Profiles.Count == 0)
+        {
+            throw new InvalidOperationException($"{path}: 'profiles' array is missing or empty.");
+        }
+
+        var profiles = new Dictionary<string, TestProfile>(parsed.Profiles.Count, StringComparer.Ordinal);
+        foreach (ProfileEntry entry in parsed.Profiles)
+        {
+            if (string.IsNullOrWhiteSpace(entry.Name))
+            {
+                throw new InvalidOperationException($"{path}: every profile needs a non-empty 'name'.");
+            }
+            if (profiles.ContainsKey(entry.Name))
+            {
+                throw new InvalidOperationException($"{path}: duplicate profile name '{entry.Name}'.");
+            }
+
+            var disks = new List<TestProfileDisk>();
+            if (entry.Disks != null)
+            {
+                foreach (DiskEntry disk in entry.Disks)
+                {
+                    DiskKind kind = ParseDiskKind(path, $"profile '{entry.Name}'", disk.Type);
+                    disks.Add(new TestProfileDisk
+                    {
+                        Kind = kind,
+                        Options = disk.Options ?? new Dictionary<string, string>()
+                    });
+                }
+            }
+
+            profiles[entry.Name] = new TestProfile { Name = entry.Name, Disks = disks };
+        }
+
+        var modifiers = new Dictionary<string, TestModifier>(StringComparer.Ordinal);
+        if (parsed.Modifiers != null)
+        {
+            foreach (ModifierEntry entry in parsed.Modifiers)
+            {
+                if (string.IsNullOrWhiteSpace(entry.Name))
+                {
+                    throw new InvalidOperationException($"{path}: every modifier needs a non-empty 'name'.");
+                }
+                if (modifiers.ContainsKey(entry.Name))
+                {
+                    throw new InvalidOperationException($"{path}: duplicate modifier name '{entry.Name}'.");
+                }
+
+                bool hasMachine = entry.MachineOptions != null && entry.MachineOptions.Count > 0;
+                bool hasDevice = entry.DeviceOptions != null && entry.DeviceOptions.Count > 0;
+                if (!hasMachine && !hasDevice)
+                {
+                    throw new InvalidOperationException(
+                        $"{path}: modifier '{entry.Name}' has neither 'machineOptions' nor 'deviceOptions'. A modifier with no targets can never apply.");
+                }
+
+                var perKind = new Dictionary<DiskKind, IReadOnlyDictionary<string, string>>();
+                if (entry.DeviceOptions != null)
+                {
+                    foreach (KeyValuePair<string, Dictionary<string, string>> kv in entry.DeviceOptions)
+                    {
+                        DiskKind kind = ParseDiskKind(path, $"modifier '{entry.Name}'", kv.Key);
+                        perKind[kind] = kv.Value;
+                    }
+                }
+
+                modifiers[entry.Name] = new TestModifier
+                {
+                    Name = entry.Name,
+                    Architectures = entry.Architectures,
+                    DeviceOptions = perKind,
+                    MachineOptions = entry.MachineOptions ?? new Dictionary<string, string>()
+                };
+            }
+        }
+
+        return new Catalog(profiles, modifiers);
+    }
+
+    private static DiskKind ParseDiskKind(string path, string context, string? type)
+    {
+        return (type ?? string.Empty).ToLowerInvariant() switch
+        {
+            "ahci" or "sata" => DiskKind.Ahci,
+            "nvme" => DiskKind.Nvme,
+            _ => throw new InvalidOperationException(
+                $"{path}: {context} references unknown device kind '{type}'. Expected 'ahci' or 'nvme'.")
+        };
+    }
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true
+    };
+
+    private sealed record ProfilesFile(List<ProfileEntry>? Profiles, List<ModifierEntry>? Modifiers);
+    private sealed record ProfileEntry(string? Name, List<DiskEntry>? Disks);
+    private sealed record DiskEntry(string? Type, Dictionary<string, string>? Options);
+    private sealed record ModifierEntry(
+        string? Name,
+        List<string>? Architectures,
+        Dictionary<string, Dictionary<string, string>>? DeviceOptions,
+        Dictionary<string, string>? MachineOptions);
+}

--- a/tests/Cosmos.TestRunner.Framework/TestRunner.cs
+++ b/tests/Cosmos.TestRunner.Framework/TestRunner.cs
@@ -76,6 +76,27 @@ namespace Cosmos.TestRunner.Framework
         }
 
         /// <summary>
+        /// Run <paramref name="testAction"/> only when <paramref name="condition"/> is
+        /// true; otherwise emit a <see cref="Skip(string, string)"/> with
+        /// <paramref name="skipReason"/>. Use to gate a test on a feature that may or
+        /// may not be present in the current QEMU profile (specific device kind, MSI-X
+        /// capability, GIC version) — keeps the test in the report as Skipped instead
+        /// of either silently disappearing or failing for a reason that's not a code
+        /// regression.
+        /// </summary>
+        public static void RunIf(bool condition, string testName, Action testAction, string skipReason)
+        {
+            if (condition)
+            {
+                Run(testName, testAction);
+            }
+            else
+            {
+                Skip(testName, skipReason);
+            }
+        }
+
+        /// <summary>
         /// Run a destructive test whose action is expected to never return
         /// (e.g. a successful Power.Reboot / Power.Shutdown). The test is
         /// pre-emptively reported as passed before invoking the action; if

--- a/tests/Cosmos.TestRunner.Framework/TestRunner.cs
+++ b/tests/Cosmos.TestRunner.Framework/TestRunner.cs
@@ -57,10 +57,40 @@ namespace Cosmos.TestRunner.Framework
             // Execute test
             testAction();
 
-            // Calculate duration
+            // Calculate duration. The raw CNTPCT_EL0 delta has produced
+            // multi-million-second readings on github-CI arm64 (QEMU TCG)
+            // for a sub-second test, propagating into the JUnit XML as
+            // bogus times. When that happens, clamp to a sane max and
+            // emit a UART warning with the raw inputs so the cause can be
+            // debugged from the log.
             var endTicks = Stopwatch.GetTimestamp();
             var elapsedTicks = endTicks - _testStartTicks;
-            var durationMs = (uint)((elapsedTicks * 1000) / Stopwatch.Frequency);
+            long freq = Stopwatch.Frequency;
+            long rawMs = (freq > 0 && elapsedTicks > 0)
+                ? (elapsedTicks * 1000) / freq
+                : 0;
+
+            const long MaxSaneDurationMs = 5L * 60L * 1000L; // 5 minutes
+            uint durationMs;
+            if (rawMs < 0 || rawMs > MaxSaneDurationMs)
+            {
+                Serial.WriteString("[TestRunner] WARN clamped durationMs=");
+                Serial.WriteNumber(rawMs);
+                Serial.WriteString(" startTicks=");
+                Serial.WriteNumber(_testStartTicks);
+                Serial.WriteString(" endTicks=");
+                Serial.WriteNumber(endTicks);
+                Serial.WriteString(" elapsedTicks=");
+                Serial.WriteNumber(elapsedTicks);
+                Serial.WriteString(" freq=");
+                Serial.WriteNumber(freq);
+                Serial.WriteString("\n");
+                durationMs = (uint)MaxSaneDurationMs;
+            }
+            else
+            {
+                durationMs = (uint)rawMs;
+            }
 
             // Check if test failed via Assert
             if (Assert.Failed)

--- a/tests/Kernels/Cosmos.Kernel.Tests.Pci/Bootloader/limine.conf
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Pci/Bootloader/limine.conf
@@ -1,0 +1,10 @@
+# Timeout in seconds that Limine will use before automatically booting.
+timeout: 0
+
+# The entry name that will be displayed in the boot menu.
+/Limine Template
+    # We use the Limine boot protocol.
+    protocol: limine
+
+    # Path to the kernel to boot. boot():/ represents the partition on which limine.conf is located.
+    path: boot():/boot/Cosmos.Kernel.Tests.Pci.elf

--- a/tests/Kernels/Cosmos.Kernel.Tests.Pci/Cosmos.Kernel.Tests.Pci.csproj
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Pci/Cosmos.Kernel.Tests.Pci.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Sdk Name="Cosmos.Sdk" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <!-- Core kernel packages (using project references for development) -->
+  <ItemGroup>
+    <ProjectReference Include="../../../src/Cosmos.Kernel/Cosmos.Kernel.csproj" />
+    <ProjectReference Include="../../../src/Cosmos.Kernel.System/Cosmos.Kernel.System.csproj" />
+    <ProjectReference Include="../../Cosmos.TestRunner.Framework/Cosmos.TestRunner.Framework.csproj" />
+  </ItemGroup>
+
+  <!-- Architecture-specific HAL (using project references for development) -->
+  <ItemGroup Condition="'$(DefineConstants)' != '' AND $(DefineConstants.Contains('ARCH_X64'))">
+    <ProjectReference Include="../../../src/Cosmos.Kernel.HAL.X64/Cosmos.Kernel.HAL.X64.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DefineConstants)' != '' AND $(DefineConstants.Contains('ARCH_ARM64'))">
+    <ProjectReference Include="../../../src/Cosmos.Kernel.HAL.ARM64/Cosmos.Kernel.HAL.ARM64.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Kernels/Cosmos.Kernel.Tests.Pci/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Pci/Kernel.cs
@@ -1,0 +1,107 @@
+using System;
+using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.HAL.Pci;
+using Cosmos.TestRunner.Framework;
+using Sys = Cosmos.Kernel.System;
+using TR = Cosmos.TestRunner.Framework.TestRunner;
+
+namespace Cosmos.Kernel.Tests.Pci;
+
+public class Kernel : Sys.Kernel
+{
+    // First device PciManager enumerated. Used by every ConfigSpace_* test;
+    // captured once at BeforeRun time so a transient state change between
+    // tests can't show up as cross-test interference.
+    private static PciDevice? s_firstDevice;
+
+    // Reason string surfaced through TR.RunIf when a test depends on at
+    // least one PCI device having been enumerated. A profile that disables
+    // ACPI on arm64 (no MCFG, no FDT fallback for the ECAM base) lands
+    // here and the device tests skip cleanly.
+    private const string SkipNoDevice = "no PCI devices enumerated — host bridge / ECAM not discovered";
+
+    protected override void BeforeRun()
+    {
+        Serial.WriteString("[Pci] BeforeRun() reached!\n");
+
+        TR.Start("PCI Subsystem Tests", expectedTests: 6);
+
+        s_firstDevice = PciManager.Count > 0 ? PciManager.Devices![0] : null;
+        bool anyDevice = s_firstDevice != null;
+
+        // ==================== Manager ====================
+        TR.Run("Manager_Initialized", TestManager_Initialized);
+        TR.RunIf(anyDevice, "Manager_HasDevices", TestManager_HasDevices, SkipNoDevice);
+
+        // ==================== ConfigSpace ====================
+        TR.RunIf(anyDevice, "ConfigSpace_VendorId_NotAllOnes",     TestConfigSpace_VendorIdNotAllOnes,     SkipNoDevice);
+        TR.RunIf(anyDevice, "ConfigSpace_DeviceId_NotAllOnes",     TestConfigSpace_DeviceIdNotAllOnes,     SkipNoDevice);
+        TR.RunIf(anyDevice, "ConfigSpace_ClassCode_InRange",       TestConfigSpace_ClassCodeInRange,       SkipNoDevice);
+        TR.RunIf(anyDevice, "ConfigSpace_VendorRead_StableAcrossCalls", TestConfigSpace_VendorReadStable,  SkipNoDevice);
+
+        TR.Finish();
+
+        Serial.WriteString("\n[Tests Complete - System Halting]\n");
+    }
+
+    protected override void Run() => Stop();
+
+    protected override void AfterRun()
+    {
+        TR.Complete();
+        Cosmos.Kernel.System.Power.Halt();
+    }
+
+    // ==================== Manager ====================
+
+    // Devices array is allocated by PciManager.Setup() during boot, even when
+    // zero devices end up being found. A null array means Setup never ran —
+    // a kernel-init regression, not a "no PCI on this profile" condition.
+    private static void TestManager_Initialized()
+    {
+        Assert.NotNull(PciManager.Devices);
+    }
+
+    private static void TestManager_HasDevices()
+    {
+        Assert.True(PciManager.Count > 0);
+    }
+
+    // ==================== ConfigSpace ====================
+    //
+    // Spot-checks against the first enumerated device. We don't pin any
+    // particular vendor/device id because that varies by QEMU machine type
+    // and version; what we assert is that the values look like a real
+    // config-space response rather than the all-ones / all-zeros patterns
+    // that surface when ECAM is unmapped or the bus is empty.
+
+    private static void TestConfigSpace_VendorIdNotAllOnes()
+    {
+        Assert.True(s_firstDevice!.VendorId != 0xFFFF && s_firstDevice.VendorId != 0x0000);
+    }
+
+    private static void TestConfigSpace_DeviceIdNotAllOnes()
+    {
+        Assert.True(s_firstDevice!.DeviceId != 0xFFFF);
+    }
+
+    private static void TestConfigSpace_ClassCodeInRange()
+    {
+        // PCI base class codes 0x00..0x13 are spec-defined; 0xFF is
+        // reserved for "unassigned". Anything outside means the byte we
+        // read is not a real class code (typically a stale-cache or
+        // unmapped read returning all-ones).
+        Assert.True(s_firstDevice!.ClassCode <= 0x13);
+    }
+
+    private static void TestConfigSpace_VendorReadStable()
+    {
+        // Two reads of the same offset must agree. Catches half-baked ECAM
+        // mappings (one read hits cached zeros, the next hits real config),
+        // and catches register-side-effect bugs in ReadRegister16 (it must
+        // be a pure read, not advance any internal pointer).
+        ushort first = s_firstDevice!.ReadRegister16(0x00);
+        ushort second = s_firstDevice.ReadRegister16(0x00);
+        Assert.Equal(first, second);
+    }
+}

--- a/tests/Kernels/Cosmos.Kernel.Tests.Storage/Cosmos.Kernel.Tests.Storage.csproj
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Storage/Cosmos.Kernel.Tests.Storage.csproj
@@ -7,6 +7,21 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
+  <!--
+    QEMU profiles + modifiers this suite opts into. Definitions live in
+    tests/profiles.json; the test runner fails fast if any name here isn't
+    in that catalog. Each profile runs once on its own, then once per
+    applicable modifier (combos that don't touch any device in the profile
+    are skipped).
+  -->
+  <ItemGroup>
+    <CosmosTestProfile Include="ahci" />
+    <CosmosTestProfile Include="nvme" />
+    <CosmosTestModifier Include="msix-min" />
+    <CosmosTestModifier Include="gicv2" />
+    <CosmosTestModifier Include="gicv3" />
+  </ItemGroup>
+
   <!-- Core kernel packages (using project references for development) -->
   <ItemGroup>
     <ProjectReference Include="../../../src/Cosmos.Kernel/Cosmos.Kernel.csproj" />

--- a/tests/Kernels/Cosmos.Kernel.Tests.Storage/Cosmos.Kernel.Tests.Storage.csproj
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Storage/Cosmos.Kernel.Tests.Storage.csproj
@@ -20,6 +20,7 @@
     <CosmosTestModifier Include="msix-min" />
     <CosmosTestModifier Include="gicv2" />
     <CosmosTestModifier Include="gicv3" />
+    <CosmosTestModifier Include="acpi-off" />
   </ItemGroup>
 
   <!-- Core kernel packages (using project references for development) -->

--- a/tests/Kernels/Cosmos.Kernel.Tests.Storage/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Storage/Kernel.cs
@@ -15,12 +15,12 @@ public class Kernel : Sys.Kernel
         Serial.WriteString("[Storage] BeforeRun() reached!\n");
         Serial.WriteString("[Storage] Starting tests...\n");
 
-        // Test count is dynamic: 2 meta tests + 12 per registered block device.
-        // The test runner attaches multiple AHCI ports + multiple NVMe
-        // controllers, so the suite walks StorageManager and runs the full
-        // round-trip suite against every device individually — catches
-        // cross-device aliasing, bounce-buffer reuse, and per-controller
-        // state that a single-device test would miss.
+        // Test count is dynamic: 2 meta tests + the generic per-device suite +
+        // the partition-table suite. The engine attaches exactly one disk per
+        // profile (test-profiles.json) — AHCI for the 'ahci' profile, NVMe for
+        // the 'nvme' profile — and runs the suite once per profile. The label
+        // we emit ("AHCI" / "NVMe") reflects the device the kernel actually
+        // bound, so a misconfigured profile is visible in the report.
         TR.Start("Storage Block Device Tests", expectedTests: 0);
 
         TR.Run("Test_StorageManager_Initialized", () =>
@@ -29,46 +29,30 @@ public class Kernel : Sys.Kernel
             Assert.True(StorageManager.IsInitialized);
         });
 
-        TR.Run("Test_AtLeastOneDevice_Present", () =>
+        TR.Run("Test_ExactlyOneDevice_Present", () =>
         {
-            Assert.True(StorageManager.DeviceCount > 0);
+            Assert.Equal(1, StorageManager.DeviceCount);
         });
 
-        int sataIdx = 0;
-        int nvmeIdx = 0;
-        for (int i = 0; i < StorageManager.DeviceCount; i++)
+        IBlockDevice? dev = StorageManager.GetDevice(0);
+        if (dev == null)
         {
-            IBlockDevice? dev = StorageManager.GetDevice(i);
-            if (dev == null)
-            {
-                continue;
-            }
-            string label = dev.Name == "SATA"
-                ? $"SATA{sataIdx++}"
-                : dev.Name == "NVMe"
-                    ? $"NVMe{nvmeIdx++}"
-                    : $"{dev.Name}{i}";
-            RunDeviceSuite(label, dev);
+            TR.Finish();
+            Serial.WriteString("\n[Tests Complete - System Halting]\n");
+            return;
         }
 
-        // Partition table round-trip tests run AFTER the per-device suites
-        // because they overwrite LBA 0..33, which the per-device tests
-        // also touch. Pick the last registered device so earlier devices'
-        // results aren't affected.
-        IBlockDevice? partitionTarget = null;
-        for (int i = StorageManager.DeviceCount - 1; i >= 0; i--)
+        string label = dev.Name switch
         {
-            IBlockDevice? dev = StorageManager.GetDevice(i);
-            if (dev != null)
-            {
-                partitionTarget = dev;
-                break;
-            }
-        }
-        if (partitionTarget != null)
-        {
-            RunPartitionTableSuite(partitionTarget);
-        }
+            "SATA" => "AHCI",
+            "NVMe" => "NVMe",
+            _ => dev.Name
+        };
+
+        RunDeviceSuite(label, dev);
+
+        // Partition table tests run last because they overwrite LBA 0..33.
+        RunPartitionTableSuite(dev);
 
         TR.Finish();
 

--- a/tests/Kernels/Cosmos.Kernel.Tests.Storage/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Storage/Kernel.cs
@@ -29,8 +29,8 @@ public class Kernel : Sys.Kernel
     {
         Serial.WriteString("[Storage] BeforeRun() reached!\n");
 
-        // 2 manager + 12 device + 5 partition + 1 CI-validation = 20 tests per profile.
-        TR.Start("Storage Block Device Tests", expectedTests: 20);
+        // 2 manager + 12 device + 5 partition = 19 tests per profile.
+        TR.Start("Storage Block Device Tests", expectedTests: 19);
 
         bool hasDevice = StorageManager.DeviceCount > 0;
         s_dev = hasDevice ? StorageManager.GetDevice(0) : null;
@@ -63,16 +63,6 @@ public class Kernel : Sys.Kernel
         TR.RunIf(dev, "Partition_RescanPartitions",       TestPartition_RescanPartitions,      SkipNoHost);
         TR.RunIf(dev, "Partition_ReadWrite_TranslatesLba", TestPartition_ReadWriteTranslatesLba, SkipNoHost);
         TR.RunIf(dev, "Partition_OutOfBounds_Throws",      TestPartition_OutOfBoundsThrows,     SkipNoHost);
-
-        // ==================== CIValidation (temporary, edge-case smoke) ====================
-        // Deliberate edge-case to validate the CI per-profile failure path
-        // end-to-end. Asserts the device kind is "SATA", which is true under
-        // every [ahci*] profile and false under every [nvme*] profile — so the
-        // PR comment should mark the four nvme matrix rows ❌ and leave the
-        // four ahci rows ✅, while ahci-on-arm64 (no device bound) shows as
-        // Skipped via the gate. Remove this in the follow-up revert once the
-        // ❌-attribution flow is confirmed against the PR table.
-        TR.RunIf(dev, "CIValidation_DeviceMustBeSATA", TestCIValidation_DeviceMustBeSATA, SkipNoDevice);
 
         TR.Finish();
 
@@ -468,16 +458,5 @@ public class Kernel : Sys.Kernel
         {
             // Expected.
         }
-    }
-
-    // ==================== CIValidation (temporary, edge-case smoke) ====================
-
-    // Edge-case test designed to fail under every [nvme*] profile and pass
-    // under every [ahci*] profile, so the PR-comment per-profile breakdown
-    // is exercised end-to-end. Pure validation hook — remove once the
-    // failure-attribution flow is confirmed against the green-path baseline.
-    private static void TestCIValidation_DeviceMustBeSATA()
-    {
-        Assert.Equal("SATA", s_dev!.Name);
     }
 }

--- a/tests/Kernels/Cosmos.Kernel.Tests.Storage/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Storage/Kernel.cs
@@ -15,12 +15,11 @@ public class Kernel : Sys.Kernel
         Serial.WriteString("[Storage] BeforeRun() reached!\n");
         Serial.WriteString("[Storage] Starting tests...\n");
 
-        // Test count is dynamic: 2 meta tests + the generic per-device suite +
-        // the partition-table suite. The engine attaches exactly one disk per
-        // profile (test-profiles.json) — AHCI for the 'ahci' profile, NVMe for
-        // the 'nvme' profile — and runs the suite once per profile. The label
-        // we emit ("AHCI" / "NVMe") reflects the device the kernel actually
-        // bound, so a misconfigured profile is visible in the report.
+        // The engine attaches exactly one disk per profile (tests/profiles.json)
+        // and runs the suite once per profile. Per-device tests are gated on
+        // dev != null via TR.RunIf, so a profile whose driver did not bind
+        // (e.g. AHCI on arm64 today) produces visible Skips instead of either
+        // vanished tests or noisy failures unrelated to the change under test.
         TR.Start("Storage Block Device Tests", expectedTests: 0);
 
         TR.Run("Test_StorageManager_Initialized", () =>
@@ -29,23 +28,21 @@ public class Kernel : Sys.Kernel
             Assert.True(StorageManager.IsInitialized);
         });
 
-        TR.Run("Test_ExactlyOneDevice_Present", () =>
-        {
-            Assert.Equal(1, StorageManager.DeviceCount);
-        });
+        bool hasDevice = StorageManager.DeviceCount > 0;
+        IBlockDevice? dev = hasDevice ? StorageManager.GetDevice(0) : null;
 
-        IBlockDevice? dev = StorageManager.GetDevice(0);
-        if (dev == null)
-        {
-            TR.Finish();
-            Serial.WriteString("\n[Tests Complete - System Halting]\n");
-            return;
-        }
+        TR.RunIf(hasDevice, "Test_ExactlyOneDevice_Present",
+            () => Assert.Equal(1, StorageManager.DeviceCount),
+            "no block device bound for this profile");
 
-        string label = dev.Name switch
+        // Label reflects what actually bound; falls back to a generic name when
+        // nothing did (so the per-device tests below register under a
+        // predictable name regardless of profile).
+        string label = dev?.Name switch
         {
             "SATA" => "AHCI",
             "NVMe" => "NVMe",
+            null => "BlockDevice",
             _ => dev.Name
         };
 
@@ -61,16 +58,23 @@ public class Kernel : Sys.Kernel
 
     private static void RunDeviceSuite(string label, IBlockDevice? dev)
     {
-        TR.Run($"Test_{label}_BlockGeometry_Sane", () =>
+        // Each per-device test is gated on `dev != null` so a profile whose
+        // driver did not bind (e.g. AHCI on arm64) shows the suite as Skipped
+        // instead of either failing or vanishing. The body still receives a
+        // dev reference; `dev!` is safe because the gate prevents the lambda
+        // from running when dev is null.
+        bool present = dev != null;
+        const string skip = "no block device bound for this profile";
+        void Run(string name, Action body) => TR.RunIf(present, name, body, skip);
+
+        Run($"Test_{label}_BlockGeometry_Sane", () =>
         {
-            Assert.NotNull(dev);
             Assert.Equal<ulong>(512, dev!.BlockSize);
             Assert.True(dev.BlockCount > 0);
         });
 
-        TR.Run($"Test_{label}_WriteRead_SingleBlock", () =>
+        Run($"Test_{label}_WriteRead_SingleBlock", () =>
         {
-            Assert.NotNull(dev);
             const ulong lba = 100;
             ulong size = dev!.BlockSize;
 
@@ -90,9 +94,8 @@ public class Kernel : Sys.Kernel
             }
         });
 
-        TR.Run($"Test_{label}_WriteRead_MultiBlock", () =>
+        Run($"Test_{label}_WriteRead_MultiBlock", () =>
         {
-            Assert.NotNull(dev);
             const ulong lba = 200;
             const ulong blocks = 4;
             ulong total = blocks * dev!.BlockSize;
@@ -113,9 +116,8 @@ public class Kernel : Sys.Kernel
             }
         });
 
-        TR.Run($"Test_{label}_WriteRead_Idempotent", () =>
+        Run($"Test_{label}_WriteRead_Idempotent", () =>
         {
-            Assert.NotNull(dev);
             const ulong lba = 250;
             ulong size = dev!.BlockSize;
 
@@ -135,9 +137,8 @@ public class Kernel : Sys.Kernel
             }
         });
 
-        TR.Run($"Test_{label}_ReReadStable", () =>
+        Run($"Test_{label}_ReReadStable", () =>
         {
-            Assert.NotNull(dev);
             const ulong lba = 300;
             ulong size = dev!.BlockSize;
 
@@ -153,9 +154,8 @@ public class Kernel : Sys.Kernel
             }
         });
 
-        TR.Run($"Test_{label}_LargeTransfer", () =>
+        Run($"Test_{label}_LargeTransfer", () =>
         {
-            Assert.NotNull(dev);
             const ulong lba = 1000;
             const ulong blocks = 32;
             ulong total = blocks * dev!.BlockSize;
@@ -176,9 +176,8 @@ public class Kernel : Sys.Kernel
             }
         });
 
-        TR.Run($"Test_{label}_BoundaryLBA", () =>
+        Run($"Test_{label}_BoundaryLBA", () =>
         {
-            Assert.NotNull(dev);
             ulong lba = dev!.BlockCount - 1;
             ulong size = dev.BlockSize;
 
@@ -199,9 +198,8 @@ public class Kernel : Sys.Kernel
         });
 
         // LBA 0 is often special (boot sector). Make sure round-trip works there.
-        TR.Run($"Test_{label}_LBA_Zero_RoundTrip", () =>
+        Run($"Test_{label}_LBA_Zero_RoundTrip", () =>
         {
-            Assert.NotNull(dev);
             ulong size = dev!.BlockSize;
 
             Span<byte> writeBuf = new byte[size];
@@ -223,9 +221,8 @@ public class Kernel : Sys.Kernel
         // Catches bounce-buffer reuse / wrong-LBA-cached bugs: write 8 contiguous
         // blocks each filled with its own marker byte, then read each block back
         // individually and confirm the markers haven't bled across blocks.
-        TR.Run($"Test_{label}_CrossBlock_Isolation", () =>
+        Run($"Test_{label}_CrossBlock_Isolation", () =>
         {
-            Assert.NotNull(dev);
             const ulong baseLba = 4000;
             const int blocks = 8;
             ulong size = dev!.BlockSize;
@@ -252,9 +249,8 @@ public class Kernel : Sys.Kernel
         // Catches LBA off-by-one / stride bugs: write to LBAs that are far apart
         // (n * 1024) so any wrap or shift error lands on a different block; the
         // pattern depends on n so we can detect a mis-routed write.
-        TR.Run($"Test_{label}_LBA_Stride_Sweep", () =>
+        Run($"Test_{label}_LBA_Stride_Sweep", () =>
         {
-            Assert.NotNull(dev);
             const int slots = 8;
             const ulong stride = 1024;
             ulong size = dev!.BlockSize;
@@ -281,9 +277,8 @@ public class Kernel : Sys.Kernel
 
         // Reads in non-sequential order should still return the right data —
         // catches code that assumes the last-touched LBA is "current".
-        TR.Run($"Test_{label}_RandomOrder_ReadAfterWrite", () =>
+        Run($"Test_{label}_RandomOrder_ReadAfterWrite", () =>
         {
-            Assert.NotNull(dev);
             const ulong baseLba = 6000;
             ulong size = dev!.BlockSize;
 
@@ -308,9 +303,8 @@ public class Kernel : Sys.Kernel
 
         // Multi-block transfer that ends exactly at the device tail. Catches
         // truncation / wrap bugs at the upper edge of LBA space.
-        TR.Run($"Test_{label}_Multiblock_TailBoundary", () =>
+        Run($"Test_{label}_Multiblock_TailBoundary", () =>
         {
-            Assert.NotNull(dev);
             const ulong blocks = 4;
             ulong size = dev!.BlockSize;
             ulong lba = dev.BlockCount - blocks;
@@ -333,9 +327,15 @@ public class Kernel : Sys.Kernel
         });
     }
 
-    private static void RunPartitionTableSuite(IBlockDevice host)
+    private static void RunPartitionTableSuite(IBlockDevice? host)
     {
-        TR.Run("Test_MBR_RoundTrip", () =>
+        // Same gating story as RunDeviceSuite: when no device bound, every
+        // partition-table test reports as Skipped.
+        bool present = host != null;
+        const string skip = "no block device bound for partition-table tests";
+        void Run(string name, Action body) => TR.RunIf(present, name, body, skip);
+
+        Run("Test_MBR_RoundTrip", () =>
         {
             // Wipe LBA 0 first so a leftover GPT signature from a prior
             // sub-test doesn't taint the IsMBR check.
@@ -359,7 +359,7 @@ public class Kernel : Sys.Kernel
             Assert.Equal<ulong>(500, parts[1].SectorCount);
         });
 
-        TR.Run("Test_GPT_RoundTrip", () =>
+        Run("Test_GPT_RoundTrip", () =>
         {
             GPT.Create(host);
             Assert.True(GPT.IsGPT(host));
@@ -381,7 +381,7 @@ public class Kernel : Sys.Kernel
             Assert.Equal<ulong>(countB, parts[1].SectorCount);
         });
 
-        TR.Run("Test_StorageManager_RescanPartitions", () =>
+        Run("Test_StorageManager_RescanPartitions", () =>
         {
             // Layout from the previous test: GPT with two partitions on `host`.
             StorageManager.RescanPartitions(host);
@@ -398,7 +398,7 @@ public class Kernel : Sys.Kernel
             Assert.Equal(2, matches);
         });
 
-        TR.Run("Test_Partition_ReadWrite_TranslatesLba", () =>
+        Run("Test_Partition_ReadWrite_TranslatesLba", () =>
         {
             // Attach a partition starting at an arbitrary LBA, write to its
             // LBA 0, and verify the bytes show up at the host's
@@ -422,7 +422,7 @@ public class Kernel : Sys.Kernel
             }
         });
 
-        TR.Run("Test_Partition_OutOfBounds_Throws", () =>
+        Run("Test_Partition_OutOfBounds_Throws", () =>
         {
             Partition partition = new(host, startingSector: 5000, sectorCount: 8, name: "tiny-part");
             Span<byte> buf = new byte[host.BlockSize];

--- a/tests/Kernels/Cosmos.Kernel.Tests.Storage/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Storage/Kernel.cs
@@ -29,8 +29,8 @@ public class Kernel : Sys.Kernel
     {
         Serial.WriteString("[Storage] BeforeRun() reached!\n");
 
-        // 2 manager + 12 device + 5 partition = 19 tests per profile.
-        TR.Start("Storage Block Device Tests", expectedTests: 19);
+        // 2 manager + 12 device + 5 partition + 1 CI-validation = 20 tests per profile.
+        TR.Start("Storage Block Device Tests", expectedTests: 20);
 
         bool hasDevice = StorageManager.DeviceCount > 0;
         s_dev = hasDevice ? StorageManager.GetDevice(0) : null;
@@ -63,6 +63,16 @@ public class Kernel : Sys.Kernel
         TR.RunIf(dev, "Partition_RescanPartitions",       TestPartition_RescanPartitions,      SkipNoHost);
         TR.RunIf(dev, "Partition_ReadWrite_TranslatesLba", TestPartition_ReadWriteTranslatesLba, SkipNoHost);
         TR.RunIf(dev, "Partition_OutOfBounds_Throws",      TestPartition_OutOfBoundsThrows,     SkipNoHost);
+
+        // ==================== CIValidation (temporary, edge-case smoke) ====================
+        // Deliberate edge-case to validate the CI per-profile failure path
+        // end-to-end. Asserts the device kind is "SATA", which is true under
+        // every [ahci*] profile and false under every [nvme*] profile — so the
+        // PR comment should mark the four nvme matrix rows ❌ and leave the
+        // four ahci rows ✅, while ahci-on-arm64 (no device bound) shows as
+        // Skipped via the gate. Remove this in the follow-up revert once the
+        // ❌-attribution flow is confirmed against the PR table.
+        TR.RunIf(dev, "CIValidation_DeviceMustBeSATA", TestCIValidation_DeviceMustBeSATA, SkipNoDevice);
 
         TR.Finish();
 
@@ -458,5 +468,16 @@ public class Kernel : Sys.Kernel
         {
             // Expected.
         }
+    }
+
+    // ==================== CIValidation (temporary, edge-case smoke) ====================
+
+    // Edge-case test designed to fail under every [nvme*] profile and pass
+    // under every [ahci*] profile, so the PR-comment per-profile breakdown
+    // is exercised end-to-end. Pure validation hook — remove once the
+    // failure-attribution flow is confirmed against the green-path baseline.
+    private static void TestCIValidation_DeviceMustBeSATA()
+    {
+        Assert.Equal("SATA", s_dev!.Name);
     }
 }

--- a/tests/Kernels/Cosmos.Kernel.Tests.Storage/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Storage/Kernel.cs
@@ -10,442 +10,453 @@ namespace Cosmos.Kernel.Tests.Storage;
 
 public class Kernel : Sys.Kernel
 {
+    // The single block device the active QEMU profile attached, captured
+    // once at BeforeRun. The profile name (set by the engine — ahci,
+    // nvme, nvme+msix-min, ...) is what the report's [profile] prefix
+    // shows; this field just holds whatever device that profile bound.
+    private static IBlockDevice? s_dev;
+
+    // Reason surfaced through TR.RunIf when a test depends on a device
+    // having actually bound. A profile whose driver did not enumerate
+    // (e.g. ahci on arm64 today) lands here and the device tests skip.
+    private const string SkipNoDevice = "no block device bound for this profile";
+
+    // Same gating reason for the partition-table tests, which also need
+    // a backing host device.
+    private const string SkipNoHost = "no block device bound for partition-table tests";
+
     protected override void BeforeRun()
     {
         Serial.WriteString("[Storage] BeforeRun() reached!\n");
-        Serial.WriteString("[Storage] Starting tests...\n");
 
-        // The engine attaches exactly one disk per profile (tests/profiles.json)
-        // and runs the suite once per profile. Per-device tests are gated on
-        // dev != null via TR.RunIf, so a profile whose driver did not bind
-        // (e.g. AHCI on arm64 today) produces visible Skips instead of either
-        // vanished tests or noisy failures unrelated to the change under test.
-        TR.Start("Storage Block Device Tests", expectedTests: 0);
-
-        TR.Run("Test_StorageManager_Initialized", () =>
-        {
-            Assert.True(StorageManager.IsEnabled);
-            Assert.True(StorageManager.IsInitialized);
-        });
+        // 2 manager + 12 device + 5 partition = 19 tests per profile.
+        TR.Start("Storage Block Device Tests", expectedTests: 19);
 
         bool hasDevice = StorageManager.DeviceCount > 0;
-        IBlockDevice? dev = hasDevice ? StorageManager.GetDevice(0) : null;
+        s_dev = hasDevice ? StorageManager.GetDevice(0) : null;
 
-        TR.RunIf(hasDevice, "Test_ExactlyOneDevice_Present",
-            () => Assert.Equal(1, StorageManager.DeviceCount),
-            "no block device bound for this profile");
+        // ==================== Manager ====================
+        TR.Run("Manager_StorageInitialized", TestManager_StorageInitialized);
+        TR.RunIf(hasDevice, "Manager_ExactlyOneDevice", TestManager_ExactlyOneDevice, SkipNoDevice);
 
-        // Label reflects what actually bound; falls back to a generic name when
-        // nothing did (so the per-device tests below register under a
-        // predictable name regardless of profile).
-        string label = dev?.Name switch
-        {
-            "SATA" => "AHCI",
-            "NVMe" => "NVMe",
-            null => "BlockDevice",
-            _ => dev.Name
-        };
+        // ==================== Device (single-disk round-trip) ====================
+        bool dev = s_dev != null;
+        TR.RunIf(dev, "Device_BlockGeometry_Sane",         TestDevice_BlockGeometrySane,        SkipNoDevice);
+        TR.RunIf(dev, "Device_WriteRead_SingleBlock",      TestDevice_WriteReadSingleBlock,     SkipNoDevice);
+        TR.RunIf(dev, "Device_WriteRead_MultiBlock",       TestDevice_WriteReadMultiBlock,      SkipNoDevice);
+        TR.RunIf(dev, "Device_WriteRead_Idempotent",       TestDevice_WriteReadIdempotent,      SkipNoDevice);
+        TR.RunIf(dev, "Device_ReReadStable",               TestDevice_ReReadStable,             SkipNoDevice);
+        TR.RunIf(dev, "Device_LargeTransfer",              TestDevice_LargeTransfer,            SkipNoDevice);
+        TR.RunIf(dev, "Device_BoundaryLBA",                TestDevice_BoundaryLBA,              SkipNoDevice);
+        TR.RunIf(dev, "Device_LBA_Zero_RoundTrip",         TestDevice_LBAZeroRoundTrip,         SkipNoDevice);
+        TR.RunIf(dev, "Device_CrossBlock_Isolation",       TestDevice_CrossBlockIsolation,      SkipNoDevice);
+        TR.RunIf(dev, "Device_LBA_Stride_Sweep",           TestDevice_LBAStrideSweep,           SkipNoDevice);
+        TR.RunIf(dev, "Device_RandomOrder_ReadAfterWrite", TestDevice_RandomOrderReadAfterWrite, SkipNoDevice);
+        TR.RunIf(dev, "Device_Multiblock_TailBoundary",    TestDevice_MultiblockTailBoundary,   SkipNoDevice);
 
-        RunDeviceSuite(label, dev);
-
-        // Partition table tests run last because they overwrite LBA 0..33.
-        RunPartitionTableSuite(dev);
+        // ==================== Partition (MBR/GPT, partition translation) ====================
+        // These run last because they overwrite LBA 0..33, which the device
+        // round-trip tests above also touch — ordering them last keeps the
+        // earlier results from being affected by the partition-table writes.
+        TR.RunIf(dev, "Partition_MBR_RoundTrip",          TestPartition_MBRRoundTrip,          SkipNoHost);
+        TR.RunIf(dev, "Partition_GPT_RoundTrip",          TestPartition_GPTRoundTrip,          SkipNoHost);
+        TR.RunIf(dev, "Partition_RescanPartitions",       TestPartition_RescanPartitions,      SkipNoHost);
+        TR.RunIf(dev, "Partition_ReadWrite_TranslatesLba", TestPartition_ReadWriteTranslatesLba, SkipNoHost);
+        TR.RunIf(dev, "Partition_OutOfBounds_Throws",      TestPartition_OutOfBoundsThrows,     SkipNoHost);
 
         TR.Finish();
 
         Serial.WriteString("\n[Tests Complete - System Halting]\n");
     }
 
-    private static void RunDeviceSuite(string label, IBlockDevice? dev)
-    {
-        // Each per-device test is gated on `dev != null` so a profile whose
-        // driver did not bind (e.g. AHCI on arm64) shows the suite as Skipped
-        // instead of either failing or vanishing. The body still receives a
-        // dev reference; `dev!` is safe because the gate prevents the lambda
-        // from running when dev is null.
-        bool present = dev != null;
-        const string skip = "no block device bound for this profile";
-        void Run(string name, Action body) => TR.RunIf(present, name, body, skip);
-
-        Run($"Test_{label}_BlockGeometry_Sane", () =>
-        {
-            Assert.Equal<ulong>(512, dev!.BlockSize);
-            Assert.True(dev.BlockCount > 0);
-        });
-
-        Run($"Test_{label}_WriteRead_SingleBlock", () =>
-        {
-            const ulong lba = 100;
-            ulong size = dev!.BlockSize;
-
-            Span<byte> writeBuf = new byte[size];
-            for (int i = 0; i < (int)size; i++)
-            {
-                writeBuf[i] = (byte)(i ^ 0xA5);
-            }
-            dev.WriteBlock(lba, 1, writeBuf);
-
-            Span<byte> readBuf = new byte[size];
-            dev.ReadBlock(lba, 1, readBuf);
-
-            for (int i = 0; i < (int)size; i++)
-            {
-                Assert.Equal(writeBuf[i], readBuf[i]);
-            }
-        });
-
-        Run($"Test_{label}_WriteRead_MultiBlock", () =>
-        {
-            const ulong lba = 200;
-            const ulong blocks = 4;
-            ulong total = blocks * dev!.BlockSize;
-
-            Span<byte> writeBuf = new byte[total];
-            for (int i = 0; i < (int)total; i++)
-            {
-                writeBuf[i] = (byte)((i * 7) ^ 0x3C);
-            }
-            dev.WriteBlock(lba, blocks, writeBuf);
-
-            Span<byte> readBuf = new byte[total];
-            dev.ReadBlock(lba, blocks, readBuf);
-
-            for (int i = 0; i < (int)total; i++)
-            {
-                Assert.Equal(writeBuf[i], readBuf[i]);
-            }
-        });
-
-        Run($"Test_{label}_WriteRead_Idempotent", () =>
-        {
-            const ulong lba = 250;
-            ulong size = dev!.BlockSize;
-
-            Span<byte> first = new byte[size];
-            first.Fill(0x11);
-            dev.WriteBlock(lba, 1, first);
-
-            Span<byte> second = new byte[size];
-            second.Fill(0x22);
-            dev.WriteBlock(lba, 1, second);
-
-            Span<byte> readBuf = new byte[size];
-            dev.ReadBlock(lba, 1, readBuf);
-            for (int i = 0; i < (int)size; i++)
-            {
-                Assert.Equal((byte)0x22, readBuf[i]);
-            }
-        });
-
-        Run($"Test_{label}_ReReadStable", () =>
-        {
-            const ulong lba = 300;
-            ulong size = dev!.BlockSize;
-
-            Span<byte> first = new byte[size];
-            dev.ReadBlock(lba, 1, first);
-
-            Span<byte> second = new byte[size];
-            dev.ReadBlock(lba, 1, second);
-
-            for (int i = 0; i < (int)size; i++)
-            {
-                Assert.Equal(first[i], second[i]);
-            }
-        });
-
-        Run($"Test_{label}_LargeTransfer", () =>
-        {
-            const ulong lba = 1000;
-            const ulong blocks = 32;
-            ulong total = blocks * dev!.BlockSize;
-
-            Span<byte> writeBuf = new byte[total];
-            for (int i = 0; i < (int)total; i++)
-            {
-                writeBuf[i] = (byte)((i + (i >> 8)) ^ 0x5A);
-            }
-            dev.WriteBlock(lba, blocks, writeBuf);
-
-            Span<byte> readBuf = new byte[total];
-            dev.ReadBlock(lba, blocks, readBuf);
-
-            for (int i = 0; i < (int)total; i++)
-            {
-                Assert.Equal(writeBuf[i], readBuf[i]);
-            }
-        });
-
-        Run($"Test_{label}_BoundaryLBA", () =>
-        {
-            ulong lba = dev!.BlockCount - 1;
-            ulong size = dev.BlockSize;
-
-            Span<byte> writeBuf = new byte[size];
-            for (int i = 0; i < (int)size; i++)
-            {
-                writeBuf[i] = (byte)(i ^ 0xF0);
-            }
-            dev.WriteBlock(lba, 1, writeBuf);
-
-            Span<byte> readBuf = new byte[size];
-            dev.ReadBlock(lba, 1, readBuf);
-
-            for (int i = 0; i < (int)size; i++)
-            {
-                Assert.Equal(writeBuf[i], readBuf[i]);
-            }
-        });
-
-        // LBA 0 is often special (boot sector). Make sure round-trip works there.
-        Run($"Test_{label}_LBA_Zero_RoundTrip", () =>
-        {
-            ulong size = dev!.BlockSize;
-
-            Span<byte> writeBuf = new byte[size];
-            for (int i = 0; i < (int)size; i++)
-            {
-                writeBuf[i] = (byte)(i ^ 0x96);
-            }
-            dev.WriteBlock(0, 1, writeBuf);
-
-            Span<byte> readBuf = new byte[size];
-            dev.ReadBlock(0, 1, readBuf);
-
-            for (int i = 0; i < (int)size; i++)
-            {
-                Assert.Equal(writeBuf[i], readBuf[i]);
-            }
-        });
-
-        // Catches bounce-buffer reuse / wrong-LBA-cached bugs: write 8 contiguous
-        // blocks each filled with its own marker byte, then read each block back
-        // individually and confirm the markers haven't bled across blocks.
-        Run($"Test_{label}_CrossBlock_Isolation", () =>
-        {
-            const ulong baseLba = 4000;
-            const int blocks = 8;
-            ulong size = dev!.BlockSize;
-
-            for (int b = 0; b < blocks; b++)
-            {
-                Span<byte> wbuf = new byte[size];
-                wbuf.Fill((byte)(0xC0 | b));
-                dev.WriteBlock(baseLba + (ulong)b, 1, wbuf);
-            }
-
-            for (int b = 0; b < blocks; b++)
-            {
-                Span<byte> rbuf = new byte[size];
-                dev.ReadBlock(baseLba + (ulong)b, 1, rbuf);
-                byte expected = (byte)(0xC0 | b);
-                for (int i = 0; i < (int)size; i++)
-                {
-                    Assert.Equal(expected, rbuf[i]);
-                }
-            }
-        });
-
-        // Catches LBA off-by-one / stride bugs: write to LBAs that are far apart
-        // (n * 1024) so any wrap or shift error lands on a different block; the
-        // pattern depends on n so we can detect a mis-routed write.
-        Run($"Test_{label}_LBA_Stride_Sweep", () =>
-        {
-            const int slots = 8;
-            const ulong stride = 1024;
-            ulong size = dev!.BlockSize;
-
-            for (int n = 0; n < slots; n++)
-            {
-                Span<byte> wbuf = new byte[size];
-                byte tag = (byte)((n * 17) ^ 0x5A);
-                wbuf.Fill(tag);
-                dev.WriteBlock((ulong)n * stride, 1, wbuf);
-            }
-
-            for (int n = 0; n < slots; n++)
-            {
-                Span<byte> rbuf = new byte[size];
-                dev.ReadBlock((ulong)n * stride, 1, rbuf);
-                byte tag = (byte)((n * 17) ^ 0x5A);
-                for (int i = 0; i < (int)size; i++)
-                {
-                    Assert.Equal(tag, rbuf[i]);
-                }
-            }
-        });
-
-        // Reads in non-sequential order should still return the right data —
-        // catches code that assumes the last-touched LBA is "current".
-        Run($"Test_{label}_RandomOrder_ReadAfterWrite", () =>
-        {
-            const ulong baseLba = 6000;
-            ulong size = dev!.BlockSize;
-
-            Span<byte> a = new byte[size]; a.Fill(0xAA);
-            Span<byte> b = new byte[size]; b.Fill(0xBB);
-            Span<byte> c = new byte[size]; c.Fill(0xCC);
-            dev.WriteBlock(baseLba + 0, 1, a);
-            dev.WriteBlock(baseLba + 1, 1, b);
-            dev.WriteBlock(baseLba + 2, 1, c);
-
-            Span<byte> r = new byte[size];
-
-            dev.ReadBlock(baseLba + 2, 1, r);
-            for (int i = 0; i < (int)size; i++) { Assert.Equal((byte)0xCC, r[i]); }
-
-            dev.ReadBlock(baseLba + 0, 1, r);
-            for (int i = 0; i < (int)size; i++) { Assert.Equal((byte)0xAA, r[i]); }
-
-            dev.ReadBlock(baseLba + 1, 1, r);
-            for (int i = 0; i < (int)size; i++) { Assert.Equal((byte)0xBB, r[i]); }
-        });
-
-        // Multi-block transfer that ends exactly at the device tail. Catches
-        // truncation / wrap bugs at the upper edge of LBA space.
-        Run($"Test_{label}_Multiblock_TailBoundary", () =>
-        {
-            const ulong blocks = 4;
-            ulong size = dev!.BlockSize;
-            ulong lba = dev.BlockCount - blocks;
-            ulong total = blocks * size;
-
-            Span<byte> writeBuf = new byte[total];
-            for (int i = 0; i < (int)total; i++)
-            {
-                writeBuf[i] = (byte)((i * 13) ^ 0x6E);
-            }
-            dev.WriteBlock(lba, blocks, writeBuf);
-
-            Span<byte> readBuf = new byte[total];
-            dev.ReadBlock(lba, blocks, readBuf);
-
-            for (int i = 0; i < (int)total; i++)
-            {
-                Assert.Equal(writeBuf[i], readBuf[i]);
-            }
-        });
-    }
-
-    private static void RunPartitionTableSuite(IBlockDevice? host)
-    {
-        // Same gating story as RunDeviceSuite: when no device bound, every
-        // partition-table test reports as Skipped.
-        bool present = host != null;
-        const string skip = "no block device bound for partition-table tests";
-        void Run(string name, Action body) => TR.RunIf(present, name, body, skip);
-
-        Run("Test_MBR_RoundTrip", () =>
-        {
-            // Wipe LBA 0 first so a leftover GPT signature from a prior
-            // sub-test doesn't taint the IsMBR check.
-            Span<byte> wipe = new byte[host.BlockSize];
-            host.WriteBlock(0, 1, wipe);
-
-            MBR.Create(host);
-            Assert.True(MBR.IsMBR(host));
-
-            // Two primary entries at distinct LBA windows.
-            MBR.WritePartition(host, 0, systemId: 0x83, startSector: 100, sectorCount: 200);
-            MBR.WritePartition(host, 1, systemId: 0x0B, startSector: 1000, sectorCount: 500);
-
-            List<MBR.PartitionEntry> parts = MBR.Parse(host);
-            Assert.Equal(2, parts.Count);
-            Assert.Equal<byte>(0x83, parts[0].SystemId);
-            Assert.Equal<ulong>(100, parts[0].StartSector);
-            Assert.Equal<ulong>(200, parts[0].SectorCount);
-            Assert.Equal<byte>(0x0B, parts[1].SystemId);
-            Assert.Equal<ulong>(1000, parts[1].StartSector);
-            Assert.Equal<ulong>(500, parts[1].SectorCount);
-        });
-
-        Run("Test_GPT_RoundTrip", () =>
-        {
-            GPT.Create(host);
-            Assert.True(GPT.IsGPT(host));
-
-            const ulong startA = 2048;
-            const ulong countA = 4096;
-            const ulong startB = startA + countA;
-            const ulong countB = 8192;
-
-            Assert.True(GPT.AddPartition(host, startA, countA, GPT.BasicDataPartitionType));
-            Assert.True(GPT.AddPartition(host, startB, countB, GPT.BasicDataPartitionType));
-
-            List<GPT.PartitionEntry> parts = GPT.Parse(host);
-            Assert.Equal(2, parts.Count);
-            Assert.Equal(GPT.BasicDataPartitionType, parts[0].PartitionType);
-            Assert.Equal<ulong>(startA, parts[0].StartSector);
-            Assert.Equal<ulong>(countA, parts[0].SectorCount);
-            Assert.Equal<ulong>(startB, parts[1].StartSector);
-            Assert.Equal<ulong>(countB, parts[1].SectorCount);
-        });
-
-        Run("Test_StorageManager_RescanPartitions", () =>
-        {
-            // Layout from the previous test: GPT with two partitions on `host`.
-            StorageManager.RescanPartitions(host);
-
-            int matches = 0;
-            for (int i = 0; i < StorageManager.Partitions.Count; i++)
-            {
-                Partition p = StorageManager.Partitions[i];
-                if (ReferenceEquals(p.Host, host))
-                {
-                    matches++;
-                }
-            }
-            Assert.Equal(2, matches);
-        });
-
-        Run("Test_Partition_ReadWrite_TranslatesLba", () =>
-        {
-            // Attach a partition starting at an arbitrary LBA, write to its
-            // LBA 0, and verify the bytes show up at the host's
-            // StartingSector — proving the translation isn't off by one.
-            const ulong startSector = 3000;
-            const ulong sectorCount = 4;
-            Partition partition = new(host, startSector, sectorCount, "test-part");
-
-            Span<byte> writeBuf = new byte[host.BlockSize];
-            for (int i = 0; i < writeBuf.Length; i++)
-            {
-                writeBuf[i] = (byte)(i ^ 0x42);
-            }
-            partition.WriteBlock(0, 1, writeBuf);
-
-            Span<byte> hostBuf = new byte[host.BlockSize];
-            host.ReadBlock(startSector, 1, hostBuf);
-            for (int i = 0; i < hostBuf.Length; i++)
-            {
-                Assert.Equal(writeBuf[i], hostBuf[i]);
-            }
-        });
-
-        Run("Test_Partition_OutOfBounds_Throws", () =>
-        {
-            Partition partition = new(host, startingSector: 5000, sectorCount: 8, name: "tiny-part");
-            Span<byte> buf = new byte[host.BlockSize];
-            try
-            {
-                partition.ReadBlock(blockNo: 8, blockCount: 1, buf);
-                Assert.Fail("Expected ArgumentOutOfRangeException for partition over-read.");
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-                // Expected.
-            }
-        });
-    }
-
-    protected override void Run()
-    {
-        Stop();
-    }
+    protected override void Run() => Stop();
 
     protected override void AfterRun()
     {
         TR.Complete();
         Cosmos.Kernel.System.Power.Halt();
+    }
+
+    // ==================== Manager ====================
+
+    private static void TestManager_StorageInitialized()
+    {
+        Assert.True(StorageManager.IsEnabled);
+        Assert.True(StorageManager.IsInitialized);
+    }
+
+    // The engine attaches exactly one disk per profile, so anything other
+    // than 1 means either the profile is misconfigured or the driver
+    // double-registered. Bound devices stay enumerated for the run.
+    private static void TestManager_ExactlyOneDevice()
+    {
+        Assert.Equal(1, StorageManager.DeviceCount);
+    }
+
+    // ==================== Device ====================
+
+    private static void TestDevice_BlockGeometrySane()
+    {
+        Assert.Equal<ulong>(512, s_dev!.BlockSize);
+        Assert.True(s_dev.BlockCount > 0);
+    }
+
+    private static void TestDevice_WriteReadSingleBlock()
+    {
+        const ulong lba = 100;
+        ulong size = s_dev!.BlockSize;
+
+        Span<byte> writeBuf = new byte[size];
+        for (int i = 0; i < (int)size; i++)
+        {
+            writeBuf[i] = (byte)(i ^ 0xA5);
+        }
+        s_dev.WriteBlock(lba, 1, writeBuf);
+
+        Span<byte> readBuf = new byte[size];
+        s_dev.ReadBlock(lba, 1, readBuf);
+
+        for (int i = 0; i < (int)size; i++)
+        {
+            Assert.Equal(writeBuf[i], readBuf[i]);
+        }
+    }
+
+    private static void TestDevice_WriteReadMultiBlock()
+    {
+        const ulong lba = 200;
+        const ulong blocks = 4;
+        ulong total = blocks * s_dev!.BlockSize;
+
+        Span<byte> writeBuf = new byte[total];
+        for (int i = 0; i < (int)total; i++)
+        {
+            writeBuf[i] = (byte)((i * 7) ^ 0x3C);
+        }
+        s_dev.WriteBlock(lba, blocks, writeBuf);
+
+        Span<byte> readBuf = new byte[total];
+        s_dev.ReadBlock(lba, blocks, readBuf);
+
+        for (int i = 0; i < (int)total; i++)
+        {
+            Assert.Equal(writeBuf[i], readBuf[i]);
+        }
+    }
+
+    private static void TestDevice_WriteReadIdempotent()
+    {
+        const ulong lba = 250;
+        ulong size = s_dev!.BlockSize;
+
+        Span<byte> first = new byte[size];
+        first.Fill(0x11);
+        s_dev.WriteBlock(lba, 1, first);
+
+        Span<byte> second = new byte[size];
+        second.Fill(0x22);
+        s_dev.WriteBlock(lba, 1, second);
+
+        Span<byte> readBuf = new byte[size];
+        s_dev.ReadBlock(lba, 1, readBuf);
+        for (int i = 0; i < (int)size; i++)
+        {
+            Assert.Equal((byte)0x22, readBuf[i]);
+        }
+    }
+
+    private static void TestDevice_ReReadStable()
+    {
+        const ulong lba = 300;
+        ulong size = s_dev!.BlockSize;
+
+        Span<byte> first = new byte[size];
+        s_dev.ReadBlock(lba, 1, first);
+
+        Span<byte> second = new byte[size];
+        s_dev.ReadBlock(lba, 1, second);
+
+        for (int i = 0; i < (int)size; i++)
+        {
+            Assert.Equal(first[i], second[i]);
+        }
+    }
+
+    private static void TestDevice_LargeTransfer()
+    {
+        const ulong lba = 1000;
+        const ulong blocks = 32;
+        ulong total = blocks * s_dev!.BlockSize;
+
+        Span<byte> writeBuf = new byte[total];
+        for (int i = 0; i < (int)total; i++)
+        {
+            writeBuf[i] = (byte)((i + (i >> 8)) ^ 0x5A);
+        }
+        s_dev.WriteBlock(lba, blocks, writeBuf);
+
+        Span<byte> readBuf = new byte[total];
+        s_dev.ReadBlock(lba, blocks, readBuf);
+
+        for (int i = 0; i < (int)total; i++)
+        {
+            Assert.Equal(writeBuf[i], readBuf[i]);
+        }
+    }
+
+    private static void TestDevice_BoundaryLBA()
+    {
+        ulong lba = s_dev!.BlockCount - 1;
+        ulong size = s_dev.BlockSize;
+
+        Span<byte> writeBuf = new byte[size];
+        for (int i = 0; i < (int)size; i++)
+        {
+            writeBuf[i] = (byte)(i ^ 0xF0);
+        }
+        s_dev.WriteBlock(lba, 1, writeBuf);
+
+        Span<byte> readBuf = new byte[size];
+        s_dev.ReadBlock(lba, 1, readBuf);
+
+        for (int i = 0; i < (int)size; i++)
+        {
+            Assert.Equal(writeBuf[i], readBuf[i]);
+        }
+    }
+
+    // LBA 0 is often special (boot sector / protective MBR). Round-trip
+    // must work there too.
+    private static void TestDevice_LBAZeroRoundTrip()
+    {
+        ulong size = s_dev!.BlockSize;
+
+        Span<byte> writeBuf = new byte[size];
+        for (int i = 0; i < (int)size; i++)
+        {
+            writeBuf[i] = (byte)(i ^ 0x96);
+        }
+        s_dev.WriteBlock(0, 1, writeBuf);
+
+        Span<byte> readBuf = new byte[size];
+        s_dev.ReadBlock(0, 1, readBuf);
+
+        for (int i = 0; i < (int)size; i++)
+        {
+            Assert.Equal(writeBuf[i], readBuf[i]);
+        }
+    }
+
+    // Catches bounce-buffer reuse / wrong-LBA-cached bugs: write 8 contiguous
+    // blocks each filled with its own marker byte, then read each block back
+    // individually and confirm the markers haven't bled across blocks.
+    private static void TestDevice_CrossBlockIsolation()
+    {
+        const ulong baseLba = 4000;
+        const int blocks = 8;
+        ulong size = s_dev!.BlockSize;
+
+        for (int b = 0; b < blocks; b++)
+        {
+            Span<byte> wbuf = new byte[size];
+            wbuf.Fill((byte)(0xC0 | b));
+            s_dev.WriteBlock(baseLba + (ulong)b, 1, wbuf);
+        }
+
+        for (int b = 0; b < blocks; b++)
+        {
+            Span<byte> rbuf = new byte[size];
+            s_dev.ReadBlock(baseLba + (ulong)b, 1, rbuf);
+            byte expected = (byte)(0xC0 | b);
+            for (int i = 0; i < (int)size; i++)
+            {
+                Assert.Equal(expected, rbuf[i]);
+            }
+        }
+    }
+
+    // Catches LBA off-by-one / stride bugs: write to LBAs that are far apart
+    // (n * 1024) so any wrap or shift error lands on a different block; the
+    // pattern depends on n so we can detect a mis-routed write.
+    private static void TestDevice_LBAStrideSweep()
+    {
+        const int slots = 8;
+        const ulong stride = 1024;
+        ulong size = s_dev!.BlockSize;
+
+        for (int n = 0; n < slots; n++)
+        {
+            Span<byte> wbuf = new byte[size];
+            byte tag = (byte)((n * 17) ^ 0x5A);
+            wbuf.Fill(tag);
+            s_dev.WriteBlock((ulong)n * stride, 1, wbuf);
+        }
+
+        for (int n = 0; n < slots; n++)
+        {
+            Span<byte> rbuf = new byte[size];
+            s_dev.ReadBlock((ulong)n * stride, 1, rbuf);
+            byte tag = (byte)((n * 17) ^ 0x5A);
+            for (int i = 0; i < (int)size; i++)
+            {
+                Assert.Equal(tag, rbuf[i]);
+            }
+        }
+    }
+
+    // Reads in non-sequential order should still return the right data —
+    // catches code that assumes the last-touched LBA is "current".
+    private static void TestDevice_RandomOrderReadAfterWrite()
+    {
+        const ulong baseLba = 6000;
+        ulong size = s_dev!.BlockSize;
+
+        Span<byte> a = new byte[size]; a.Fill(0xAA);
+        Span<byte> b = new byte[size]; b.Fill(0xBB);
+        Span<byte> c = new byte[size]; c.Fill(0xCC);
+        s_dev.WriteBlock(baseLba + 0, 1, a);
+        s_dev.WriteBlock(baseLba + 1, 1, b);
+        s_dev.WriteBlock(baseLba + 2, 1, c);
+
+        Span<byte> r = new byte[size];
+
+        s_dev.ReadBlock(baseLba + 2, 1, r);
+        for (int i = 0; i < (int)size; i++) { Assert.Equal((byte)0xCC, r[i]); }
+
+        s_dev.ReadBlock(baseLba + 0, 1, r);
+        for (int i = 0; i < (int)size; i++) { Assert.Equal((byte)0xAA, r[i]); }
+
+        s_dev.ReadBlock(baseLba + 1, 1, r);
+        for (int i = 0; i < (int)size; i++) { Assert.Equal((byte)0xBB, r[i]); }
+    }
+
+    // Multi-block transfer that ends exactly at the device tail. Catches
+    // truncation / wrap bugs at the upper edge of LBA space.
+    private static void TestDevice_MultiblockTailBoundary()
+    {
+        const ulong blocks = 4;
+        ulong size = s_dev!.BlockSize;
+        ulong lba = s_dev.BlockCount - blocks;
+        ulong total = blocks * size;
+
+        Span<byte> writeBuf = new byte[total];
+        for (int i = 0; i < (int)total; i++)
+        {
+            writeBuf[i] = (byte)((i * 13) ^ 0x6E);
+        }
+        s_dev.WriteBlock(lba, blocks, writeBuf);
+
+        Span<byte> readBuf = new byte[total];
+        s_dev.ReadBlock(lba, blocks, readBuf);
+
+        for (int i = 0; i < (int)total; i++)
+        {
+            Assert.Equal(writeBuf[i], readBuf[i]);
+        }
+    }
+
+    // ==================== Partition ====================
+
+    private static void TestPartition_MBRRoundTrip()
+    {
+        // Wipe LBA 0 first so a leftover GPT signature from a prior
+        // sub-test doesn't taint the IsMBR check.
+        Span<byte> wipe = new byte[s_dev!.BlockSize];
+        s_dev.WriteBlock(0, 1, wipe);
+
+        MBR.Create(s_dev);
+        Assert.True(MBR.IsMBR(s_dev));
+
+        // Two primary entries at distinct LBA windows.
+        MBR.WritePartition(s_dev, 0, systemId: 0x83, startSector: 100, sectorCount: 200);
+        MBR.WritePartition(s_dev, 1, systemId: 0x0B, startSector: 1000, sectorCount: 500);
+
+        List<MBR.PartitionEntry> parts = MBR.Parse(s_dev);
+        Assert.Equal(2, parts.Count);
+        Assert.Equal<byte>(0x83, parts[0].SystemId);
+        Assert.Equal<ulong>(100, parts[0].StartSector);
+        Assert.Equal<ulong>(200, parts[0].SectorCount);
+        Assert.Equal<byte>(0x0B, parts[1].SystemId);
+        Assert.Equal<ulong>(1000, parts[1].StartSector);
+        Assert.Equal<ulong>(500, parts[1].SectorCount);
+    }
+
+    private static void TestPartition_GPTRoundTrip()
+    {
+        GPT.Create(s_dev!);
+        Assert.True(GPT.IsGPT(s_dev));
+
+        const ulong startA = 2048;
+        const ulong countA = 4096;
+        const ulong startB = startA + countA;
+        const ulong countB = 8192;
+
+        Assert.True(GPT.AddPartition(s_dev, startA, countA, GPT.BasicDataPartitionType));
+        Assert.True(GPT.AddPartition(s_dev, startB, countB, GPT.BasicDataPartitionType));
+
+        List<GPT.PartitionEntry> parts = GPT.Parse(s_dev);
+        Assert.Equal(2, parts.Count);
+        Assert.Equal(GPT.BasicDataPartitionType, parts[0].PartitionType);
+        Assert.Equal<ulong>(startA, parts[0].StartSector);
+        Assert.Equal<ulong>(countA, parts[0].SectorCount);
+        Assert.Equal<ulong>(startB, parts[1].StartSector);
+        Assert.Equal<ulong>(countB, parts[1].SectorCount);
+    }
+
+    // Layout left by Partition_GPTRoundTrip: GPT with two partitions on s_dev.
+    // Run order matters — depends on the previous test having succeeded.
+    private static void TestPartition_RescanPartitions()
+    {
+        StorageManager.RescanPartitions(s_dev!);
+
+        int matches = 0;
+        for (int i = 0; i < StorageManager.Partitions.Count; i++)
+        {
+            Partition p = StorageManager.Partitions[i];
+            if (ReferenceEquals(p.Host, s_dev))
+            {
+                matches++;
+            }
+        }
+        Assert.Equal(2, matches);
+    }
+
+    // Attach a partition starting at an arbitrary LBA, write to its LBA 0,
+    // and verify the bytes show up at the host's StartingSector — proves
+    // the translation isn't off by one.
+    private static void TestPartition_ReadWriteTranslatesLba()
+    {
+        const ulong startSector = 3000;
+        const ulong sectorCount = 4;
+        Partition partition = new(s_dev!, startSector, sectorCount, "test-part");
+
+        Span<byte> writeBuf = new byte[s_dev!.BlockSize];
+        for (int i = 0; i < writeBuf.Length; i++)
+        {
+            writeBuf[i] = (byte)(i ^ 0x42);
+        }
+        partition.WriteBlock(0, 1, writeBuf);
+
+        Span<byte> hostBuf = new byte[s_dev.BlockSize];
+        s_dev.ReadBlock(startSector, 1, hostBuf);
+        for (int i = 0; i < hostBuf.Length; i++)
+        {
+            Assert.Equal(writeBuf[i], hostBuf[i]);
+        }
+    }
+
+    private static void TestPartition_OutOfBoundsThrows()
+    {
+        Partition partition = new(s_dev!, startingSector: 5000, sectorCount: 8, name: "tiny-part");
+        Span<byte> buf = new byte[s_dev!.BlockSize];
+        try
+        {
+            partition.ReadBlock(blockNo: 8, blockCount: 1, buf);
+            Assert.Fail("Expected ArgumentOutOfRangeException for partition over-read.");
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // Expected.
+        }
     }
 }

--- a/tests/profiles.json
+++ b/tests/profiles.json
@@ -1,0 +1,56 @@
+{
+  // Global QEMU profile catalog. Two orthogonal axes:
+  //   * profiles  — a hardware "shape" (which disks/NICs are attached, etc.).
+  //   * modifiers — generic knobs that compose with a profile. Two flavors:
+  //       - deviceOptions: per-disk-kind overrides (msix tuning, cache mode)
+  //       - machineOptions: -M property overrides (gic-version, ...)
+  //     plus an optional architectures filter so arch-specific knobs (GIC) are
+  //     silently skipped on the wrong arch.
+  //
+  // A modifier with only deviceOptions is gated on at least one matching disk
+  // kind in the profile; a modifier with machineOptions applies regardless of
+  // what's attached. A suite opts in via <CosmosTestProfile/> and
+  // <CosmosTestModifier/> items; test names are prefixed [profile] or
+  // [profile+modifier].
+  "profiles": [
+    {
+      "name": "ahci",
+      "disks": [
+        { "type": "ahci" }
+      ]
+    },
+    {
+      "name": "nvme",
+      "disks": [
+        { "type": "nvme" }
+      ]
+    }
+  ],
+  "modifiers": [
+    {
+      // Constrain MSI-X to 1 vector. QEMU's `nvme` device rejects
+      // msix_qsize=0, so 1 is the smallest legal table — exercises the
+      // kernel's single-vector/vector-pressure path.
+      // Targets nvme only because ich9-ahci does not expose msix_qsize.
+      "name": "msix-min",
+      "deviceOptions": {
+        "nvme": { "msix_qsize": "1" }
+      }
+    },
+    {
+      // Force GICv2 (legacy distributor). cortex-a72 supports both v2 and v3,
+      // so flipping this exercises the kernel's GICv2 IRQ-ack/EOI path
+      // separate from GICv3 ICC_* system registers.
+      "name": "gicv2",
+      "architectures": ["arm64"],
+      "machineOptions": { "gic-version": "2" }
+    },
+    {
+      // Force GICv3. Default on most newer QEMU virt machines, but pinning
+      // it makes the test matrix explicit and disambiguates from `auto`.
+      "name": "gicv3",
+      "architectures": ["arm64"],
+      "machineOptions": { "gic-version": "3" }
+    }
+  ]
+}

--- a/tests/profiles.json
+++ b/tests/profiles.json
@@ -51,6 +51,16 @@
       "name": "gicv3",
       "architectures": ["arm64"],
       "machineOptions": { "gic-version": "3" }
+    },
+    {
+      // Disable ACPI on the machine. Default is acpi=on for both q35 and
+      // virt; flipping it forces the kernel onto its non-ACPI discovery
+      // paths (no MADT/IORT/MCFG, fall back to FDT or hard-coded layout).
+      // Useful smoke for "ACPI tables absent" code; on x64 it typically
+      // disables PCIe enumeration and surfaces as missing devices in the
+      // dependent tests via the existing TR.RunIf gating.
+      "name": "acpi-off",
+      "machineOptions": { "acpi": "off" }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- A suite can now declare one or more QEMU launch configurations and the engine runs the kernel once per (profile, modifier) cell, prefixing test names with `[profile]` / `[profile+modifier]`.
- Storage suite opts into `{ahci, nvme} × {msix-min, gicv2, gicv3}` — x64 expands to 3 runs (gic filtered), arm64 to 7 (full matrix).
- CI per-suite PR comment now shows per-matrix-cell breakdown alongside the per-arch totals so a failure points at the exact profile.

## How it works
**Catalog** — `tests/profiles.json`:
- `profiles`: a hardware shape (disks attached, etc.).
- `modifiers`: orthogonal overlays composing with a profile. Two flavors plus an arch filter:
  - `deviceOptions` — per-disk-kind QEMU `-device` overrides (e.g. `nvme: msix_qsize=1`).
  - `machineOptions` — `-M` property overrides (e.g. `gic-version=2`).
  - optional `architectures` filter so arm64-only knobs vanish on x64.

**Opt-in** — each suite's `.csproj`:
```xml
<ItemGroup>
  <CosmosTestProfile Include=\"ahci\" />
  <CosmosTestProfile Include=\"nvme\" />
  <CosmosTestModifier Include=\"msix-min\" />
  <CosmosTestModifier Include=\"gicv2\" />
  <CosmosTestModifier Include=\"gicv3\" />
</ItemGroup>
```

**Engine** — for each requested profile, emit baseline plus one variant per applicable modifier. Skip combos where the modifier targets no matching device kind (e.g. `ahci+msix-min`) or the wrong arch (e.g. `ahci+gicv2` on x64).

## Local results
- `make test KERNEL=Storage` → 3 runs, 57/57 passed.
- `make test KERNEL=Storage ARCH=arm64` → 7 runs. 3 failures all in the `[ahci*] Test_ExactlyOneDevice_Present` cells: latent arm64 AHCI port-enumeration bug (`AHCI Ports discovered: 0`) the matrix surfaces — previously hidden because the old suite always attached both AHCI + NVMe at once and only checked `DeviceCount > 0`. Not a regression from this PR; tracked separately.

## Test plan
- [ ] CI matrix renders per-profile rows in the Storage PR comment.
- [ ] x64 Storage shows 3 rows: ahci, nvme, nvme+msix-min.
- [ ] arm64 Storage shows the full 7-row matrix with the AHCI failures isolated to their specific cells.
- [ ] Other suites (HelloWorld etc.) keep their previous single-row-per-arch behaviour.