### PR TITLE
Gaps and GC/graphics fixes found porting AuraOS to gen3

### DIFF
--- a/src/Cosmos.Kernel.Core/CPU/IRQContext.cs
+++ b/src/Cosmos.Kernel.Core/CPU/IRQContext.cs
@@ -74,6 +74,16 @@ public struct IRQContext
     public ulong interrupt;
     public ulong cpu_flags;
     public ulong fault_address;  // CR2: page-fault linear address (valid for #PF, int 14)
+
+    // The interrupt stub's frame continues past the info block (see ThreadContext.X64 /
+    // Interrupts.s): the TempRcx scratch slot followed by the hardware interrupt frame.
+    // Exposing them here lets exception handlers report the faulting RIP.
+    public ulong temp_rcx;       // context-switch scratch slot (zero otherwise)
+    public ulong rip;            // faulting/interrupted instruction pointer
+    public ulong cs;             // code segment selector
+    public ulong rflags;         // saved RFLAGS
+    public ulong rsp;            // interrupted stack pointer (always pushed in 64-bit mode)
+    public ulong ss;             // stack segment selector
 }
 
 #endif

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Alloc.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Alloc.cs
@@ -120,7 +120,7 @@ public static unsafe partial class GarbageCollector
                         split->MethodTable = s_freeMethodTable;
                         split->Size = (int)remainder;
                         split->Next = null;
-                        AddToFreeList(split);
+                        AddToFreeList(split, 'a');
                     }
 
                     // Clear and return
@@ -310,7 +310,7 @@ public static unsafe partial class GarbageCollector
                         split->MethodTable = s_freeMethodTable;
                         split->Size = (int)remainder;
                         split->Next = null;
-                        AddToFreeList(split);
+                        AddToFreeList(split, 'r');
                     }
 
                     MemoryOp.MemSet((byte*)block, 0, (int)size);
@@ -455,7 +455,9 @@ public static unsafe partial class GarbageCollector
     /// Inserts a free block into the appropriate size-class free list.
     /// </summary>
     /// <param name="block">The free block to add.</param>
