### PR TITLE
Add Cosmos.Kernel.Tests.Interrupts suite (x64 + arm64)

### DIFF
--- a/.github/workflows/kernel-tests.yml
+++ b/.github/workflows/kernel-tests.yml
@@ -345,11 +345,34 @@ jobs:
       event_name: ${{ github.event_name }}
       head_ref: ${{ github.head_ref || github.ref_name }}
 
+  # ── Interrupts ────────────────────────────────────────────────────────────────
+  interrupts-tests:
+    needs: setup
+    uses: ./.github/workflows/kernel-test-run.yml
+    with:
+      suite_name: Interrupts
+      suite_id: interrupts
+      kernel_path: tests/Kernels/Cosmos.Kernel.Tests.Interrupts
+      timeout_x64: 60
+      timeout_arm64: 90
+      step_timeout_minutes: 5
+
+  interrupts-results:
+    needs: interrupts-tests
+    if: always()
+    uses: ./.github/workflows/kernel-test-results.yml
+    with:
+      suite_name: Interrupts
+      suite_id: interrupts
+      kernel_path: tests/Kernels/Cosmos.Kernel.Tests.Interrupts
+      event_name: ${{ github.event_name }}
+      head_ref: ${{ github.head_ref || github.ref_name }}
+
   # ── Summary ───────────────────────────────────────────────────────────────────
   test-summary:
     name: Test Summary
     runs-on: ubuntu-24.04
-    needs: [ helloworld-results, memory-results, typecasting-results, timer-results, network-results, runtime-results, threading-results, math-results, graphic-results, power-results, garbagecollector-results, pci-results, storage-results ]
+    needs: [ helloworld-results, memory-results, typecasting-results, timer-results, network-results, runtime-results, threading-results, math-results, graphic-results, power-results, garbagecollector-results, interrupts-results, pci-results, storage-results ]
     if: always()
     steps:
       - name: 📊 Generate Summary
@@ -380,6 +403,7 @@ jobs:
           add_row "Graphic"          "${{ needs.graphic-tests.result }}"
           add_row "Power"            "${{ needs.power-tests.result }}"
           add_row "GarbageCollector" "${{ needs.garbagecollector-tests.result }}"
+          add_row "Interrupts"       "${{ needs.interrupts-tests.result }}"
           add_row "Pci"              "${{ needs.pci-tests.result }}"
           add_row "Storage"          "${{ needs.storage-tests.result }}"
 

--- a/tests/Cosmos.TestRunner.Framework/TestRunner.cs
+++ b/tests/Cosmos.TestRunner.Framework/TestRunner.cs
@@ -254,6 +254,75 @@ namespace Cosmos.TestRunner.Framework
             return string.Empty;
         }
 
