### PR TITLE
GC soundness tests, ConditionVariable lost-wakeup fix, EH boundary hardening, release hygiene

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,10 @@ jobs:
             ### Quick Start
 
             - [Installation guide](https://valentinbreiz.github.io/nativeaot-patcher/articles/user/install.html)
+          # Append the auto-generated changelog (merged PRs / commits since the
+          # previous tag) below the download table — releases had no change
+          # description at all before this.
+          generate_release_notes: true
           draft: false
           prerelease: false
           files: |

--- a/docs/articles/user/debugging.md
+++ b/docs/articles/user/debugging.md
@@ -1,12 +1,41 @@
-# Debugging with VSCode and QEMU
+# Debugging with VS Code and QEMU
 
-## Setting Up Debugging
+Kernel debugging uses remote GDB: QEMU exposes a GDB server on `localhost:1234`, VS Code connects to it with `cppdbg`, and breakpoints are set directly in the editor. The `cosmos new` template ships the required `.vscode/launch.json` and `.vscode/tasks.json` preconfigured.
 
-Debugging the kernel with VSCode and QEMU uses remote GDB debugging. Breakpoints can be set directly in the editor as with any standard debugging session.
+---
 
-### How to Debug
+## Prerequisites
 
-1. Open the RUN AND DEBUG view in VSCode
-2. Set breakpoints anywhere in your kernel source code
-3. Start your debugging session (F5) — for example, select **Debug x64 DevKernel** from the RUN AND DEBUG dropdown
-4. Qemu will launchs and the kernel will stop at your breakpoints as expected
+| Tool | Purpose | Notes |
+|------|---------|-------|
+| `gdb` | x64 debugging | Must be on `PATH`; the launch config invokes it as `gdb` |
+| `gdb-multiarch` | ARM64 debugging | Must be on `PATH`; required for aarch64 targets |
+| QEMU | Runs the kernel | Installed by `cosmos install` |
+| VS Code C/C++ extension | `cppdbg` debug adapter | `ms-vscode.cpptools` |
+
+`cosmos check` verifies the toolchain. On Debian/Ubuntu, `apt install gdb gdb-multiarch` covers both debuggers.
+
+---
+
+## Debugging a kernel created with `cosmos new`
+
+1. Open the kernel folder in VS Code.
+2. Set breakpoints in your kernel source.
+3. Open the **Run and Debug** view and select **Debug x64 Kernel** (or **Debug ARM64 Kernel**).
+4. Press F5. The pre-launch task builds the kernel, starts QEMU with `-s -S` (GDB server, frozen at startup), and the debugger attaches. Execution stops at your breakpoints.
+
+The configuration names above are what the template generates. When working on the framework repository itself, the equivalent configurations are named **Debug x64 DevKernel** / **Debug ARM64 DevKernel**.
+
+---
+
+## Serial log
+
+Every kernel boot phase logs to the serial port (COM1); `cosmos run` and `make run` connect it to your terminal. When a kernel does not come up, or crashes before the debugger is useful, the serial log is the first thing to read — see [Kernel Startup](startup.md) for a phase-by-phase walkthrough and how to symbolicate crash addresses.
+
+---
+
+## Known limitations
+
+- Source-link and variable-inspection bugs exist in the VS Code debugging experience (see the [roadmap](../../roadmap.md)); stepping and breakpoints work, but inspecting some locals can show wrong or missing values.
+- Debugging assumes QEMU. VMware, VirtualBox and Hyper-V are untested targets.
+- ARM64 debugging under TCG emulation is slow; expect multi-second pauses on step operations on large kernels.

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Mark.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Mark.cs
@@ -18,14 +18,16 @@ public static unsafe partial class GarbageCollector
 {
     /// <summary>
     /// Executes the mark phase: scans roots (stack, GC handles) and marks all reachable objects.
+    /// Static roots need no separate pass: <c>ManagedModule.InitializeStatics</c> holds every
+    /// module's GC-statics base objects in a spine array behind a strong GC handle, so the
+    /// handle scan reaches all objects referenced by static fields transitively (proven by the
+    /// GC_StaticOnlyReachability kernel test).
     /// </summary>
     private static void MarkPhase()
     {
         s_markStackCount = 0;
         ScanStackRoots();
         ScanGCHandles();
-        // TODO: scan static roots — objects reachable only through static fields aren't rooted
-        //       yet (see the s_maxSegmentSize note in GarbageCollector.cs).
     }
 
     /// <summary>
@@ -81,7 +83,7 @@ public static unsafe partial class GarbageCollector
     /// GCInfo — it is parked at a call-site safepoint, so the scan is sound — while every other
     /// registered thread (preempted at an arbitrary IP, where its GCInfo lookup may be meaningless)
     /// still gets a conservative word-by-word scan of its saved registers and stack until
-    /// return-address hijacking lands. See issue #346.
+    /// return-address hijacking lands. See issue #385.
     /// <para>
     /// <see cref="GarbageCollector.Collect"/> runs this inside <c>InternalCpu.DisableInterruptsScope()</c>,
     /// so the other registered threads are quiescent for the duration.

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.cs
@@ -182,8 +182,6 @@ public static unsafe partial class GarbageCollector
 
     /// <summary>
     /// Default segment size. Grows as needed.
-    /// Note: increasing this (e.g. 64KB) requires enabling ScanStaticRoots in MarkPhase
-    /// to prevent GC from collecting objects only reachable through static fields.
     /// </summary>
     private static uint s_maxSegmentSize = (uint)PageAllocator.PageSize;
 

--- a/src/Cosmos.Kernel.Core/Runtime/ExceptionHandling/ExceptionHelper.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/ExceptionHandling/ExceptionHelper.cs
@@ -206,7 +206,12 @@ public static unsafe partial class ExceptionHelper
 
             // Does this frame have a handler covering the call that threw? On a rethrow, the
             // clauses this exception already entered must not catch it again.
-            if (TryFindHandler(ex, frame.ReturnAddress, isRethrow, frame.FramePointer, out EHClause clause, pRegDisplay))
+            // Probe one byte back into the call: every ReturnAddress here — including frame 0's
+            // throwAddress, captured as RhpThrowEx's return address — points at the instruction
+            // AFTER the call, and clause try-ends are exclusive, so a call ending a try region
+            // would otherwise miss its handler (#387). RyuJIT pads such calls with nop/int3
+            // today, making this adjustment behavior-preserving on the current codegen.
+            if (TryFindHandler(ex, frame.ReturnAddress - 1, isRethrow, frame.FramePointer, out EHClause clause, pRegDisplay))
             {
                 Serial.WriteString("[EH] Handler found at 0x");
                 Serial.WriteHex((nuint)clause.HandlerAddress);

--- a/src/Cosmos.Kernel.Core/Scheduler/ConditionVariable.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/ConditionVariable.cs
@@ -39,6 +39,13 @@ public class ConditionVariable : IDisposable
     /// <param name="mutex">The mutex protecting the condition.</param>
     /// <remarks>
     /// This method releases the mutex while the thread is blocked and re-acquires it before returning.
+    /// Waiter-list insertion, the mutex release, and the park form one IRQ-off section so a Signal
+    /// can only ever observe a fully parked thread. The mutex must be released before BlockThread
+    /// (a Blocked thread still holding it could never be signaled), but inside the scope: releasing
+    /// with interrupts enabled re-opens the lost-wakeup window (#357) — the release hands the mutex
+    /// to a waiter and requests a reschedule, so the very next IRQ exit can run the new owner, whose
+    /// Signal readies this still-Running thread; the subsequent BlockThread then buries the wakeup
+    /// forever. Same shape as Mutex.Acquire / InterruptEvent.WaitCore (eab7e338).
     /// </remarks>
     public void Wait(Mutex mutex)
     {
@@ -54,18 +61,24 @@ public class ConditionVariable : IDisposable
         Serial.WriteNumber(currentThread.Id);
         Serial.WriteString("\n");
 
-        _lockGuard.Acquire();
-        if (!_waitingThreads.Contains(currentThread!))
+        using (_lockGuard.AcquireIrqSafe())
         {
-            _waitingThreads.Add(currentThread!);
+            if (!ContainsWaiterLocked(currentThread))
+            {
+                _waitingThreads.Add(currentThread);
+            }
+
+            mutex.Release();
+            SchedulerManager.BlockThread(currentThread.CpuId, currentThread);
         }
-        _lockGuard.Release();
 
-        // Release the mutex while waiting
-        mutex.Release();
-
-        SchedulerManager.BlockThread(currentThread.CpuId, currentThread);
-        InternalCpu.Halt();
+        // Only park the CPU while still Blocked (same rationale as Mutex.Acquire): if a Signal
+        // already readied this thread between scope-dispose and this point, halting would sleep
+        // past the wake-up until an unrelated interrupt.
+        if (currentThread.State == ThreadState.Blocked)
+        {
+            InternalCpu.Halt();
+        }
 
         Serial.WriteString("[CV] Wait WOKE thread=");
         Serial.WriteNumber(currentThread.Id);
@@ -99,34 +112,77 @@ public class ConditionVariable : IDisposable
         Serial.WriteNumber(timeoutMs);
         Serial.WriteString("\n");
 
-        // Release the mutex while waiting
-        mutex.Release();
-
-        _lockGuard.Acquire();
-        if (!_waitingThreads.Contains(currentThread!))
+        // Same atomic insert+release+park section as Wait — the old order (release, then
+        // insert) additionally lost any Signal landing between the two: it found no waiters.
+        using (_lockGuard.AcquireIrqSafe())
         {
-            _waitingThreads.Add(currentThread!);
-        }
-        _lockGuard.Release();
+            if (!ContainsWaiterLocked(currentThread))
+            {
+                _waitingThreads.Add(currentThread);
+            }
 
-        // Put thread to sleep with timeout
-        SchedulerManager.Sleep(currentThread.CpuId, currentThread, timeoutMs);
+            mutex.Release();
+            SchedulerManager.MarkSleeping(currentThread.CpuId, currentThread, timeoutMs);
+        }
+
+        if (currentThread.State == ThreadState.Sleeping)
+        {
+            InternalCpu.Halt();
+        }
 
         Serial.WriteString("[CV] WaitTimeout WOKE thread=");
         Serial.WriteNumber(currentThread.Id);
         Serial.WriteString("\n");
 
+        // Signaled iff Signal/SignalAll removed this thread from the wait list before the
+        // timeout fired. On timeout the stale entry must be removed here, or a later Signal
+        // would consume it instead of waking a real waiter.
+        bool signaled;
+        using (_lockGuard.AcquireIrqSafe())
+        {
+            signaled = !ContainsWaiterLocked(currentThread);
+            if (!signaled)
+            {
+                RemoveWaiterLocked(currentThread);
+            }
+        }
+
+        currentThread.WakeupTime = 0;
+
         // Reacquire the mutex before returning
         mutex.Acquire();
 
-        if (currentThread.WakeupTime > 0)
+        return signaled;
+    }
+
+    /// <summary>
+    /// ReferenceEquals scan (not List.Contains) to match the scheduler's convention of
+    /// avoiding EqualityComparer&lt;T&gt;.Default in kernel paths (see Mutex, InterruptEvent).
+    /// Caller must hold <see cref="_lockGuard"/>.
+    /// </summary>
+    private bool ContainsWaiterLocked(SchedThread thread)
+    {
+        for (int i = 0; i < _waitingThreads.Count; i++)
         {
-            currentThread.WakeupTime = 0;
-            return true;
+            if (ReferenceEquals(_waitingThreads[i], thread))
+            {
+                return true;
+            }
         }
-        else
+
+        return false;
+    }
+
+    /// <summary>Removes a thread from the wait list. Caller must hold <see cref="_lockGuard"/>.</summary>
+    private void RemoveWaiterLocked(SchedThread thread)
+    {
+        for (int i = 0; i < _waitingThreads.Count; i++)
         {
-            return false;
+            if (ReferenceEquals(_waitingThreads[i], thread))
+            {
+                _waitingThreads.RemoveAt(i);
+                return;
+            }
         }
     }
 
@@ -135,26 +191,27 @@ public class ConditionVariable : IDisposable
     /// </summary>
     public void Signal()
     {
-        _lockGuard.Acquire();
-
-        if (_waitingThreads.Count > 0)
+        // IRQ-safe like every other _lockGuard use: Wait holds this lock with interrupts
+        // masked, so a plain-acquire holder preempted mid-section would deadlock it.
+        using (_lockGuard.AcquireIrqSafe())
         {
-            SchedThread waitingThread = _waitingThreads[0];
-            _waitingThreads.RemoveAt(0);
+            if (_waitingThreads.Count > 0)
+            {
+                SchedThread waitingThread = _waitingThreads[0];
+                _waitingThreads.RemoveAt(0);
 
-            Serial.WriteString("[CV] Signal -> ReadyThread id=");
-            Serial.WriteNumber(waitingThread.Id);
-            Serial.WriteString("\n");
+                Serial.WriteString("[CV] Signal -> ReadyThread id=");
+                Serial.WriteNumber(waitingThread.Id);
+                Serial.WriteString("\n");
 
-            // Wake the thread by marking it ready
-            SchedulerManager.ReadyThread(waitingThread.CpuId, waitingThread);
+                // Wake the thread by marking it ready
+                SchedulerManager.ReadyThread(waitingThread.CpuId, waitingThread);
+            }
+            else
+            {
+                Serial.WriteString("[CV] Signal (no waiters)\n");
+            }
         }
-        else
-        {
-            Serial.WriteString("[CV] Signal (no waiters)\n");
-        }
-
-        _lockGuard.Release();
     }
 
     /// <summary>
@@ -162,17 +219,16 @@ public class ConditionVariable : IDisposable
     /// </summary>
     public void SignalAll()
     {
-        _lockGuard.Acquire();
-
-        foreach (SchedThread thread in _waitingThreads)
+        using (_lockGuard.AcquireIrqSafe())
         {
-            // Wake each thread by marking it ready
-            SchedulerManager.ReadyThread(thread.CpuId, thread);
+            foreach (SchedThread thread in _waitingThreads)
+            {
+                // Wake each thread by marking it ready
+                SchedulerManager.ReadyThread(thread.CpuId, thread);
+            }
+
+            _waitingThreads.Clear();
         }
-
-        _waitingThreads.Clear();
-
-        _lockGuard.Release();
     }
 
     public void Dispose()

--- a/src/Cosmos.Kernel.Core/Scheduler/SchedulerManager.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/SchedulerManager.cs
@@ -504,6 +504,26 @@ public static class SchedulerManager
     /// <param name="timeoutMs">Timeout in milliseconds. 0 means indefinite sleep (until signaled).</param>
     public static void Sleep(uint cpuId, Thread thread, uint timeoutMs)
     {
+        MarkSleeping(cpuId, thread, timeoutMs);
+
+        // Only park the CPU while still Sleeping: if a wake already landed between
+        // scope-dispose and this point, halting would sleep past it.
+        if (thread.State == ThreadState.Sleeping)
+        {
+            InternalCpu.Halt();
+        }
+    }
+
+    /// <summary>
+    /// Marks a thread Sleeping with a wake deadline without halting — for callers that must
+    /// make the state change atomic with their own IRQ-off section (ConditionVariable.WaitTimeout)
+    /// and park afterwards under a state guard.
+    /// </summary>
+    /// <param name="cpuId">CPU ID of the thread.</param>
+    /// <param name="thread">Thread to sleep.</param>
+    /// <param name="timeoutMs">Timeout in milliseconds. 0 means indefinite sleep (until signaled).</param>
+    public static void MarkSleeping(uint cpuId, Thread thread, uint timeoutMs)
+    {
         using (InternalCpu.DisableInterruptsScope())
         {
             PerCpuState cpuState = _cpuStates[cpuId];
@@ -515,8 +535,6 @@ public static class SchedulerManager
             _currentScheduler.OnThreadBlocked(cpuState, thread);
             thread.State = ThreadState.Sleeping;
         }
-
-        InternalCpu.Halt();
     }
 
     /// <summary>

--- a/tests/Cosmos.TestRunner.Framework/TestRunner.cs
+++ b/tests/Cosmos.TestRunner.Framework/TestRunner.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using Cosmos.Kernel.Boot.Limine;
+using Cosmos.Kernel.Core.CPU;
 using Cosmos.Kernel.Core.IO;
 
 namespace Cosmos.TestRunner.Framework
@@ -462,24 +463,31 @@ namespace Cosmos.TestRunner.Framework
         /// </summary>
         private static void SendMessage(byte command, byte[] payload)
         {
-            // Send magic signature (0x19740807 little-endian)
-            Serial.ComWrite(SerialSignatureByte0);
-            Serial.ComWrite(SerialSignatureByte1);
-            Serial.ComWrite(SerialSignatureByte2);
-            Serial.ComWrite(SerialSignatureByte3);
-
-            // Send command byte
-            Serial.ComWrite(command);
-
-            // Send length (little-endian ushort)
-            ushort length = (ushort)payload.Length;
-            Serial.ComWrite((byte)(length & ByteMask));
-            Serial.ComWrite((byte)((length >> Byte1Shift) & ByteMask));
-
-            // Send payload
-            foreach (var b in payload)
+            // The protocol shares the UART with diagnostic traces written from IRQ handlers
+            // and other threads ([SCHED]/[CV] wake logs). A frame must go out as one
+            // uninterrupted byte sequence: an IRQ landing mid-frame interleaves its log into
+            // the message and the host-side parser drops or garbles it.
+            using (InternalCpu.DisableInterruptsScope())
             {
-                Serial.ComWrite(b);
+                // Send magic signature (0x19740807 little-endian)
+                Serial.ComWrite(SerialSignatureByte0);
+                Serial.ComWrite(SerialSignatureByte1);
+                Serial.ComWrite(SerialSignatureByte2);
+                Serial.ComWrite(SerialSignatureByte3);
+
+                // Send command byte
+                Serial.ComWrite(command);
+
+                // Send length (little-endian ushort)
+                ushort length = (ushort)payload.Length;
+                Serial.ComWrite((byte)(length & ByteMask));
+                Serial.ComWrite((byte)((length >> Byte1Shift) & ByteMask));
+
+                // Send payload
+                foreach (var b in payload)
+                {
+                    Serial.ComWrite(b);
+                }
             }
         }
 

--- a/tests/Kernels/Cosmos.Kernel.Tests.GarbageCollector/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.GarbageCollector/Kernel.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Cosmos.Kernel.Core.IO;
 using Cosmos.Kernel.Core.Memory;
 using Cosmos.Kernel.Core.Memory.GarbageCollector.GcInfo;
 using Cosmos.Kernel.Core.Runtime.GcInfo;
+using Cosmos.Kernel.System.Timer;
 using Cosmos.TestRunner.Framework;
 using CoreGC = Cosmos.Kernel.Core.Memory.GarbageCollector.GarbageCollector;
 using Sys = Cosmos.Kernel.System;
@@ -21,7 +23,7 @@ public class Kernel : Sys.Kernel
         Serial.WriteString("[GarbageCollector] BeforeRun() reached!\n");
         Serial.WriteString("[GarbageCollector] Starting tests...\n");
 
-        TR.Start("GarbageCollector Tests", expectedTests: 41);
+        TR.Start("GarbageCollector Tests", expectedTests: 43);
 
         // Garbage Collection Tests
         TR.Run("GC_IsEnabled", TestGCIsEnabled);
@@ -52,6 +54,11 @@ public class Kernel : Sys.Kernel
         TR.Run("GC_FuncletNoFalseRoot", TestGCFuncletNoFalseRoot);
         TR.Run("GC_FuncletNoCrashOnAllocInCatch", TestGCFuncletNoCrashOnAllocInCatch);
         TR.Run("GC_ThrowThroughDeepChain", TestGCThrowThroughDeepChain);
+
+        // GC Soundness Tests. The interior-pointer test (byref-only root across a collect)
+        // is parked in #384 until interior-pointer support (#376) lands — it fails today.
+        TR.Run("GC_StaticOnlyReachability", TestGCStaticOnlyReachability);
+        TR.Run("GC_MultithreadChurnUnderCollect", TestGCMultithreadChurnUnderCollect);
 
         // GC Info & Configuration Tests
         TR.Run("GC_Info_SimpleMemoryInfo", TestGCInfoSimpleMemoryInfo);
@@ -882,6 +889,139 @@ public class Kernel : Sys.Kernel
         string caught = CatchAtopDeepChain();
         Assert.True(caught == "deep-throw",
             "EH: a throw must propagate through 5 intermediate frames that may omit RBP/X29 — got '" + caught + "'");
+    }
+
+    // ==================== GC Soundness Tests ====================
+
+    /// <summary>Holds the only reference to the statics-reachability test array.</summary>
+    private static int[]? s_staticOnlyArray;
+
+    /// <summary>
+    /// Stores a fresh array into a static field. NoInlining so the array reference dies with
+    /// this frame — after return, the static field is the only root.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AllocateStaticOnlyArray()
+    {
+        int[] arr = new int[2100];
+        for (int i = 0; i < arr.Length; i++)
+        {
+            arr[i] = 0x0BAD0000 + i;
+        }
+
+        s_staticOnlyArray = arr;
+    }
+
+    private static void TestGCStaticOnlyReachability()
+    {
+        AllocateStaticOnlyArray();
+
+        CoreGC.Collect();
+
+        for (int i = 0; i < 512; i++)
+        {
+            int[] junk = new int[32];
+            junk[0] = i;
+        }
+
+        int[]? arr = s_staticOnlyArray;
+        Assert.True(arr != null && arr.Length == 2100 && arr[8] == 0x0BAD0008 && arr[2099] == 0x0BAD0000 + 2099,
+            "GC: an object whose only root is a static field must survive collection");
+
+        s_staticOnlyArray = null;
+    }
+
+    private static volatile bool s_churnStop;
+    private static int s_churnStartedCount;
+    private static int s_churnDoneCount;
+    private static int s_churnErrorCount;
+    private static int s_churnIterations;
+
+    /// <summary>
+    /// Worker: allocates patterned arrays in a ring while the main thread forces collections.
+    /// While this thread is parked, the GC scans its stack and saved registers; if the scan
+    /// misses a live survivor, the recycled memory loses the 0x7C pattern and the worker
+    /// records an error.
+    /// </summary>
+    private static void GCChurnWorker()
+    {
+        Interlocked.Increment(ref s_churnStartedCount);
+
+        int[][] keep = new int[8][];
+        int iteration = 0;
+        while (!s_churnStop)
+        {
+            int[] fresh = new int[64];
+            for (int i = 0; i < fresh.Length; i++)
+            {
+                fresh[i] = 0x7C000000 + i;
+            }
+
+            keep[iteration & 7] = fresh;
+
+            int[] survivor = keep[(iteration >> 2) & 7];
+            if (survivor != null && (survivor[0] != 0x7C000000 || survivor[63] != 0x7C00003F))
+            {
+                Interlocked.Increment(ref s_churnErrorCount);
+            }
+
+            Interlocked.Increment(ref s_churnIterations);
+            iteration++;
+        }
+
+        Interlocked.Increment(ref s_churnDoneCount);
+    }
+
+    private static void TestGCMultithreadChurnUnderCollect()
+    {
+        s_churnStop = false;
+        s_churnStartedCount = 0;
+        s_churnDoneCount = 0;
+        s_churnErrorCount = 0;
+        s_churnIterations = 0;
+
+        Thread worker1 = new Thread(GCChurnWorker);
+        Thread worker2 = new Thread(GCChurnWorker);
+        worker1.Start();
+        worker2.Start();
+
+        for (int i = 0; i < 200 && s_churnStartedCount < 2; i++)
+        {
+            TimerManager.Wait(10);
+        }
+
+        Assert.Equal(2, s_churnStartedCount, "GC: both churn workers must start");
+
+        // Force collections while the workers allocate. The workers are parked during each
+        // Collect, so their survivors are only reachable through the parked-thread stack scan.
+        for (int c = 0; c < 10; c++)
+        {
+            for (int i = 0; i < 64; i++)
+            {
+                int[] garbage = new int[48];
+                garbage[0] = i;
+            }
+
+            CoreGC.Collect();
+            TimerManager.Wait(5);
+        }
+
+        s_churnStop = true;
+        for (int i = 0; i < 400 && s_churnDoneCount < 2; i++)
+        {
+            TimerManager.Wait(10);
+        }
+
+        Serial.WriteString("[Test] churn iterations: ");
+        Serial.WriteNumber((uint)s_churnIterations);
+        Serial.WriteString(", errors: ");
+        Serial.WriteNumber((uint)s_churnErrorCount);
+        Serial.WriteString("\n");
+
+        Assert.Equal(2, s_churnDoneCount, "GC: both churn workers must finish after stop is signaled");
+        Assert.True(s_churnIterations > 0, "GC: churn workers must have completed at least one iteration");
+        Assert.Equal(0, s_churnErrorCount,
+            "GC: parked-thread survivors must never be corrupted by collections (" + s_churnErrorCount + " errors)");
     }
 
     // ==================== GC Info & Configuration Tests ====================


### PR DESCRIPTION
Release-blocker sweep for the First Release milestone.

---

## GC soundness tests (`✅`)

| Test | Pre-fix proof | Result |
|------|---------------|--------|
| `GC_StaticOnlyReachability` | Passed immediately — statics are already rooted: `ManagedModule.InitializeStatics` keeps every module's GC-statics bases in a spine array behind a strong GC handle | The stale `MarkPhase` TODO / `s_maxSegmentSize` note claiming otherwise are removed |
| `GC_MultithreadChurnUnderCollect` | Two workers, 11k+ patterned allocations against 10 forced collections, 0 errors | Guards the parked-thread scan; precise-scan follow-up is #385 |
| Interior-pointer test | **Failed as predicted** (`after churn: 0`) — re-proving #384 live on main | Parked in #384 until #376 lands (per repo owner) |

## ConditionVariable lost-wakeup fix (Fixes #357)

Root cause (full interleaving in the issue comment): `Wait` released the mutex and parked with interrupts enabled; the release hands the mutex to a waiter and requests a reschedule, so the very next IRQ exit runs the new owner, whose `Signal` readies the still-Running thread — its subsequent `BlockThread` buries the wakeup, and `LowLevelLock._isAnyWaitingThreadSignaled` then suppresses every future `SignalWaiter` on the wait subsystem's `s_lock`. `Mutex.Acquire` / `InterruptEvent.WaitCore` closed this exact race in eab7e338; `ConditionVariable` never got the same fix. `WaitTimeout` was worse: it inserted into the wait list *after* releasing the mutex (a Signal in between found no waiters) and left stale waiter entries behind on timeout.

Insertion + mutex release + park are now one IRQ-off section, halts are state-guarded, Signal/SignalAll are IRQ-safe, and signaled-vs-timeout is decided by wait-list membership.

## Test-protocol frame atomicity

Frames went out byte-by-byte on the UART shared with IRQ-context diagnostics. Proven with a byte dump: the .NET timer-queue thread's wake logs interleaved mid-frame (`Delegate_Chaining_Pipelin[SCHED] Waking sleeping thread 18…`), producing a 52/53 "incomplete" Threading run. One `DisableInterruptsScope` around `SendMessage` makes frames uninterruptible.

## EH handler-lookup hardening (Fixes #387)

An LSDA census of the built x64 kernel (152 clauses / 125 methods, parser byte-compatible with `TryFindHandlerInLSDA`) proved the call-at-try-end miss is unreachable today (RyuJIT pads with `nop`/`int3`) **and** that probing `returnAddress - 1` is behavior-preserving on the entire population. The probe closes the boundary miss if that codegen invariant ever changes.

## Docs / release hygiene

- `debugging.md` rewritten: correct template config names (`Debug x64 Kernel`, not `Debug x64 DevKernel`), `gdb`/`gdb-multiarch` prerequisites, serial-log pointer, and a Known-limitations section disclosing the roadmap-admitted source-link/variable bugs.
- `release.yml` now appends the generated changelog to GitHub releases (they previously carried no change description).

---

## Verification matrix

| Suite | x64 (KVM) | arm64 (TCG) |
|-------|-----------|-------------|
| GarbageCollector (43 tests, incl. 2 new) | ✅ | ✅ |
| Threading (53 tests) | ✅ | ✅ ×3 |
| TypeCasting (EH) | ✅ | ✅ |

Related: #385 (parked-thread precise scan re-filed), #386 (malloc-heap sweepers, no code change per owner's redirect), milestone [First Release (Gen3 RC)](https://github.com/valentinbreiz/nativeaot-patcher/milestone/1).