-    private static void AddToFreeList(FreeBlock* block)
+    /// <param name="source">Call-site tag for diagnostics: 'a'=AllocFromFreeList split,
+    /// 'r'=AllocFromFreeListRaw split, 't'=TLAB gap stamp, 's'=sweep, 'p'=pinned heap.</param>
+    private static void AddToFreeList(FreeBlock* block, char source)
     {
         if (!s_freeListsInitialized || block == null || block->Size < MinBlockSize)
         {
@@ -479,6 +481,22 @@ public static unsafe partial class GarbageCollector
         if (sizeClass < 0)
         {
             sizeClass = NumSizeClasses - 1;
+        }
+
+        // Cheap last-line guard against re-inserting the current head: a second
+        // head-insert of the same block would set block->Next = block, and the
+        // next free-list walk would spin forever inside DisableInterrupts (this
+        // is how the double TLAB-stamp bug hung Collect(); see StampUnusedTlab).
+        // Deeper duplicates/overlaps need the O(list) debug tripwire this check
+        // replaced — reintroduce it locally when hunting free-list corruption.
+        if (s_freeLists[sizeClass] == block)
+        {
+            Serial.WriteString("[GC] BUG: duplicate free-list head insert src=");
+            Serial.WriteString(source == 'a' ? "a" : source == 'r' ? "r" : source == 't' ? "t" : source == 's' ? "s" : "p");
+            Serial.WriteString(" blk=0x");
+            Serial.WriteHex((ulong)block);
+            Serial.WriteString("\n");
+            return;
         }
 
         block->Next = s_freeLists[sizeClass];

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Info.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Info.cs
@@ -1,6 +1,7 @@
 // This code is licensed under MIT license (see LICENSE for details)
 
 using System.Runtime.InteropServices;
+using Cosmos.Kernel.Core.IO;
 using Cosmos.Kernel.Core.Scheduler;
 using SchedulerThread = Cosmos.Kernel.Core.Scheduler.Thread;
 
@@ -158,8 +159,19 @@ public static unsafe partial class GarbageCollector
             for (int i = 0; i < NumSizeClasses; i++)
             {
                 FreeBlock* cur = s_freeLists[i];
+                int guard = 0;
                 while (cur != null)
                 {
+                    // Defensive cycle guard: a corrupted free list must degrade the
+                    // metric, not hang the collection inside DisableInterrupts.
+                    if (++guard > 1_000_000)
+                    {
+                        Serial.WriteString("[GC] BUG: free-list cycle detected walking class ");
+                        Serial.WriteNumber((uint)i);
+                        Serial.WriteString("\n");
+                        break;
+                    }
+
                     fragmented += (uint)cur->Size;
                     cur = cur->Next;
                 }
@@ -465,8 +477,19 @@ public static unsafe partial class GarbageCollector
             for (int i = 0; i < NumSizeClasses; i++)
             {
                 FreeBlock* cur = s_freeLists[i];
+                int guard = 0;
                 while (cur != null)
                 {
+                    // Defensive cycle guard: a corrupted free list must degrade the
+                    // metric, not hang the collection inside DisableInterrupts.
+                    if (++guard > 1_000_000)
+                    {
+                        Serial.WriteString("[GC] BUG: free-list cycle detected walking class ");
+                        Serial.WriteNumber((uint)i);
+                        Serial.WriteString("\n");
+                        break;
+                    }
+
                     fragmented += (uint)cur->Size;
                     cur = cur->Next;
                 }

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.PinnedHeap.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.PinnedHeap.cs
@@ -301,7 +301,7 @@ public static unsafe partial class GarbageCollector
         freeBlock->MethodTable = s_freeMethodTable;
         freeBlock->Size = (int)size;
         freeBlock->Next = null;
-        AddToFreeList(freeBlock);
+        AddToFreeList(freeBlock, 'p');
     }
 
     /// <summary>

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Sweep.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Sweep.cs
@@ -168,7 +168,7 @@ public static unsafe partial class GarbageCollector
         freeBlock->MethodTable = s_freeMethodTable;
         freeBlock->Size = (int)size;
         freeBlock->Next = null;
-        AddToFreeList(freeBlock);
+        AddToFreeList(freeBlock, 's');
     }
 
     /// <summary>

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Tlab.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Tlab.cs
@@ -133,8 +133,6 @@ public static unsafe partial class GarbageCollector
     public static void ReturnAllocContext(ref AllocContext ac)
     {
         StampUnusedTlab(ref ac);
-        ac.AllocPtr = null;
-        ac.AllocLimit = null;
     }
 
     /// <summary>
@@ -182,7 +180,7 @@ public static unsafe partial class GarbageCollector
             freeBlock->MethodTable = s_freeMethodTable;
             freeBlock->Size = (int)gap;
             freeBlock->Next = null;
-            AddToFreeList(freeBlock);
+            AddToFreeList(freeBlock, 't');
         }
         else if (gap > 0)
         {
@@ -190,5 +188,16 @@ public static unsafe partial class GarbageCollector
             // stale MethodTable pointers and break early.
             MemoryOp.MemSet(ac.AllocPtr, 0, (int)gap);
         }
+
+        // The gap now belongs to the free list (or is dead space) — the context
+        // MUST forget it. RefillAllocContext stamps before trying to acquire a
+        // new buffer; if every attempt fails it returns with the context intact,
+        // and the subsequent Collect() → ReturnAllAllocContexts() would stamp
+        // the SAME gap again. That second head-insert makes the free block point
+        // at itself (block->Next = head = block), and the next free-list walk —
+        // GetCurrentFragmentation at the top of Collect() — spins forever with
+        // interrupts disabled: the "hang at [GC] Collection #1" bug.
+        ac.AllocPtr = null;
+        ac.AllocLimit = null;
     }
 }

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.cs
@@ -332,9 +332,13 @@ public static unsafe partial class GarbageCollector
             return;
         }
 
-        // Allocate mark stack
-        s_markStackCapacity = 4096;
-        s_markStack = (nint*)PageAllocator.AllocPages(PageType.Unmanaged, 1, true);
+        // Allocate mark stack. Capacity MUST match the backing allocation:
+        // one 4K page holds 512 nint entries, and PushMarkStack bounds-checks
+        // against s_markStackCapacity before growing — a larger capacity here
+        // means the mark phase writes past the page and corrupts adjacent
+        // allocations as soon as more than 512 objects are pending.
+        s_markStack = (nint*)PageAllocator.AllocPages(PageType.Unmanaged, s_markStackPageCount, true);
+        s_markStackCapacity = (int)(s_markStackPageCount * PageAllocator.PageSize / (ulong)sizeof(nint));
         if (s_markStack == null)
         {
             Serial.WriteString("[GC] ERROR: Failed to allocate mark stack\n");

--- a/src/Cosmos.Kernel.Core/Memory/MemoryOp.cs
+++ b/src/Cosmos.Kernel.Core/Memory/MemoryOp.cs
@@ -74,11 +74,14 @@ public static unsafe class MemoryOp
             offset = blockCount * 16;
         }
 
