### PR TITLE
Step the EH dispatch via CFI, not the frame-pointer chain

### DIFF
--- a/src/Cosmos.Kernel.Core/Runtime/ExceptionHandling/CfiArch.ARM64.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/ExceptionHandling/CfiArch.ARM64.cs
@@ -26,6 +26,7 @@ internal static class CfiArch
     public const byte CfaRegAtEntry = (byte)DwarfReg.SP;       // CFA = SP at function entry (AAPCS64)
     public const int CfaOffsetAtEntry = 0;
     public const int StackPointerReg = (int)DwarfReg.SP;       // Regs[31] = unwound caller SP
+    public const int FramePointerReg = (int)DwarfReg.FP;       // Regs[29] = unwound caller frame pointer (X29)
     public const int RaColumn = (int)DwarfReg.LR;              // 30 — LR is the RA reg (no pseudo-reg)
     public const int DefaultCodeAlignFactor = 4;               // every ARM64 instruction is 4 bytes
     public const RegSaveKind RaInitRule = RegSaveKind.SameValue;  // LR is a normal reg; SameValue = the seeded default

--- a/src/Cosmos.Kernel.Core/Runtime/ExceptionHandling/CfiArch.X64.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/ExceptionHandling/CfiArch.X64.cs
@@ -24,6 +24,7 @@ internal static class CfiArch
     public const byte CfaRegAtEntry = (byte)DwarfReg.RSP;        // CFA = RSP + 8 at function entry
     public const int CfaOffsetAtEntry = 8;
     public const int StackPointerReg = (int)DwarfReg.RSP;        // Regs[7] = unwound caller SP
+    public const int FramePointerReg = (int)DwarfReg.RBP;        // Regs[6] = unwound caller frame pointer
     public const int RaColumn = (int)DwarfReg.RA;                // 16 — default return-address register
     public const int DefaultCodeAlignFactor = 1;
     public const RegSaveKind RaInitRule = RegSaveKind.AtCfaOffset;  // return address at CFA - 8 by default

--- a/src/Cosmos.Kernel.Core/Runtime/ExceptionHandling/ExceptionHelper.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/ExceptionHandling/ExceptionHelper.cs
@@ -180,20 +180,29 @@ public static unsafe partial class ExceptionHelper
                 break;
             }
 
-            // Capture this frame's IP before stepping up — CFI unwinds it below.
+            // Capture this frame's IP before stepping up.
             nuint currentFrameIP = frame.ReturnAddress;
 
-            // Step to the caller via the frame-pointer chain; stop if it runs out.
-            if (!UnwindOneFrame(ref frame))
-            {
-                break;
-            }
-
-            // Unwind the register state with CFI for the frame we just left, so it reflects the
-            // caller's values on the next iteration (needed for filter evaluation).
+            // Step to the caller. CFI (the .eh_frame unwinder) is the source of truth: it works
+            // regardless of whether the current method keeps RBP/X29 (RyuJIT omits the frame
+            // pointer on methods with no EH, small frames, no localloc, no address-taken locals —
+            // the managed equivalent of `-fomit-frame-pointer`; tail-called methods don't even
+            // get their own frame). The frame-pointer chain breaks across any such intermediate,
+            // so we drive the walk from CFI and reserve `UnwindOneFrame` for the (defensive)
+            // case where there is no throw context to seed the unwind state with.
             if (pThrowContext != null)
             {
-                UnwindOneFrameWithCFI(ref unwindState, currentFrameIP);
+                if (!UnwindOneFrameWithCFI(ref unwindState, currentFrameIP))
+                {
+                    break;   // No CFI for this IP — can't unwind further precisely.
+                }
+                frame.ReturnAddress = unwindState.ReturnAddress;
+                frame.FramePointer = unwindState.GetRegValue(CfiArch.FramePointerReg);
+                frame.StackPointer = unwindState.StackPointer;
+            }
+            else if (!UnwindOneFrame(ref frame))
+            {
+                break;
             }
 
             frameCount++;
@@ -209,9 +218,10 @@ public static unsafe partial class ExceptionHelper
         // catching frame already reconstructed its body register state at the call that threw, so
         // `unwindState` carries the callee-saved registers and the resume SP directly — that's what
         // `ProjectRegDisplay` copies in (and, on x64, what it wires the pRxx pointers to point at).
-        // The frame pointer is the one exception: it comes from the frame-pointer chain (`[RBP]` on
-        // x64, `[FP]` on ARM64), because CFI can legitimately report it "SameValue" for a
-        // -fomit-frame-pointer caller — so we override it here after the projection.
+        // The frame pointer is overridden separately: `catchFrame.FramePointer` was derived from
+        // the same CFI walk, so the two should agree, but we pin it explicitly to match what the
+        // funclet expects to find at function entry (`push rbp; mov rbp, rsp` semantics on x64;
+        // the establisher's X29 on ARM64).
         if (pThrowContext != null)
         {
             pRegDisplay = &regDisplay;

--- a/tests/Kernels/Cosmos.Kernel.Tests.GarbageCollector/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.GarbageCollector/Kernel.cs
@@ -21,7 +21,7 @@ public class Kernel : Sys.Kernel
         Serial.WriteString("[GarbageCollector] BeforeRun() reached!\n");
         Serial.WriteString("[GarbageCollector] Starting tests...\n");
 
-        TR.Start("GarbageCollector Tests", expectedTests: 40);
+        TR.Start("GarbageCollector Tests", expectedTests: 41);
 
         // Garbage Collection Tests
         TR.Run("GC_IsEnabled", TestGCIsEnabled);
@@ -51,6 +51,7 @@ public class Kernel : Sys.Kernel
         TR.Run("GC_PreciseStackScan", TestGCPreciseStackScan);
         TR.Run("GC_FuncletNoFalseRoot", TestGCFuncletNoFalseRoot);
         TR.Run("GC_FuncletNoCrashOnAllocInCatch", TestGCFuncletNoCrashOnAllocInCatch);
+        TR.Run("GC_ThrowThroughDeepChain", TestGCThrowThroughDeepChain);
 
         // GC Info & Configuration Tests
         TR.Run("GC_Info_SimpleMemoryInfo", TestGCInfoSimpleMemoryInfo);
@@ -808,6 +809,79 @@ public class Kernel : Sys.Kernel
             Assert.Equal(32640, sum,
                 "GC: a catch funclet's allocations must survive a collection forced from inside the catch (shape " + shape + ", issue #227)");
         }
