### PR TITLE
🐛 Fix GC segment leak: sweep zero-gap stranding + TLAB free-list reuse

### DIFF
--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Alloc.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Alloc.cs
@@ -326,6 +326,58 @@ public static unsafe partial class GarbageCollector
     }
 
     /// <summary>
+    /// Removes and returns the largest free-list block of at least
+    /// <paramref name="minSize"/> bytes, taken whole (no split) and zeroed.
+    /// TLAB-refill fallback: lets refills reuse the sub-TlabSize blocks that
+    /// sweep leaves in partially live segments instead of growing the heap
+    /// with a new segment. The unused tail is stamped back to the free list
+    /// by the next <see cref="StampUnusedTlab"/> like any other TLAB gap.
+    /// </summary>
+    private static void* AllocLargestFromFreeListRaw(uint minSize, out uint blockSize)
+    {
+        blockSize = 0;
+        if (!s_freeListsInitialized)
+        {
+            return null;
+        }
+
+        for (int i = NumSizeClasses - 1; i >= 0; i--)
+        {
+            FreeBlock* prev = null;
+            FreeBlock* best = null;
+            FreeBlock* bestPrev = null;
+            for (FreeBlock* block = s_freeLists[i]; block != null; block = block->Next)
+            {
+                if ((uint)block->Size >= minSize && (best == null || block->Size > best->Size))
+                {
+                    best = block;
+                    bestPrev = prev;
+                }
+
+                prev = block;
+            }
+
+            if (best != null)
+            {
+                if (bestPrev != null)
+                {
+                    bestPrev->Next = best->Next;
+                }
+                else
+                {
+                    s_freeLists[i] = best->Next;
+                }
+
+                blockSize = (uint)best->Size;
+                MemoryOp.MemSet((byte*)best, 0, (int)blockSize);
+                return best;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Bump allocation in a segment without incrementing <see cref="s_totalAllocatedBytes"/>.
     /// Used by TLAB refill.
     /// </summary>

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.PinnedHeap.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.PinnedHeap.cs
@@ -210,7 +210,21 @@ public static unsafe partial class GarbageCollector
 
             // Validate MethodTable
             MethodTable* mt = obj->GetMethodTable();
-            if (mt == null || IsInGCHeap((nint)mt))
+            if (mt == null)
+            {
+                // Zeroed gap — dead space. Fold it into the free run so the
+                // run stays contiguous and the trailing reset can reach Bump.
+                if (freeRunStart == null)
+                {
+                    freeRunStart = ptr;
+                }
+
+                freeRunSize += (uint)sizeof(nint);
+                ptr += sizeof(nint);
+                continue;
+            }
+
+            if (IsInGCHeap((nint)mt))
             {
                 // Skip invalid objects
                 ptr += sizeof(nint);

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Sweep.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Sweep.cs
@@ -58,8 +58,19 @@ public static unsafe partial class GarbageCollector
 
             if (mt == null)
             {
-                // End of valid objects
-                break;
+                // Zeroed TLAB gap (< MinBlockSize, zeroed by StampUnusedTlab) —
+                // dead space. Fold it into the free run and keep walking:
+                // breaking here would strand everything up to Bump, so the
+                // trailing reset never fires and the segment can never be
+                // returned to the page allocator.
+                if (freeRunStart == null)
+                {
+                    freeRunStart = ptr;
+                }
+
+                freeRunSize += (uint)sizeof(nint);
+                ptr += sizeof(nint);
+                continue;
             }
 
             // Check if this is a free block from previous GC

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Tlab.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Tlab.cs
@@ -72,6 +72,19 @@ public static unsafe partial class GarbageCollector
                 return SetupTlab(ref ac, buffer, requestSize);
             }
 
+            // Fall back to the largest free-list block before growing the heap.
+            // Post-sweep blocks are always smaller than TlabSize (gap stamps and
+            // surviving objects cap them below 8192), so requiring a full-size
+            // TLAB would leave every partially live segment's free space
+            // unusable and burn a fresh segment per refill: one long-lived
+            // 26-byte string then pins 3 pages forever.
+            uint minSize = size > MinBlockSize ? size : MinBlockSize;
+            buffer = AllocLargestFromFreeListRaw(minSize, out uint blockSize);
+            if (buffer != null)
+            {
+                return SetupTlab(ref ac, buffer, blockSize);
+            }
+
             // Try slow path: walk segments, allocate new segment if needed
             buffer = AllocateObjectSlowRaw(requestSize);
             if (buffer != null)


### PR DESCRIPTION
## Problem

Running `startx` (SystemMonitor) showed used pages growing without bound (~4 MB lost in 3.5 min, ~6 pages per collection) even though every GC freed ~1,300 objects.

Diagnosed live in QEMU by driving `startx` headless, tracking `AllocPages`/`[GC]` serial output, and walking the GC segment lists from `pmemsave` heap dumps with MethodTables resolved against the kernel ELF symbols.

## Root causes (two stacked defects)

**1. Sweep stranded segments on zeroed TLAB gaps.** `StampUnusedTlab` zeroes TLAB gaps smaller than `MinBlockSize` (24 B, no room for a FreeBlock header). `SweepSegment` hit the null MethodTable word and `break`-ed, so the trailing free run never reached `Bump`, `Bump`/`UsedSize` were never reset, `isFree` never held, and `ReorderSegmentsAndFreeEmpty` never returned the segment's pages. Heap dump showed 691 segments alive, 475 of them fully dead but pinned by an 8- or 16-byte zero gap at the TLAB boundary (offsets 8176/8184).

**2. TLAB refill could not reuse partially live segments.** Post-sweep free blocks are always < 8192 B (gap stamps and surviving objects split them), but `RefillAllocContext` only accepted full-`TlabSize` blocks — so a segment holding *any* live object contributed nothing, and every refill burned a fresh 3-page segment. Long-lived small objects (e.g. CoreLib's `Number.s_smallNumberCache` entries, populated by the monitor drawing values 0–299) each condemned 3 pages for a 26-byte string (~×470 amplification), leaving a residual leak of ~1 segment/min after fix 1.

## Fixes

- `SweepSegment`/`SweepPinnedSegment`: fold null-MT words into the current free run and keep walking, so runs stay contiguous, the trailing reset fires, and fully dead segments return to the page allocator.
- `RefillAllocContext`: before growing the heap, fall back to the largest free-list block ≥ `max(size, MinBlockSize)` taken whole as a smaller TLAB (`AllocLargestFromFreeListRaw`); the unused tail is stamped back like any TLAB gap.

## Verification

After fix 1, the same `startx` run went from 691 stuck segments to a stable ~30, with fully dead segments returned each GC; residual growth dropped from ~5 pages/s to ~0.05 pages/s, and heap dumps attribute the remainder to the free-block reuse gap that fix 2 closes.

## Related findings (not in this PR)

- `ScanStaticRoots` is disabled: static-only-referenced objects (Number cache, AppContext dictionaries, 274 static slots pointing into the heap) survive only via stale conservative-scan slots in parked-thread stacks — collection of live static data is possible.
- Inverted MethodTable validation in `SweepSmallHeap`/`SweepMediumHeap`/`SweepLargeHeap` (checks `!IsInGCHeap` where the comment says the opposite).
- `FlushPinnedFreeRun` adds pinned free runs to the regular free list despite its doc comment.