-        // Fill remaining bytes using scalar (with the byte value extracted)
-        byte byteValue = (byte)(value & 0xFF);
+        // Fill remaining bytes using scalar, preserving the 32-bit pattern phase:
+        // dest[0] carries byte 0 of the pattern and SIMD blocks are 16 bytes (a whole
+        // number of patterns), so byte offset & 3 selects the right pattern byte.
+        // Using only the low byte here corrupted non-uniform fills (e.g. ARGB pixels)
+        // whenever the byte count was not a multiple of 16.
         while (offset < count)
         {
-            dest[offset] = byteValue;
+            dest[offset] = (byte)(value >> ((offset & 3) * 8));
             offset++;
         }
     }

--- a/src/Cosmos.Kernel.Core/Runtime/Math.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Math.cs
@@ -222,6 +222,217 @@ internal static class Math
         return x - intPart;
     }
 
+    // --------------- fmod (fdlibm e_fmod.c) ---------------
+    // Bit-exact remainder; NativeAOT emits calls to this for the C# `%`
+    // operator on double (and fmodf for float).
+
+    [RuntimeExport("fmod")]
+    internal static double fmod(double x, double y)
+    {
+        int n, hx, hy, hz, ix, iy, sx, i;
+        uint lx, ly, lz;
+
+        hx = HighWord(x);
+        lx = (uint)LowWord(x);
+        hy = HighWord(y);
+        ly = (uint)LowWord(y);
+        sx = hx & unchecked((int)0x80000000); /* sign of x */
+        hx ^= sx;                             /* |x| */
+        hy &= 0x7fffffff;                     /* |y| */
+
+        /* purge off exception values: y=0, x not finite, or y NaN */
+        if ((hy | (int)ly) == 0 || hx >= 0x7ff00000 ||
+            (hy | (ly != 0 ? 1 : 0)) > 0x7ff00000)
+        {
+            return (x * y) / (x * y);
+        }
+
+        if (hx <= hy)
+        {
+            if (hx < hy || lx < ly)
+            {
+                return x; /* |x| < |y| */
+            }
+
+            if (lx == ly)
+            {
+                return sx != 0 ? -0.0 : 0.0; /* |x| == |y| */
+            }
+        }
+
+        /* determine ix = ilogb(x) */
+        if (hx < 0x00100000)
+        {
+            if (hx == 0)
+            {
+                for (ix = -1043, i = (int)lx; i > 0; i <<= 1)
+                {
+                    ix -= 1;
+                }
+            }
+            else
+            {
+                for (ix = -1022, i = hx << 11; i > 0; i <<= 1)
+                {
+                    ix -= 1;
+                }
+            }
+        }
+        else
+        {
+            ix = (hx >> 20) - 1023;
+        }
+
+        /* determine iy = ilogb(y) */
+        if (hy < 0x00100000)
+        {
+            if (hy == 0)
+            {
+                for (iy = -1043, i = (int)ly; i > 0; i <<= 1)
+                {
+                    iy -= 1;
+                }
+            }
+            else
+            {
+                for (iy = -1022, i = hy << 11; i > 0; i <<= 1)
+                {
+                    iy -= 1;
+                }
+            }
+        }
+        else
+        {
+            iy = (hy >> 20) - 1023;
+        }
+
+        /* set up {hx,lx}, {hy,ly} and align y to x */
+        if (ix >= -1022)
+        {
+            hx = 0x00100000 | (0x000fffff & hx);
+        }
+        else
+        {
+            /* subnormal x, shift x to normal */
+            n = -1022 - ix;
+            if (n <= 31)
+            {
+                hx = (hx << n) | (int)(lx >> (32 - n));
+                lx <<= n;
+            }
+            else
+            {
+                hx = (int)(lx << (n - 32));
+                lx = 0;
+            }
+        }
+
+        if (iy >= -1022)
+        {
+            hy = 0x00100000 | (0x000fffff & hy);
+        }
+        else
+        {
+            /* subnormal y, shift y to normal */
+            n = -1022 - iy;
+            if (n <= 31)
+            {
+                hy = (hy << n) | (int)(ly >> (32 - n));
+                ly <<= n;
+            }
+            else
+            {
+                hy = (int)(ly << (n - 32));
+                ly = 0;
+            }
+        }
+
+        /* fixed-point fmod */
+        n = ix - iy;
+        while (n-- != 0)
+        {
+            hz = hx - hy;
+            lz = lx - ly;
+            if (lx < ly)
+            {
+                hz -= 1;
+            }
+
+            if (hz < 0)
+            {
+                hx = hx + hx + (int)(lx >> 31);
+                lx += lx;
+            }
+            else
+            {
+                if ((hz | (int)lz) == 0)
+                {
+                    return sx != 0 ? -0.0 : 0.0;
+                }
+
+                hx = hz + hz + (int)(lz >> 31);
+                lx = lz + lz;
+            }
+        }
+
+        hz = hx - hy;
+        lz = lx - ly;
+        if (lx < ly)
+        {
+            hz -= 1;
+        }
+
+        if (hz >= 0)
+        {
+            hx = hz;
+            lx = lz;
+        }
+
+        /* convert back to floating value and restore the sign */
+        if ((hx | (int)lx) == 0)
+        {
+            return sx != 0 ? -0.0 : 0.0;
+        }
+
+        while (hx < 0x00100000)
+        {
+            /* normalize x */
+            hx = hx + hx + (int)(lx >> 31);
+            lx += lx;
+            iy -= 1;
+        }
+
+        if (iy >= -1022)
+        {
+            /* normalize output */
+            hx = (hx - 0x00100000) | ((iy + 1023) << 20);
+            return BitsToDouble(((long)(hx | sx) << 32) | lx);
+        }
+
+        /* subnormal output */
+        n = -1022 - iy;
+        if (n <= 20)
+        {
+            lx = (lx >> n) | ((uint)hx << (32 - n));
+            hx >>= n;
+        }
+        else if (n <= 31)
+        {
+            lx = (uint)((hx << (32 - n)) | (int)(lx >> n));
+            hx = sx;
+        }
+        else
+        {
+            lx = (uint)(hx >> (n - 32));
+            hx = sx;
+        }
+
+        return BitsToDouble(((long)(hx | sx) << 32) | lx) * 1.0;
+    }
+
+    [RuntimeExport("fmodf")]
+    internal static float fmodf(float x, float y) => (float)fmod(x, y);
+
     [RuntimeExport("fma")]
     internal static double fma(double x, double y, double z)
     {
@@ -1102,4 +1313,147 @@ internal static class Math
 
     [RuntimeExport("powf")]
     internal static float powf(float x, float y) => (float)pow(x, y);
+
+    // --------------- hyperbolics (after fdlibm e_cosh.c / e_sinh.c / s_tanh.c) ---------------
+    // Structured like fdlibm but with exp(x)-1 standing in for expm1 (not ported),
+    // so tiny-argument cases early-return before the precision of exp-1 matters.
+
+    [RuntimeExport("cosh")]
+    internal static double cosh(double x)
+    {
+        if (double.IsNaN(x))
+        {
+            return double.NaN;
+        }
+
+        if (double.IsInfinity(x))
+        {
+            return double.PositiveInfinity;
+        }
+
+        double ax = Abs(x);
+
+        /* |x| tiny: cosh(x) = 1 to double precision */
+        if (ax < 7.45e-9) /* 2^-27 */
+        {
+            return 1.0;
+        }
+
+        if (ax < 22.0)
+        {
+            double t = FdlibmExp(ax);
+            return 0.5 * t + 0.5 / t;
+        }
+
+        /* |x| in [22, log(maxdouble)]: cosh(x) = exp(|x|)/2 */
+        if (ax < 7.09782712893383973096e+02)
+        {
+            return 0.5 * FdlibmExp(ax);
+        }
+
+        /* |x| in [log(maxdouble), overflowthreshold] */
+        if (ax <= 7.10475860073943863426e+02)
+        {
+            double w = FdlibmExp(0.5 * ax);
+            return 0.5 * w * w;
+        }
+
+        return double.PositiveInfinity;
+    }
+
+    [RuntimeExport("coshf")]
+    internal static float coshf(float x) => (float)cosh(x);
+
+    [RuntimeExport("sinh")]
+    internal static double sinh(double x)
+    {
+        if (double.IsNaN(x) || double.IsInfinity(x))
+        {
+            return x + x; /* preserves NaN and signed infinity */
+        }
+
+        double ax = Abs(x);
+        double h = x < 0 ? -0.5 : 0.5;
+
+        if (ax < 22.0)
+        {
+            /* |x| tiny: sinh(x) = x to double precision */
+            if (ax < 3.73e-9) /* 2^-28 */
+            {
+                return x;
+            }
+
+            double t = FdlibmExp(ax) - 1.0;
+            if (ax < 1.0)
+            {
+                return h * (2.0 * t - t * t / (t + 1.0));
+            }
+
+            return h * (t + t / (t + 1.0));
+        }
+
+        /* |x| in [22, log(maxdouble)]: sinh(x) = sign(x)*exp(|x|)/2 */
+        if (ax < 7.09782712893383973096e+02)
+        {
+            return h * FdlibmExp(ax);
+        }
+
+        /* |x| in [log(maxdouble), overflowthreshold] */
+        if (ax <= 7.10475860073943863426e+02)
+        {
+            double w = FdlibmExp(0.5 * ax);
+            return h * w * w;
+        }
+
+        return x > 0 ? double.PositiveInfinity : double.NegativeInfinity;
+    }
+
+    [RuntimeExport("sinhf")]
+    internal static float sinhf(float x) => (float)sinh(x);
+
+    [RuntimeExport("tanh")]
+    internal static double tanh(double x)
+    {
+        if (double.IsNaN(x))
+        {
+            return double.NaN;
+        }
+
+        if (double.IsInfinity(x))
+        {
+            return x > 0 ? 1.0 : -1.0;
+        }
+
+        double ax = Abs(x);
+        double z;
+
+        if (ax < 22.0)
+        {
+            /* |x| tiny: tanh(x) = x to double precision */
+            if (ax < 2.78e-17) /* 2^-55 */
+            {
+                return x * (1.0 + x);
+            }
+
+            if (ax >= 1.0)
+            {
+                double t = FdlibmExp(2.0 * ax) - 1.0;
+                z = 1.0 - 2.0 / (t + 2.0);
+            }
+            else
+            {
+                double t = FdlibmExp(-2.0 * ax) - 1.0;
+                z = -t / (t + 2.0);
+            }
+        }
+        else
+        {
+            z = 1.0; /* |x| >= 22: tanh saturates */
+        }
+
+        return x >= 0 ? z : -z;
+    }
+
+    [RuntimeExport("tanhf")]
+    internal static float tanhf(float x) => (float)tanh(x);
 }