+    }
+
+    // ==================== EH dispatch through FP-omitted intermediate frames ===================
+    //
+    // ILC's RyuJIT-based codegen omits the frame pointer on managed methods that don't need it
+    // (no EH clauses, no stackalloc, no large frame, no address-taken locals) — the same effect
+    // C's `-fomit-frame-pointer` has on a function. The five DeepThrowLevel* helpers below are
+    // deliberately starved of every characteristic that forces RBP/X29 to be kept; on at least
+    // some of them RyuJIT is free to use the frame register as a general-purpose scratch.
+    //
+    // If the EH dispatcher's frame-pointer-chain walker (`ExceptionHelper.UnwindOneFrame`) is
+    // the only thing stepping between the throw site and the catching method, an FP-omitted
+    // intermediate breaks the chain — `[RBP]` no longer points at the caller's saved RBP, the
+    // walker reads scratch, and either `TryFindHandler` runs against a garbage return address or
+    // the loop bottoms out without finding the handler. Either way the kernel halts and this
+    // test never returns.
+    //
+    // The catching method (`CatchAtopDeepChain`) has a try/catch, so RyuJIT must keep its own
+    // RBP — that part of the unwind is sound. The fragility, if any, is entirely in the chain
+    // of intermediates between the throw and the catch.
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void DeepThrowLevel0()
+    {
+        throw new Exception("deep-throw");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void DeepThrowLevel1()
+    {
+        DeepThrowLevel0();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void DeepThrowLevel2()
+    {
+        DeepThrowLevel1();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void DeepThrowLevel3()
+    {
+        DeepThrowLevel2();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void DeepThrowLevel4()
+    {
+        DeepThrowLevel3();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static string CatchAtopDeepChain()
+    {
+        try
+        {
+            DeepThrowLevel4();
+            return "unreached";
+        }
+        catch (Exception ex)
+        {
+            return ex.Message;
+        }
+    }
+
+    private static void TestGCThrowThroughDeepChain()
+    {
+        // The throw happens five managed frames below the catch. If the EH dispatch survives any
+        // of those frames omitting RBP/X29, this round-trips the exception message; otherwise the
+        // kernel halts and the test runner reports the test as failed (or never completes).
+        string caught = CatchAtopDeepChain();
+        Assert.True(caught == "deep-throw",
+            "EH: a throw must propagate through 5 intermediate frames that may omit RBP/X29 — got '" + caught + "'");
     }
 
     // ==================== GC Info & Configuration Tests ====================


### PR DESCRIPTION
## Summary
- The exception dispatcher now steps frame-to-frame via CFI (the `.eh_frame` unwinder) instead of the frame-pointer chain whenever a throw context is present. RyuJIT routinely omits RBP/X29 on managed methods (no EH, small frame, no localloc, no address-taken locals; tail-called methods own no frame at all), so the old `[RBP]` walk read scratch the moment it crossed such an intermediate and `TryFindHandler` ran against a garbage return address.
- `UnwindOneFrame` (the frame-pointer-chain walker) is kept only as a defensive fallback for the case where no throw context was passed (unreachable through `RhpThrowEx` in practice).
- Adds `CfiArch.FramePointerReg` so the dispatch reads the unwound RBP/X29 arch-neutrally, mirroring the existing `StackPointerReg`.
- Adds `GC_ThrowThroughDeepChain`: throws five managed frames below its catch through minimal intermediates (`DeepThrowLevel0..4`) that RyuJIT is free to compile frame-pointer-omitted, then asserts the message round-trips. Codifies a "throw through arbitrary intermediates must work" invariant the existing funclet tests do not cover.

## Context
Split out of #343 (storage stack): the NVMe interrupt-completion path was the first code to throw across FP-omitted frames and surfaced the regression. This is a runtime exception-unwinder change with no storage dependency, so it stands on its own. The CFI infrastructure it builds on (`CfiArch`, `DwarfCfiParser`, `ExceptionHelper`) is already on main.

## Out of scope
- The defensive `UnwindOneFrame` fallback is left in place rather than removed.

## Test plan
- [ ] `GC_ThrowThroughDeepChain` passes on x64 and arm64.
- [ ] Existing funclet tests (`GC_FuncletNoCrashOnAllocInCatch`, `GC_FuncletNoFalseRoot`) still pass; the catch-build frame-pointer override now no-ops (CFI-derived `catchFrame.FramePointer` equals the unwound RBP/X29).