+        // Cached profile cell name backing the prefix/contains helpers; reading
+        // the Limine cmdline is cheap but they are called repeatedly. Each
+        // matrix cell is a fresh boot, so the static starts empty per cell.
+        private static string? s_profileName;
+
+        /// <summary>
+        /// The active profile-matrix cell name (cached <see cref="GetProfileName"/>),
+        /// e.g. <c>nvme+gicv3</c>. Empty for a suite that opts into no profiles.
+        /// </summary>
+        public static string ProfileName
+        {
+            get
+            {
+                if (s_profileName == null)
+                {
+                    s_profileName = GetProfileName();
+                }
+                return s_profileName;
+            }
+        }
+
+        /// <summary>
+        /// True when the active profile cell name starts with <paramref name="prefix"/>.
+        /// A cell name always leads with its base profile (e.g. the "nvme" in
+        /// "nvme+gicv2"), so a prefix check identifies the profile. Lives here
+        /// because the kernel runtime does not plug <c>string.StartsWith</c>.
+        /// </summary>
+        public static bool ProfileHasPrefix(string prefix)
+        {
+            string profile = ProfileName;
+            if (profile.Length < prefix.Length)
+            {
+                return false;
+            }
+            for (int i = 0; i < prefix.Length; i++)
+            {
+                if (profile[i] != prefix[i])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// True when <paramref name="needle"/> occurs anywhere in the active
+        /// profile cell name. Detects a composed modifier such as the "gicv2" in
+        /// "nvme+gicv2+acpi-off". Lives here because the kernel runtime does not
+        /// plug <c>string.Contains</c>.
+        /// </summary>
+        public static bool ProfileContains(string needle)
+        {
+            string profile = ProfileName;
+            int limit = profile.Length - needle.Length;
+            for (int i = 0; i <= limit; i++)
+            {
+                int j = 0;
+                while (j < needle.Length && profile[i + j] == needle[j])
+                {
+                    j++;
+                }
+                if (j == needle.Length)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         /// <summary>
         /// Skip a test
         /// </summary>

--- a/tests/Kernels/Cosmos.Kernel.Tests.Interrupts/Bootloader/limine.conf
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Interrupts/Bootloader/limine.conf
@@ -1,0 +1,10 @@
+# Timeout in seconds that Limine will use before automatically booting.
+timeout: 0
+
+# The entry name that will be displayed in the boot menu.
+/Limine Template
+    # We use the Limine boot protocol.
+    protocol: limine
+
+    # Path to the kernel to boot. boot():/ represents the partition on which limine.conf is located.
+    path: boot():/boot/Cosmos.Kernel.Tests.Interrupts.elf

--- a/tests/Kernels/Cosmos.Kernel.Tests.Interrupts/Cosmos.Kernel.Tests.Interrupts.csproj
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Interrupts/Cosmos.Kernel.Tests.Interrupts.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Sdk Name="Cosmos.Sdk" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <!-- Core kernel packages (using project references for development) -->
+  <ItemGroup>
+    <ProjectReference Include="../../../src/Cosmos.Kernel/Cosmos.Kernel.csproj" />
+    <ProjectReference Include="../../../src/Cosmos.Kernel.System/Cosmos.Kernel.System.csproj" />
+    <ProjectReference Include="../../Cosmos.TestRunner.Framework/Cosmos.TestRunner.Framework.csproj" />
+  </ItemGroup>
+
+  <!-- Architecture-specific HAL (using project references for development) -->
+  <ItemGroup Condition="'$(DefineConstants)' != '' AND $(DefineConstants.Contains('ARCH_X64'))">
+    <ProjectReference Include="../../../src/Cosmos.Kernel.HAL.X64/Cosmos.Kernel.HAL.X64.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DefineConstants)' != '' AND $(DefineConstants.Contains('ARCH_ARM64'))">
+    <ProjectReference Include="../../../src/Cosmos.Kernel.HAL.ARM64/Cosmos.Kernel.HAL.ARM64.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Kernels/Cosmos.Kernel.Tests.Interrupts/Cosmos.Kernel.Tests.Interrupts.csproj
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Interrupts/Cosmos.Kernel.Tests.Interrupts.csproj
@@ -7,6 +7,18 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
+  <!--
+    Run the suite once per GIC version on arm64 so both interrupt-controller
+    paths are exercised deterministically: gicv2 (no ITS -> no MSI routing) and
+    gicv3 (ITS + LPI -> MSI routing). The gic* modifiers are arm64-only, so x64
+    just runs the bare cell. Definitions live in tests/profiles.json.
+  -->
+  <ItemGroup>
+    <CosmosTestProfile Include="bare" />
+    <CosmosTestModifier Include="gicv2" />
+    <CosmosTestModifier Include="gicv3" />
+  </ItemGroup>
+
   <!-- Core kernel packages (using project references for development) -->
   <ItemGroup>
     <ProjectReference Include="../../../src/Cosmos.Kernel/Cosmos.Kernel.csproj" />

--- a/tests/Kernels/Cosmos.Kernel.Tests.Interrupts/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Interrupts/Kernel.cs
@@ -24,13 +24,6 @@ namespace Cosmos.Kernel.Tests.Interrupts;
 // stays covered by the Storage suite's NVMe assertions.
 public class Kernel : Sys.Kernel
 {
-#if !ARCH_X64
-    // The active profile-matrix cell name (bare, bare+gicv2, bare+gicv3),
-    // injected by the engine on the Limine cmdline. Drives the per-GIC-version
-    // assertions below.
-    private static string s_profile = string.Empty;
-#endif
-
     protected override void BeforeRun()
     {
         Serial.WriteString("[Interrupts] BeforeRun() reached!\n");
@@ -51,16 +44,15 @@ public class Kernel : Sys.Kernel
         TR.Run("Msi_RoutingAvailable", TestMsiRoutingAvailableX64);
 #else
         // ==================== arm64 (GIC, per cell's gic-version) ====================
-        s_profile = TR.GetProfileName();
         TR.Run("Gic_Initialized", TestGicInitialized);
 
-        if (ProfileContains("gicv3"))
+        if (TR.ProfileContains("gicv3"))
         {
             // GICv3 + ITS: the MSI delivery path must be fully up.
             TR.Run("Its_Lpi_BroughtUp", TestItsLpiUp);
             TR.Run("Msi_RoutingAvailable", TestMsiRoutingAvailableArm64);
         }
-        else if (ProfileContains("gicv2"))
+        else if (TR.ProfileContains("gicv2"))
         {
             // GICv2 has no ITS, so there is no LPI/MSI path: the kernel must
             // report it absent and fall back to polled rather than claim MSI.
@@ -195,27 +187,6 @@ public class Kernel : Sys.Kernel
     private static void TestMsiRoutingUnavailableOnGicv2()
     {
         Assert.False(MsiRouting.IsAvailable, "GICv2 has no ITS, so MSI routing must be unavailable");
-    }
-
-    // Substring match over the cell name (the kernel runtime does not plug
-    // string.Contains). Detects the composed modifier, e.g. the "gicv2" in
-    // "bare+gicv2".
-    private static bool ProfileContains(string needle)
-    {
-        int limit = s_profile.Length - needle.Length;
-        for (int i = 0; i <= limit; i++)
-        {
-            int j = 0;
-            while (j < needle.Length && s_profile[i + j] == needle[j])
-            {
-                j++;
-            }
-            if (j == needle.Length)
-            {
-                return true;
-            }
-        }
-        return false;
     }
 
 #endif

--- a/tests/Kernels/Cosmos.Kernel.Tests.Interrupts/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Interrupts/Kernel.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Diagnostics;
+using Cosmos.Kernel.Core.CPU;
+using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.System.Timer;
+using Cosmos.TestRunner.Framework;
+using Sys = Cosmos.Kernel.System;
+using TR = Cosmos.TestRunner.Framework.TestRunner;
+using SysThread = System.Threading.Thread;
+#if ARCH_X64
+using Cosmos.Kernel.Core.X64.Cpu;
+#else
+using Cosmos.Kernel.Core.ARM64.Cpu;
+#endif
+
+namespace Cosmos.Kernel.Tests.Interrupts;
+
+// Exercises the interrupt subsystem itself (no devices): the controller is up,
+// the dynamic-vector allocator behaves, and an interrupt actually fires and is
+// dispatched end-to-end. Per-arch tests cover the backend that delivers MSIs
+// (x64 LAPIC, arm64 GICv3 ITS/LPI). The NVMe MSI-X delivery path is covered
+// separately by the Storage suite.
+public class Kernel : Sys.Kernel
+{
+    protected override void BeforeRun()
+    {
+        Serial.WriteString("[Interrupts] BeforeRun() reached!\n");
+
+        // 4 cross-arch + 3 arch-specific = 7 tests per architecture.
+        TR.Start("Interrupt System Tests", expectedTests: 7);
+
+        // ==================== Cross-arch ====================
+        TR.Run("InterruptManager_Enabled", TestInterruptManagerEnabled);
+        TR.Run("TimerSource_Registered", TestTimerSourceRegistered);
+        TR.Run("VectorAllocator_ReturnsDistinctDynamicVectors", TestVectorAllocatorDistinct);
+        TR.Run("TimerInterrupt_WakesSleepingThread", TestTimerInterruptWakesSleepingThread);
+
+#if ARCH_X64
+        // ==================== x64 (LAPIC + MSI) ====================
+        TR.Run("Lapic_Initialized", TestLapicInitialized);
+        TR.Run("Lapic_TimerCalibrated", TestLapicTimerCalibrated);
+        TR.Run("Msi_RoutingAvailable", TestMsiRoutingAvailableX64);
+#else
+        // ==================== arm64 (GIC + ITS/LPI) ====================
+        TR.Run("Gic_Initialized", TestGicInitialized);
+        // The ITS/LPI path only exists when the machine instantiates a GICv3
+        // ITS; on an ITS-less machine these report Skipped instead of Failed.
+        TR.RunIf(GICv3Its.IsInitialized, "Its_Lpi_BroughtUp", TestItsLpiBroughtUp, NoItsReason);
+        TR.RunIf(GICv3Its.IsInitialized, "Msi_RoutingAvailable", TestMsiRoutingAvailableArm64, NoItsReason);
+#endif
+
+        TR.Finish();
+
+        Serial.WriteString("\n[Tests Complete - System Halting]\n");
+    }
+
+    protected override void Run() => Stop();
+
+    protected override void AfterRun()
+    {
+        TR.Complete();
+        Cosmos.Kernel.System.Power.Halt();
+    }
+
+    // ==================== Cross-arch ====================
+
+    private static void TestInterruptManagerEnabled()
+    {
+        Assert.True(InterruptManager.IsEnabled, "InterruptManager should report enabled");
+    }
+
+    // A registered timer device is the periodic interrupt source that drives
+    // the scheduler; without one nothing would generate IRQs to dispatch.
+    private static void TestTimerSourceRegistered()
+    {
+        Assert.True(TimerManager.IsInitialized, "TimerManager should be initialized");
+        Assert.True(TimerManager.Timer != null, "A timer device should be registered");
+    }
+
+    // Exercises the dynamic-vector allocator MSI/MSI-X programmers depend on:
+    // every allocation must fall in the [0x40, 0xFE] dynamic window and be
+    // unique, so two devices never collide on the same vector.
+    private static void TestVectorAllocatorDistinct()
+    {
+        byte v1 = InterruptManager.AllocateVector(NoopHandler);
+        byte v2 = InterruptManager.AllocateVector(NoopHandler);
+        byte v3 = InterruptManager.AllocateVector(NoopHandler);
+
+        Assert.True(v1 >= 0x40 && v1 <= 0xFE, "vector 1 should be in the dynamic range");
+        Assert.True(v2 >= 0x40 && v2 <= 0xFE, "vector 2 should be in the dynamic range");
+        Assert.True(v3 >= 0x40 && v3 <= 0xFE, "vector 3 should be in the dynamic range");
+        Assert.True(v1 != v2 && v2 != v3 && v1 != v3, "allocated vectors must be distinct");
+    }
+
+    // End-to-end proof the interrupt path is live: a scheduler-blocking sleep
+    // can only resume once the periodic timer IRQ fires, is dispatched through
+    // the controller, and the handler wakes the blocked thread. The elapsed
+    // time is read from the free-running Stopwatch (TSC / CNTPCT), which does
+    // not depend on interrupts, so a sane duration isolates the IRQ path. If
+    // interrupts were dead the sleep would never return and the suite would
+    // time out.
+    private static void TestTimerInterruptWakesSleepingThread()
+    {
+        long start = Stopwatch.GetTimestamp();
+        SysThread.Sleep(200);
+        long end = Stopwatch.GetTimestamp();
+
+        long elapsedMs = (end - start) * 1000 / Stopwatch.Frequency;
+        Serial.WriteString("[Interrupts] Sleep(200ms) measured ms: ");
+        Serial.WriteNumber((ulong)elapsedMs);
+        Serial.WriteString("\n");
+
+        Assert.True(elapsedMs >= 100 && elapsedMs <= 800,
+            "a 200ms scheduler sleep should resume in roughly 200ms via the timer IRQ");
+    }
+
+    private static void NoopHandler(ref IRQContext context)
+    {
+    }
+
+#if ARCH_X64
+
+    private static void TestLapicInitialized()
+    {
+        Assert.True(LocalApic.IsInitialized, "LAPIC should be initialized");
+    }
+
+    private static void TestLapicTimerCalibrated()
+    {
+        Assert.True(LocalApic.IsTimerCalibrated, "LAPIC timer should be calibrated");
+        Assert.True(LocalApic.TicksPerMs > 0, "LAPIC ticks-per-ms should be non-zero");
+    }
+
+    // On x64 the LAPIC is the MSI routing backend and its binder is registered
+    // at boot, so MsiRouting must report available.
+    private static void TestMsiRoutingAvailableX64()
+    {
+        Assert.True(MsiRouting.IsAvailable, "x64 MSI routing (LAPIC binder) should be available");
+    }
+
+#else
+
+    private const string NoItsReason = "no GIC ITS on this machine (MSI routing needs ITS + LPI)";
+
+    private static void TestGicInitialized()
+    {
+        Assert.True(GIC.IsInitialized, "GIC should be initialized");
+    }
+
+    // Runs only when the machine exposes a GICv3 ITS (gated by the caller).
+    // With the ITS up, the LPI configuration/pending tables must also be
+    // initialized; together they are the ARM64 MSI delivery path.
+    private static void TestItsLpiBroughtUp()
+    {
+        Assert.True(GICv3Its.IsInitialized, "GICv3 ITS should be initialized");
+        Assert.True(GICv3Lpi.IsInitialized, "GICv3 LPI tables should be initialized");
+    }
+
+    private static void TestMsiRoutingAvailableArm64()
+    {
+        Assert.True(MsiRouting.IsAvailable, "arm64 MSI routing (ITS binder) should be available");
+    }
+
+#endif
+}

--- a/tests/Kernels/Cosmos.Kernel.Tests.Interrupts/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Interrupts/Kernel.cs
@@ -15,18 +15,27 @@ using Cosmos.Kernel.Core.ARM64.Cpu;
 
 namespace Cosmos.Kernel.Tests.Interrupts;
 
-// Exercises the interrupt subsystem itself (no devices): the controller is up,
-// the dynamic-vector allocator behaves, and an interrupt actually fires and is
-// dispatched end-to-end. Per-arch tests cover the backend that delivers MSIs
-// (x64 LAPIC, arm64 GICv3 ITS/LPI). The NVMe MSI-X delivery path is covered
-// separately by the Storage suite.
+// Exercises the interrupt subsystem itself (no device drivers): the controller
+// is up, the dynamic MSI vector allocator behaves, and an interrupt actually
+// fires and is dispatched end-to-end. On arm64 the suite opts into the gicv2
+// and gicv3 QEMU profiles (tests/profiles.json) so BOTH interrupt-controller
+// paths are covered deterministically rather than depending on the machine
+// default. End-to-end MSI *delivery* (a device raising an MSI through the ITS)
+// stays covered by the Storage suite's NVMe assertions.
 public class Kernel : Sys.Kernel
 {
+#if !ARCH_X64
+    // The active profile-matrix cell name (bare, bare+gicv2, bare+gicv3),
+    // injected by the engine on the Limine cmdline. Drives the per-GIC-version
+    // assertions below.
+    private static string s_profile = string.Empty;
+#endif
+
     protected override void BeforeRun()
     {
         Serial.WriteString("[Interrupts] BeforeRun() reached!\n");
 
-        // 4 cross-arch + 3 arch-specific = 7 tests per architecture.
+        // 4 cross-arch + 3 arch-specific = 7 tests per cell.
         TR.Start("Interrupt System Tests", expectedTests: 7);
 
         // ==================== Cross-arch ====================
@@ -41,12 +50,30 @@ public class Kernel : Sys.Kernel
         TR.Run("Lapic_TimerCalibrated", TestLapicTimerCalibrated);
         TR.Run("Msi_RoutingAvailable", TestMsiRoutingAvailableX64);
 #else
-        // ==================== arm64 (GIC + ITS/LPI) ====================
+        // ==================== arm64 (GIC, per cell's gic-version) ====================
+        s_profile = TR.GetProfileName();
         TR.Run("Gic_Initialized", TestGicInitialized);
-        // The ITS/LPI path only exists when the machine instantiates a GICv3
-        // ITS; on an ITS-less machine these report Skipped instead of Failed.
-        TR.RunIf(GICv3Its.IsInitialized, "Its_Lpi_BroughtUp", TestItsLpiBroughtUp, NoItsReason);
-        TR.RunIf(GICv3Its.IsInitialized, "Msi_RoutingAvailable", TestMsiRoutingAvailableArm64, NoItsReason);
+
+        if (ProfileContains("gicv3"))
+        {
+            // GICv3 + ITS: the MSI delivery path must be fully up.
+            TR.Run("Its_Lpi_BroughtUp", TestItsLpiUp);
+            TR.Run("Msi_RoutingAvailable", TestMsiRoutingAvailableArm64);
+        }
+        else if (ProfileContains("gicv2"))
+        {
+            // GICv2 has no ITS, so there is no LPI/MSI path: the kernel must
+            // report it absent and fall back to polled rather than claim MSI.
+            TR.Run("Its_Lpi_BroughtUp", TestItsAbsentOnGicv2);
+            TR.Run("Msi_RoutingAvailable", TestMsiRoutingUnavailableOnGicv2);
+        }
+        else
+        {
+            // Bare cell: gic-version is whatever the machine defaults to, so the
+            // ITS/MSI state is not determinate. The gicv2/gicv3 cells assert it.
+            TR.Skip("Its_Lpi_BroughtUp", "gic-version not pinned by this cell");
+            TR.Skip("Msi_RoutingAvailable", "gic-version not pinned by this cell");
+        }
 #endif
 
         TR.Finish();
@@ -140,25 +167,55 @@ public class Kernel : Sys.Kernel
 
 #else
 
-    private const string NoItsReason = "no GIC ITS on this machine (MSI routing needs ITS + LPI)";
-
     private static void TestGicInitialized()
     {
         Assert.True(GIC.IsInitialized, "GIC should be initialized");
     }
 
-    // Runs only when the machine exposes a GICv3 ITS (gated by the caller).
-    // With the ITS up, the LPI configuration/pending tables must also be
-    // initialized; together they are the ARM64 MSI delivery path.
-    private static void TestItsLpiBroughtUp()
+    // gicv3 cell: the ITS and its LPI configuration/pending tables are the
+    // ARM64 MSI delivery path and must both be up.
+    private static void TestItsLpiUp()
     {
-        Assert.True(GICv3Its.IsInitialized, "GICv3 ITS should be initialized");
-        Assert.True(GICv3Lpi.IsInitialized, "GICv3 LPI tables should be initialized");
+        Assert.True(GICv3Its.IsInitialized, "GICv3 ITS should be initialized on a gicv3 machine");
+        Assert.True(GICv3Lpi.IsInitialized, "GICv3 LPI tables should be initialized on a gicv3 machine");
     }
 
     private static void TestMsiRoutingAvailableArm64()
     {
-        Assert.True(MsiRouting.IsAvailable, "arm64 MSI routing (ITS binder) should be available");
+        Assert.True(MsiRouting.IsAvailable, "arm64 MSI routing (ITS binder) should be available on a gicv3 machine");
+    }
+
+    // gicv2 cell: no ITS exists, so the LPI/MSI path must report absent. This
+    // is the path that forces drivers to the polled fallback.
+    private static void TestItsAbsentOnGicv2()
+    {
+        Assert.False(GICv3Its.IsInitialized, "GICv2 exposes no ITS");
+    }
+
+    private static void TestMsiRoutingUnavailableOnGicv2()
+    {
+        Assert.False(MsiRouting.IsAvailable, "GICv2 has no ITS, so MSI routing must be unavailable");
+    }
+
+    // Substring match over the cell name (the kernel runtime does not plug
+    // string.Contains). Detects the composed modifier, e.g. the "gicv2" in
+    // "bare+gicv2".
+    private static bool ProfileContains(string needle)
+    {
+        int limit = s_profile.Length - needle.Length;
+        for (int i = 0; i <= limit; i++)
+        {
+            int j = 0;
+            while (j < needle.Length && s_profile[i + j] == needle[j])
+            {
+                j++;
+            }
+            if (j == needle.Length)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
 #endif

--- a/tests/Kernels/Cosmos.Kernel.Tests.Storage/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Storage/Kernel.cs
@@ -17,11 +17,6 @@ public class Kernel : Sys.Kernel
     // [profile] prefix shows; this field just holds whatever device bound.
     private static IBlockDevice? s_dev;
 
-    // The active profile-matrix cell name, read from the Limine cmdline
-    // (profile=<name>) the engine injects. Drives the path-assertion tests
-    // so a cell proves it exercised the hardware it claims to.
-    private static string s_profile = string.Empty;
-
     // Reason surfaced through TR.RunIf when a test depends on a device
     // having actually bound. A profile whose driver did not enumerate
     // (e.g. nvme+acpi-off on arm64, where no-ACPI removes PCIe discovery)
@@ -39,7 +34,6 @@ public class Kernel : Sys.Kernel
         // 2 manager + 2 profile + 12 device + 6 partition = 22 tests per profile.
         TR.Start("Storage Block Device Tests", expectedTests: 22);
 
-        s_profile = TR.GetProfileName();
         bool hasDevice = StorageManager.DeviceCount > 0;
         s_dev = hasDevice ? StorageManager.GetDevice(0) : null;
 
@@ -53,7 +47,7 @@ public class Kernel : Sys.Kernel
         // regression pass before.
         TR.RunIf(hasDevice, "Profile_DeviceKindMatches", TestProfile_DeviceKindMatches, SkipNoDevice);
 
-        if (!ProfileHasPrefix("nvme"))
+        if (!TR.ProfileHasPrefix("nvme"))
         {
             TR.Skip("Profile_NvmeInterruptModeMatches", "not an NVMe profile");
         }
@@ -61,13 +55,13 @@ public class Kernel : Sys.Kernel
         {
             TR.Skip("Profile_NvmeInterruptModeMatches", SkipNoDevice);
         }
-        else if (ProfileContains("gicv2") || ProfileContains("gicv3"))
+        else if (TR.ProfileContains("gicv2") || TR.ProfileContains("gicv3"))
         {
             // Only the GIC-version cells pin a determinate NVMe interrupt path:
             // gicv3 brings up the ITS so MSI-X can route; gicv2 has no ITS so
             // the driver must fall back to polled. Adaptive run (Action<bool>):
             // the condition is "expect MSI-X" == this is the gicv3 cell.
-            TR.RunIf(ProfileContains("gicv3"), "Profile_NvmeInterruptModeMatches", TestProfile_NvmeInterruptMode);
+            TR.RunIf(TR.ProfileContains("gicv3"), "Profile_NvmeInterruptModeMatches", TestProfile_NvmeInterruptMode);
         }
         else
         {
@@ -142,48 +136,8 @@ public class Kernel : Sys.Kernel
     // nvme-* => NVMe. Proves the driver that bound matches the cell's intent.
     private static void TestProfile_DeviceKindMatches()
     {
-        string expected = ProfileHasPrefix("ahci") ? "SATA" : "NVMe";
+        string expected = TR.ProfileHasPrefix("ahci") ? "SATA" : "NVMe";
         Assert.Equal(expected, s_dev!.Name);
-    }
-
-    // Minimal prefix match. The kernel runtime does not plug string.StartsWith /
-    // string.Contains, and a cell name always leads with its base profile (e.g.
-    // "nvme+gicv2+acpi-off"), so a prefix check identifies the profile.
-    private static bool ProfileHasPrefix(string prefix)
-    {
-        if (s_profile.Length < prefix.Length)
-        {
-            return false;
-        }
-        for (int i = 0; i < prefix.Length; i++)
-        {
-            if (s_profile[i] != prefix[i])
-            {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    // Substring match over the cell name (the kernel runtime has no
-    // string.Contains). Detects a composed modifier such as the "gicv2" in
-    // "nvme+gicv2+acpi-off".
-    private static bool ProfileContains(string needle)
-    {
-        int limit = s_profile.Length - needle.Length;
-        for (int i = 0; i <= limit; i++)
-        {
-            int j = 0;
-            while (j < needle.Length && s_profile[i + j] == needle[j])
-            {
-                j++;
-            }
-            if (j == needle.Length)
-            {
-                return true;
-            }
-        }
-        return false;
     }
 
     // A gicv3 cell must come up MSI-X (arm64 GICv3 ITS routes it); a gicv2 cell

--- a/tests/profiles.json
+++ b/tests/profiles.json
@@ -14,6 +14,11 @@
   // [profile+modifier].
   "profiles": [
     {
+      // No devices attached. A base for non-storage suites (e.g. Interrupts)
+      // that only want machine modifiers like gic-version composed onto them.
+      "name": "bare"
+    },
+    {
       "name": "ahci",
       "disks": [
         { "type": "ahci" }


### PR DESCRIPTION
## Summary
A dedicated test suite for the interrupt subsystem itself, independent of any device driver. It gives the interrupt / MSI / GIC code (which lives in #343) direct cross-arch coverage that previously existed only indirectly, through the NVMe MSI-X path in the Storage suite.

## What it tests (7 per cell)
**Cross-arch:**
- `InterruptManager.IsEnabled`.
- A timer device is registered (the periodic IRQ source that drives the scheduler).
- The dynamic MSI vector allocator returns distinct vectors in the `[0x40, 0xFE]` window.
- End-to-end: a scheduler-blocking `Thread.Sleep(200)` resumes via the timer IRQ, timed by the free-running `Stopwatch` (TSC / CNTPCT), which does not depend on interrupts. A dead IRQ path would never wake the sleep and would time the suite out.

**x64:**
- LAPIC initialized and timer calibrated.
- `MsiRouting.IsAvailable` (LAPIC binder registered at boot).

**arm64 (runs once per GIC version):** the suite opts into the `bare` profile plus the `gicv2` / `gicv3` modifiers, so both interrupt-controller paths are exercised deterministically instead of depending on the machine default:
- Every cell: GIC initialized.
- `gicv3` cell: ITS + LPI tables up, `MsiRouting.IsAvailable`.
- `gicv2` cell: no ITS, `MsiRouting` unavailable (the polled-fallback path).
- `bare` (default) cell: gic-version not pinned, so ITS/MSI state is reported Skipped.

## Notes
- Targets `feature/storage` because the interrupt / MSI / ITS code it exercises lives there, not on `main`.
- Adds a diskless `bare` profile to `tests/profiles.json` for non-storage suites that only want machine modifiers.
- True end-to-end MSI *delivery* (a device raising an MSI through the ITS) stays covered by the Storage suite's `nvme+gicv3` assertion.
- Wired into `kernel-tests.yml` as `interrupts-tests` / `interrupts-results` and added to the summary table.