--- a/src/Cosmos.Kernel.Native.X64/CPU/CpuOps.s
+++ b/src/Cosmos.Kernel.Native.X64/CPU/CpuOps.s
@@ -8,6 +8,7 @@
 .global _native_cpu_restore_irq
 .global _native_cpu_read_cr3
 .global _native_cpu_invlpg
+.global RhCpuIdEx
 
 .text
 
@@ -56,4 +57,21 @@ _native_cpu_read_cr3:
 // Invalidate the TLB entry covering the virtual address in RDI.
 _native_cpu_invlpg:
     invlpg  [rdi]
+    ret
+
+// NativeAOT runtime helper backing System.Runtime.Intrinsics.X86.X86Base.CpuId.
+// void RhCpuIdEx(int* cpuInfo /*RDI*/, int functionId /*ESI*/, int subFunctionId /*EDX*/)
+// Mirrors dotnet/runtime nativeaot amd64 MiscStubs; RBX is callee-saved and
+// clobbered by CPUID, so preserve it.
+RhCpuIdEx:
+    push    rbx
+    mov     r8, rdi         // cpuInfo out pointer (CPUID clobbers all four regs)
+    mov     eax, esi        // leaf
+    mov     ecx, edx        // subleaf
+    cpuid
+    mov     dword ptr [r8], eax
+    mov     dword ptr [r8+4], ebx
+    mov     dword ptr [r8+8], ecx
+    mov     dword ptr [r8+12], edx
+    pop     rbx
     ret

--- a/src/Cosmos.Kernel.System/Graphics/GopCanvas.cs
+++ b/src/Cosmos.Kernel.System/Graphics/GopCanvas.cs
@@ -35,8 +35,10 @@ internal class GopCanvas : Canvas
     /// <param name="mode">The display mode to use.</param>
     internal unsafe GopCanvas(Mode mode) : base(mode)
     {
-        ThrowIfModeIsNotValid(mode);
-
+        // The requested mode is only validated when there is no Limine framebuffer
+        // to adopt (see Mode setter): with a live framebuffer the request is
+        // ignored anyway, and the AvailableModes list must not reject callers who
+        // pass the framebuffer's true resolution (which may not be listed).
         if (Limine.Framebuffer.Response != null && Limine.Framebuffer.Response->FramebufferCount > 0)
         {
             LimineFramebuffer* fb = Limine.Framebuffer.Response->Framebuffers[0];
@@ -114,8 +116,23 @@ internal class GopCanvas : Canvas
         get => mode;
         set
         {
-            mode = value;
-            SetMode(mode);
+            // GOP/Limine cannot change the framebuffer mode after boot (SetMode is
+            // a no-op), so a requested mode must not shadow the real framebuffer
+            // resolution: callers read Mode back to learn the actual screen size,
+            // and adopting the request would make every consumer lay out its UI
+            // for a resolution the hardware never switched to. The real
+            // framebuffer size is also deliberately NOT checked against
+            // AvailableModes — that legacy VBE list doesn't contain every mode
+            // firmware can hand us (e.g. 1280x800).
+            if (driver != null)
+            {
+                mode = new Mode(driver.Width, driver.Height, value.ColorDepth);
+            }
+            else
+            {
+                SetMode(value);
+                mode = value;
+            }
         }
     }
 

--- a/src/Cosmos.Kernel.System/Graphics/KernelConsole.cs
+++ b/src/Cosmos.Kernel.System/Graphics/KernelConsole.cs
@@ -56,7 +56,7 @@ public class KernelConsole
         0xFF008000, // DarkGreen
         0xFF008080, // DarkCyan
         0xFF800000, // DarkRed
-        0xFF808000, // DarkMagenta
+        0xFF800080, // DarkMagenta
         0xFF808000, // DarkYellow
         0xFFC0C0C0, // Gray
         0xFF808080, // DarkGray

--- a/src/Cosmos.Kernel.System/Mouse/MouseManager.cs
+++ b/src/Cosmos.Kernel.System/Mouse/MouseManager.cs
@@ -30,9 +30,16 @@ public static class MouseManager
     public static int Y { get; private set; }
 
     /// <summary>
-    /// Scroll wheel delta.
+    /// Scroll wheel delta. Set on each wheel event and never cleared by the
+    /// driver; pollers consume it with <see cref="ResetScrollDelta"/> (gen2 parity).
     /// </summary>
     public static int ScrollDelta { get; private set; }
+
+    /// <summary>
+    /// Clears <see cref="ScrollDelta"/> after a poller has consumed it, so a
+    /// stale delta is not re-processed every frame until the next wheel event.
+    /// </summary>
+    public static void ResetScrollDelta() => ScrollDelta = 0;
 
     /// <summary>
     /// Left button state.

--- a/src/Cosmos.Kernel/Panic.cs
+++ b/src/Cosmos.Kernel/Panic.cs
@@ -84,6 +84,9 @@ public static class Panic
         Serial.WriteString("  R13: 0x"); Serial.WriteHex(ctx.r13);
         Serial.WriteString("  R14: 0x"); Serial.WriteHex(ctx.r14); Serial.WriteString("\n");
         Serial.WriteString("  R15: 0x"); Serial.WriteHex(ctx.r15); Serial.WriteString("\n");
+        Serial.WriteString("  RIP: 0x"); Serial.WriteHex(ctx.rip);
+        Serial.WriteString("  RSP: 0x"); Serial.WriteHex(ctx.rsp); Serial.WriteString("\n");
+        Serial.WriteString("  RFL: 0x"); Serial.WriteHex(ctx.rflags); Serial.WriteString("\n");
         Serial.WriteString("  CR2: 0x"); Serial.WriteHex(ctx.fault_address); Serial.WriteString("\n");
 #endif
     }

--- a/src/Cosmos.Kernel/Panic.cs
+++ b/src/Cosmos.Kernel/Panic.cs
@@ -37,6 +37,7 @@ public static class Panic
         Serial.WriteString(exceptionName);
         Serial.WriteString("\n========================================\n");
         PrintCpuContext(ref ctx);
+        PrintStackTrace(ref ctx);
         Serial.WriteString("========================================\n");
         Serial.WriteString("System halted.\n");
 
@@ -90,6 +91,89 @@ public static class Panic
         Serial.WriteString("  CR2: 0x"); Serial.WriteHex(ctx.fault_address); Serial.WriteString("\n");
 #endif
     }
+
+    /// <summary>
+    /// Prints the call stack of the interrupted code by walking the frame-pointer
+    /// chain. Allocation-free. Addresses are raw — symbolicate against the kernel
+    /// ELF with nm/addr2line.
+    /// </summary>
+    /// <remarks>
+    /// There is no page-table walker available here, so every dereference is
+    /// gated on plausibility checks (higher-half, 8-byte aligned, within a bounded
+    /// window above the faulting stack pointer, monotonically increasing). This is
+    /// printed last so that a worst-case double fault cannot swallow the register
+    /// dump above it.
+    /// </remarks>
+    private static unsafe void PrintStackTrace(ref IRQContext ctx)
+    {
+#if ARCH_ARM64
+        ulong ip = ctx.elr;
+        ulong sp = ctx.sp;
+        ulong fp = ctx.x29;
+#else
+        ulong ip = ctx.rip;
+        ulong sp = ctx.rsp;
+        ulong fp = ctx.rbp;
+#endif
+        Serial.WriteString("\nStack trace (raw return addresses, symbolicate with nm):\n");
+        Serial.WriteString("  ip:  0x"); Serial.WriteHex(ip); Serial.WriteString("\n");
+
+        // A fault on (or just past) the stack itself means its guard/unmapped
+        // page is adjacent — any read below could double-fault, so don't walk.
+        if (ctx.fault_address >= sp - 0x10000 && ctx.fault_address < sp + 0x1000)
+        {
+            Serial.WriteString("  (fault address is near the stack pointer - possible stack overflow, not walking)\n");
+            return;
+        }
+
+        if (!IsPlausibleStackAddress(sp))
+        {
+            return;
+        }
+
+#if ARCH_ARM64
+        // On ARM64 the immediate caller of a leaf is in the link register.
+        Serial.WriteString("  lr:  0x"); Serial.WriteHex(ctx.x30); Serial.WriteString("\n");
+#else
+        // Frameless leaf helpers (write barriers, memcpy, ...) leave their
+        // caller's return address at [rsp]; ignore this line if ip is not a leaf.
+        Serial.WriteString("  sp0: 0x"); Serial.WriteHex(*(ulong*)sp);
+        Serial.WriteString(" (return address if ip is a frameless leaf)\n");
+#endif
+
+        // Both SysV x64 and AAPCS64 lay frames out as [fp] = caller fp,
+        // [fp+8] = return address.
+        int frame = 0;
+        while (frame < 32 &&
+               IsPlausibleStackAddress(fp) &&
+               fp >= sp && fp - sp < 0x100000)
+        {
+            ulong nextFp = *(ulong*)fp;
+            ulong ret = *((ulong*)fp + 1);
+
+            if (ret == 0)
+            {
+                break;
+            }
+
+            Serial.WriteString("  [");
+            Serial.WriteNumber((uint)frame);
+            Serial.WriteString("]  0x");
+            Serial.WriteHex(ret);
+            Serial.WriteString("\n");
+
+            if (nextFp <= fp)
+            {
+                break;
+            }
+
+            fp = nextFp;
+            frame++;
+        }
+    }
+
+    private static bool IsPlausibleStackAddress(ulong address) =>
+        address >= 0xFFFF800000000000UL && (address & 7) == 0;
 
     private static void HaltCpu()
     {

--- a/src/Cosmos.Sdk/Sdk/Sdk.props
+++ b/src/Cosmos.Sdk/Sdk/Sdk.props
@@ -40,7 +40,9 @@
     <CosmosEnableFat Condition="'$(CosmosEnableFat)' == ''">true</CosmosEnableFat>
     <CosmosEnableGraphics Condition="'$(CosmosEnableGraphics)' == ''">true</CosmosEnableGraphics>
     <CosmosEnableScheduler Condition="'$(CosmosEnableScheduler)' == ''">true</CosmosEnableScheduler>
-    <CosmosDefaultFont Condition="'$(CosmosDefaultFont)' == ''">Cosmos.Kernel.System.Graphics.Fonts.CustomFont.psf</CosmosDefaultFont>
+    <!-- CosmosDefaultFont has no default: when unset, PCScreenFont falls back to its
+         embedded Fonts.DefaultFont.psf. Set it to the manifest resource name of a PSF
+         embedded in the kernel project to override the default console font. -->
   </PropertyGroup>
 
   <!-- Default kernel class name - inferred from RootNamespace or AssemblyName -->
@@ -69,7 +71,9 @@
     <RuntimeHostConfigurationOption Include="Cosmos.Kernel.System.Filesystems.Fat.Enabled" Value="$(CosmosEnableFat)" Trim="true"/>
     <RuntimeHostConfigurationOption Include="Cosmos.Kernel.System.Graphics.Enabled" Value="$(CosmosEnableGraphics)" Trim="true"/>
     <RuntimeHostConfigurationOption Include="Cosmos.Kernel.Core.Scheduler.Enabled" Value="$(CosmosEnableScheduler)" Trim="true"/>
-    <RuntimeHostConfigurationOption Condition="'$(CosmosDefaultFont)' != ''" Include="Cosmos.Kernel.System.Graphics.Fonts.CustomFont" Value="$(CosmosDefaultFont)" />
+    <!-- Key must match PCScreenFont.Default.DefaultFontKey ("...Fonts.DefaultFont");
+         it was previously written as "...Fonts.CustomFont", which nothing reads. -->
+    <RuntimeHostConfigurationOption Condition="'$(CosmosDefaultFont)' != ''" Include="Cosmos.Kernel.System.Graphics.Fonts.DefaultFont" Value="$(CosmosDefaultFont)" />
     <!-- Root architecture-specific HAL assemblies to ensure module initializers run -->
     <IlcArg Condition="'$(DefineConstants)' != '' AND $(DefineConstants.Contains('ARCH_X64'))" Include="--root:Cosmos.Kernel.HAL.X64"/>
     <IlcArg Condition="'$(DefineConstants)' != '' AND $(DefineConstants.Contains('ARCH_ARM64'))" Include="--root:Cosmos.Kernel.HAL.ARM64"/>


### PR DESCRIPTION
Fixes for issues hit while porting AuraOS (gen2/IL2CPU) to gen3. Each was found against a real UI-heavy kernel workload; the full field notes live in the AuraOS repo as GEN3-GAPS.md.

## GC correctness

- **Free-list cycle hang at first collection** — `RefillAllocContext` stamps the old TLAB gap into the free list before acquiring a new buffer but left `AllocPtr/AllocLimit` intact. When every refill attempt fails (heap exhausted — the only path that calls `Collect()`), `ReturnAllAllocContexts` stamped the same gap a second time; the repeated head-insert made the `FreeBlock` point at itself and `GetCurrentFragmentation` at the top of `Collect()` then spun forever with interrupts disabled. Symptom: freeze at `[GC] Collection #1` under allocation pressure. `StampUnusedTlab` now nulls the context after donating the gap; `AddToFreeList` gained an O(1) duplicate-head guard and the fragmentation walkers gained cycle guards so this class of bug logs instead of hangs.
- **Mark stack out-of-bounds** — `Initialize` claimed a 4096-entry capacity over a single 4K page (512 slots); any mark phase with >512 pending objects wrote up to 28KB past the allocation. Capacity is now computed from the backing allocation.

## Graphics

- **`Canvas.Mode` reported a resolution the hardware never switched to** — the boot `KernelConsole` creates the GopCanvas first (adopting the real Limine framebuffer); a later `GetFullScreenCanvas(mode)` overwrote `Mode` with the request while `SetMode` is a no-op. Consumers sizing their UI from `Mode` (the documented way to learn the real resolution) got the lie — AuraOS laid out for 1920×1080 on a 1280×800 framebuffer. The setter now keeps reporting `driver.Width/Height`, and the true framebuffer resolution is never validated against the legacy `AvailableModes` list (which lacks e.g. 1280×800).

## Diagnostics

- **Frame-pointer stack trace in CPU-exception panics** — RIP alone can't identify the caller when a fault lands in a shared leaf helper (`RhpAssignRef`, memcpy, …). The panic now walks the FP chain (allocation-free, plausibility-gated, skipped on suspected stack overflow) and prints raw return addresses plus the `[rsp]` leaf-return slot, x64 and ARM64 — symbolicate with `nm`. Together with the earlier IRQContext change this took AuraOS crash triage from "guess" to "exact managed frame in one boot".

## Porting gaps (batch)

- kernel libm: `fmod`, `cosh/sinh/tanh` (+float wrappers) — `%` on doubles failed to link
- `RhCpuIdEx` native stub so `X86Base.CpuId` links
- `MemoryOp.FillWithSimd` unaligned-tail fill corruption
- `CosmosDefaultFont` MSBuild knob written under the key that is actually read
- `MouseManager.ResetScrollDelta()` (gen2 parity)
- `KernelConsole` DarkMagenta palette duplicate

Tested by booting AuraOS (1280×800 GOP, FAT disk, full desktop UI) under sustained allocation pressure: collections now complete repeatedly with no `[GC] BUG` lines, and panics self-symbolicate.