### PR TITLE
✨ Add cosmos update and a daily update notice

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -87,6 +87,37 @@ jobs:
           name: Cosmos.Tests.Scanner-Results
           path: ./tests/Cosmos.Tests.Scanner/TestResults/Cosmos.Tests.Scanner.trx
 
+  tools-tests:
+    name: Run Cosmos.Tests.Tools
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        dotnet-version: [ 10.0.x ]
+    steps:
+      - name: 📥 Checkout Code
+        uses: actions/checkout@v4
+
+      - name: 🛠️ Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
+      - name: 🔄 Restore Dependencies
+        run: dotnet restore ./tests/Cosmos.Tests.Tools/Cosmos.Tests.Tools.csproj
+
+      - name: 🔨 Build Cosmos.Tests.Tools
+        run: dotnet build ./tests/Cosmos.Tests.Tools/Cosmos.Tests.Tools.csproj --configuration Debug --no-restore
+
+      - name: 🚀 Run Tests
+        run: dotnet test ./tests/Cosmos.Tests.Tools/Cosmos.Tests.Tools.csproj --no-build --configuration Debug --logger "trx;LogFileName=Cosmos.Tests.Tools.trx"
+
+      - name: 📤 Upload Test Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: Cosmos.Tests.Tools-Results
+          path: ./tests/Cosmos.Tests.Tools/TestResults/Cosmos.Tests.Tools.trx
+
   analyzer-tests:
     name: Run Cosmos.Tests.Build.Analyzer.Patcher
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,6 +196,8 @@ jobs:
             | Windows | `CosmosSetup-${{ needs.build-packages.outputs.version }}-windows.exe` | Requires .NET 10 SDK, run installer |
             | Linux / macOS | `dotnet tool install -g Cosmos.Tools && cosmos install` | Requires .NET 10 SDK |
 
+            Already installed? Run `cosmos update` to move to this release — or `dotnet tool update -g Cosmos.Tools && cosmos install` if your CLI predates the update command.
+
             ### Prerequisites
 
             - [.NET 10 SDK](https://dot.net/download)

--- a/docs/articles/user/install.md
+++ b/docs/articles/user/install.md
@@ -45,6 +45,26 @@ cosmos uninstall
 dotnet tool uninstall -g Cosmos.Tools
 ```
 
+## Updating
+
+Update everything in one step — the CLI, the patcher, the build tools, the project templates, and the VS Code extension:
+
+```bash
+cosmos update
+```
+
+Run it inside a kernel project directory to also move the project's Cosmos version pins (the `Sdk="Cosmos.Sdk/..."` attribute and `Cosmos.*` package references) to the latest release. Additional options:
+
+| Option | Effect |
+|--------|--------|
+| `cosmos update --check` | Report available updates without installing anything |
+| `cosmos update --no-project` | Update the tools but leave project files untouched |
+| `cosmos update --version <VERSION>` | Move the CLI, patcher, templates, and project pins to a specific version (system tools always follow the `tools-latest` bundles) |
+
+Projects pinned to a version newer than the latest release (for example a locally built date-stamped version) are left untouched unless `--version` is passed explicitly.
+
+This works on Windows too — existing installations update in place without re-running the installer. `cosmos build`, `cosmos run`, and `cosmos check` also print a one-line notice when a newer release exists (checked at most once per day; set `COSMOS_NO_UPDATE_NOTIFIER=1` to disable).
+
 ## Quick Start
 
 Once installed, create and build your first kernel:

--- a/docs/articles/user/install.md
+++ b/docs/articles/user/install.md
@@ -67,12 +67,4 @@ This works on Windows too — existing installations update in place without re-
 
 ## Quick Start
 
-Once installed, create and build your first kernel:
-
-```bash
-cosmos new MyKernel
-cd MyKernel
-cosmos build
-```
-
-Or open VS Code and use the Cosmos extension to create, build, and run bare-metal C# kernels directly from the editor.
+Once installed, see [Kernel Startup](startup.md) to create your first kernel and learn the boot flow.

--- a/nativeaot-patcher.tests.slnx
+++ b/nativeaot-patcher.tests.slnx
@@ -5,6 +5,7 @@
         <Project Path="tests\Cosmos.Tests.NativeWrapper\Cosmos.Tests.NativeWrapper.csproj"/>
         <Project Path="tests\Cosmos.Tests.Patcher\Cosmos.Tests.Patcher.csproj"/>
         <Project Path="tests\Cosmos.Tests.Scanner\Cosmos.Tests.Scanner.csproj"/>
+        <Project Path="tests\Cosmos.Tests.Tools\Cosmos.Tests.Tools.csproj"/>
         <Project Path="tests\Cosmos.Tests.BuildCache\Cosmos.Tests.BuildCache.csproj"/>
         <Project Path="tests\Cosmos.TestRunner.Engine\Cosmos.TestRunner.Engine.csproj"/>
         <Project Path="tests\Cosmos.TestRunner.Framework\Cosmos.TestRunner.Framework.csproj"/>

--- a/src/Cosmos.Tools/Commands/BuildCommand.cs
+++ b/src/Cosmos.Tools/Commands/BuildCommand.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Cosmos.Tools.Platform;
+using Cosmos.Tools.Update;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -168,6 +169,7 @@ public class BuildCommand : AsyncCommand<BuildSettings>
             }
 
             AnsiConsole.WriteLine();
+            await UpdateNotifier.MaybeNotifyAsync();
         }
 
         return success ? 0 : 1;

--- a/src/Cosmos.Tools/Commands/CheckCommand.cs
+++ b/src/Cosmos.Tools/Commands/CheckCommand.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Cosmos.Tools.Platform;
+using Cosmos.Tools.Update;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -31,6 +32,7 @@ public class CheckCommand : AsyncCommand<CheckSettings>
         {
             PrintResults(results);
             PrintSummary(results);
+            await UpdateNotifier.MaybeNotifyAsync();
         }
 
         return 0;

--- a/src/Cosmos.Tools/Commands/InstallCommand.cs
+++ b/src/Cosmos.Tools/Commands/InstallCommand.cs
@@ -29,8 +29,8 @@ public class InstallSettings : CommandSettings
 
 public class InstallCommand : AsyncCommand<InstallSettings>
 {
-    private const string ToolsRepo = "valentinbreiz/nativeaot-patcher";
-    private const string ToolsReleaseTag = "tools-latest";
+    internal const string ToolsRepo = "valentinbreiz/nativeaot-patcher";
+    internal const string ToolsReleaseTag = "tools-latest";
 
     public override async Task<int> ExecuteAsync(CommandContext context, InstallSettings settings)
     {
@@ -92,7 +92,7 @@ public class InstallCommand : AsyncCommand<InstallSettings>
     //  Tool installation — download from GitHub release `tools-latest`
     // ═══════════════════════════════════════════════════════════════════════
 
-    private static async Task<bool> InstallToolsFromReleaseAsync()
+    internal static async Task<bool> InstallToolsFromReleaseAsync()
     {
         string platform = GetPlatformTarget();
         string ext = OperatingSystem.IsWindows() ? "zip" : "tar.gz";
@@ -150,7 +150,13 @@ public class InstallCommand : AsyncCommand<InstallSettings>
             }
 
             // Asset name -> "<assetPrefix>-<version>-<platform>.<ext>"
-            string wantedVersion = asset.Name.Substring(pattern.Length, asset.Name.Length - pattern.Length - suffix.Length);
+            int versionLength = asset.Name.Length - pattern.Length - suffix.Length;
+            if (versionLength <= 0)
+            {
+                AnsiConsole.MarkupLine($"  [red]{releaseAsset}:[/] malformed asset name [white]{asset.Name}[/] in release '{ToolsReleaseTag}'");
+                continue;
+            }
+            string wantedVersion = asset.Name.Substring(pattern.Length, versionLength);
 
             bool allFoundAndMatching = true;
             foreach (var tool in group)
@@ -228,7 +234,7 @@ public class InstallCommand : AsyncCommand<InstallSettings>
         return true;
     }
 
-    private static string GetPlatformTarget()
+    internal static string GetPlatformTarget()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -245,9 +251,9 @@ public class InstallCommand : AsyncCommand<InstallSettings>
     //  GitHub Release asset fetching
     // ═══════════════════════════════════════════════════════════════════════
 
-    private record ReleaseAsset(string Name, string DownloadUrl);
+    internal record ReleaseAsset(string Name, string DownloadUrl);
 
-    private static async Task<List<ReleaseAsset>> FetchReleaseAssetsAsync(string repo, string tag)
+    internal static async Task<List<ReleaseAsset>> FetchReleaseAssetsAsync(string repo, string tag)
     {
         using var http = CreateHttpClient();
         string url = $"https://api.github.com/repos/{repo}/releases/tags/{tag}";
@@ -386,7 +392,7 @@ public class InstallCommand : AsyncCommand<InstallSettings>
         return path;
     }
 
-    private static async Task InstallVSCodeExtensionAsync()
+    internal static async Task InstallVSCodeExtensionAsync()
     {
         string? codeCommand = GetVSCodeCommand();
         if (codeCommand == null)
@@ -453,14 +459,14 @@ public class InstallCommand : AsyncCommand<InstallSettings>
         await InstallTemplateAsync("Cosmos.Build.Templates");
     }
 
-    private static async Task InstallDotnetToolAsync(string packageName)
+    internal static async Task InstallDotnetToolAsync(string packageName, string extraArgs = "")
     {
         try
         {
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = $"tool update -g {packageName}",
+                Arguments = $"tool update -g {packageName}{extraArgs}",
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
@@ -475,7 +481,7 @@ public class InstallCommand : AsyncCommand<InstallSettings>
             }
             else
             {
-                psi.Arguments = $"tool install -g {packageName}";
+                psi.Arguments = $"tool install -g {packageName}{extraArgs}";
                 using var installProcess = Process.Start(psi);
                 if (installProcess != null)
                 {
@@ -487,14 +493,14 @@ public class InstallCommand : AsyncCommand<InstallSettings>
         catch { AnsiConsole.MarkupLine("[yellow]SKIPPED[/]"); }
     }
 
-    private static async Task InstallTemplateAsync(string packageName)
+    internal static async Task InstallTemplateAsync(string packageName, string? version = null)
     {
         try
         {
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = $"new install {packageName}",
+                Arguments = $"new install {packageName}{(version != null ? $"::{version}" : "")}",
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true

--- a/src/Cosmos.Tools/Commands/RunCommand.cs
+++ b/src/Cosmos.Tools/Commands/RunCommand.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using Cosmos.Tools.Launcher;
 using Cosmos.Tools.Platform;
+using Cosmos.Tools.Update;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -108,6 +109,9 @@ public class RunCommand : AsyncCommand<RunSettings>
             AnsiConsole.MarkupLine($"  [red]{Markup.Escape(ex.Message)}[/]");
             return 1;
         }
+
+        // Notify before QEMU starts — stdio is handed to the guest serial console after this.
+        await UpdateNotifier.MaybeNotifyAsync();
 
         AnsiConsole.MarkupLine($"  Running [blue]{Path.GetFileName(isoPath)}[/] ([blue]{settings.Arch}[/]) via QEMU [dim]({plan.Source.ToString().ToLowerInvariant()}: {plan.BinaryPath})[/]");
         if (plan.Source == ToolSource.Bundle)

--- a/src/Cosmos.Tools/Commands/UninstallCommand.cs
+++ b/src/Cosmos.Tools/Commands/UninstallCommand.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using Cosmos.Tools.Platform;
+using Cosmos.Tools.Update;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -77,6 +78,19 @@ public class UninstallCommand : AsyncCommand<UninstallSettings>
                 bool pathOk = InstallCommand.RemoveToolsFromWindowsPath(toolsPath);
                 AnsiConsole.MarkupLine(pathOk ? "[green]OK[/]" : "[dim]nothing to remove[/]");
             }
+
+            AnsiConsole.Markup("  Update-check state -> remove ... ");
+            bool stateOk = false;
+            try
+            {
+                if (File.Exists(UpdateNotifier.StateFilePath))
+                {
+                    File.Delete(UpdateNotifier.StateFilePath);
+                    stateOk = true;
+                }
+            }
+            catch { }
+            AnsiConsole.MarkupLine(stateOk ? "[green]OK[/]" : "[dim]not found[/]");
         }
 
         if (removePackages)

--- a/src/Cosmos.Tools/Commands/UpdateCommand.cs
+++ b/src/Cosmos.Tools/Commands/UpdateCommand.cs
@@ -1,0 +1,510 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using Cosmos.Tools.Platform;
+using Cosmos.Tools.Update;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Cosmos.Tools.Commands;
+
+public class UpdateSettings : CommandSettings
+{
+    [CommandOption("-y|--auto")]
+    [Description("Automatically update without prompting")]
+    public bool Auto { get; set; }
+
+    [CommandOption("--check")]
+    [Description("Report available updates without installing anything")]
+    public bool Check { get; set; }
+
+    [CommandOption("--version <VERSION>")]
+    [Description("Update to a specific version instead of the latest release (must exist on your configured feeds)")]
+    public string? Version { get; set; }
+
+    [CommandOption("--prerelease")]
+    [Description("Include prerelease versions")]
+    public bool Prerelease { get; set; }
+
+    [CommandOption("--project <DIR>")]
+    [Description("Project directory whose Cosmos version pins should be updated (defaults to the current directory)")]
+    public string? Project { get; set; }
+
+    [CommandOption("--no-project")]
+    [Description("Do not touch project files")]
+    public bool NoProject { get; set; }
+}
+
+/// <summary>
+/// One-step update of everything a Cosmos install is made of: the system-tools
+/// bundles, the Cosmos.Patcher global tool, the project templates, the VS Code
+/// extension, the current project's version pins, and — last, because replacing
+/// the running tool must be the final act — the cosmos CLI itself.
+/// </summary>
+public class UpdateCommand : AsyncCommand<UpdateSettings>
+{
+    /// <summary>An update refusing to touch more files than this without an explicit --project is the monorepo-root guard.</summary>
+    private const int MaxPinFilesWithoutExplicitProject = 8;
+
+    private sealed record PinPlanEntry(string FilePath, ProjectPinUpdater.PinEdit Edit, string? SkipReason);
+
+    public override async Task<int> ExecuteAsync(CommandContext context, UpdateSettings settings)
+    {
+        CommandHelper.PrintHeader("Cosmos Update", settings.Check ? "Check only" : null);
+
+        // Validate inputs before anything runs — a bad flag must not abort the
+        // update midway with half the steps already applied.
+        if (settings.Version != null && !NuGetVersions.IsValidVersionRequest(settings.Version))
+        {
+            AnsiConsole.MarkupLine($"  [red]--version '{Markup.Escape(settings.Version)}' is not a valid version.[/]");
+            return 1;
+        }
+
+        string? projectRoot = null;
+        if (!settings.NoProject)
+        {
+            projectRoot = Path.GetFullPath(settings.Project ?? Directory.GetCurrentDirectory());
+            if (!Directory.Exists(projectRoot))
+            {
+                AnsiConsole.MarkupLine($"  [red]--project: '{Markup.Escape(projectRoot)}' is not a directory.[/]");
+                return 1;
+            }
+        }
+
+        string currentCli = NuGetVersions.CurrentCliVersion();
+        bool includePrerelease = settings.Prerelease || currentCli.Contains('-');
+
+        string? latestTools;
+        string? latestSdk;
+        if (settings.Version != null)
+        {
+            latestTools = settings.Version;
+            latestSdk = settings.Version;
+        }
+        else
+        {
+            // Plain client for nuget.org — InstallCommand.CreateHttpClient attaches
+            // the user's GitHub token to every request and must not talk to NuGet.
+            using HttpClient nuget = new HttpClient();
+            nuget.DefaultRequestHeaders.Add("User-Agent", "Cosmos-Tools");
+            Task<string?> toolsLookup = NuGetVersions.GetLatestVersionAsync(nuget, "Cosmos.Tools", includePrerelease);
+            Task<string?> sdkLookup = NuGetVersions.GetLatestVersionAsync(nuget, "Cosmos.Sdk", includePrerelease);
+            latestTools = await toolsLookup;
+            latestSdk = await sdkLookup;
+
+            if (latestTools == null && latestSdk == null)
+            {
+                AnsiConsole.MarkupLine("  [yellow]Could not reach nuget.org — package updates are unavailable.[/]");
+            }
+        }
+
+        bool cliOutdated = latestTools != null && NuGetVersions.IsNewer(latestTools, currentCli);
+        AnsiConsole.MarkupLine(cliOutdated
+            ? $"  cosmos CLI: [yellow]{Markup.Escape(currentCli)}[/] -> [green]{Markup.Escape(latestTools!)}[/]"
+            : $"  cosmos CLI: [green]{Markup.Escape(currentCli)}[/] [dim](up to date)[/]");
+
+        // The pin plan is computed (and shown) before anything is confirmed or
+        // written, so the user sees exactly which files an update would edit.
+        List<PinPlanEntry> pinPlan = BuildPinPlan(projectRoot, latestSdk, settings);
+
+        if (settings.Check)
+        {
+            await PrintBundleStatusAsync();
+            PrintPinPlan(pinPlan, projectRoot, latestSdk);
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine("  Run [blue]cosmos update[/] to apply available updates.");
+            AnsiConsole.WriteLine();
+            return 0;
+        }
+
+        PrintPinPlan(pinPlan, projectRoot, latestSdk);
+
+        if (!settings.Auto)
+        {
+            AnsiConsole.WriteLine();
+            bool proceed = AnsiConsole.Confirm("  Proceed with update?", false);
+            if (!proceed)
+            {
+                AnsiConsole.WriteLine("  Update cancelled.");
+                return 0;
+            }
+        }
+
+        AnsiConsole.WriteLine();
+
+        // System-tools bundles: InstallToolsFromReleaseAsync already compares each
+        // bundle against the tools-latest asset versions and skips matches.
+        bool toolsOk = await InstallCommand.InstallToolsFromReleaseAsync();
+
+        // Pin the dotnet tools to the requested train when one was named; plain
+        // updates track the latest stable release.
+        string toolVersionArgs = settings.Version != null
+            ? $" --version {settings.Version}"
+            : includePrerelease && latestSdk != null ? $" --version {latestSdk}" : "";
+        string? templateVersion = settings.Version ?? (includePrerelease ? latestSdk : null);
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.Markup("  Updating Cosmos.Patcher... ");
+        await InstallCommand.InstallDotnetToolAsync("Cosmos.Patcher", toolVersionArgs);
+
+        // `dotnet new install` refuses to touch an already-installed template
+        // package, so the templates must be uninstalled first (the same shape the
+        // Windows installer uses). That is only safe when a feed is reachable —
+        // otherwise the reinstall fails and the templates are simply gone.
+        AnsiConsole.Markup("  Updating Cosmos.Build.Templates... ");
+        if (settings.Version != null || latestSdk != null || latestTools != null)
+        {
+            await RunQuietAsync("dotnet", "new uninstall Cosmos.Build.Templates");
+            await InstallCommand.InstallTemplateAsync("Cosmos.Build.Templates", templateVersion);
+        }
+        else
+        {
+            AnsiConsole.MarkupLine("[yellow]SKIPPED (no feed reachable)[/]");
+        }
+
+        await InstallCommand.InstallVSCodeExtensionAsync();
+
+        bool pinsOk = ApplyPinPlan(pinPlan, projectRoot);
+
+        bool selfOk = await SelfUpdateAsync(settings, currentCli, latestTools, includePrerelease);
+
+        UpdateNotifier.RecordUpdated(latestTools);
+
+        bool ok = toolsOk && pinsOk && selfOk;
+        AnsiConsole.WriteLine();
+        AnsiConsole.WriteLine("  " + new string('-', 50));
+        AnsiConsole.MarkupLine(ok ? "  [green]Update complete![/]" : "  [yellow]Update finished with errors (see above).[/]");
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("  Run [blue]cosmos check[/] to verify the installation.");
+        AnsiConsole.WriteLine();
+
+        return ok ? 0 : 1;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  --check reporting
+    // ═══════════════════════════════════════════════════════════════════════
+
+    private static async Task PrintBundleStatusAsync()
+    {
+        AnsiConsole.WriteLine();
+
+        List<InstallCommand.ReleaseAsset> assets;
+        try
+        {
+            assets = await InstallCommand.FetchReleaseAssetsAsync(InstallCommand.ToolsRepo, InstallCommand.ToolsReleaseTag);
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"  [yellow]Could not reach the tools release: {Markup.Escape(ex.Message)}[/]");
+            return;
+        }
+
+        string platform = InstallCommand.GetPlatformTarget();
+        string ext = OperatingSystem.IsWindows() ? "zip" : "tar.gz";
+        string toolsPath = ToolChecker.GetCosmosToolsPath();
+
+        IEnumerable<string> releaseAssets = ToolDefinitions.GetAllTools()
+            .OfType<CommandToolDefinition>()
+            .Where(t => t.ReleaseAsset != null)
+            .Select(t => t.ReleaseAsset!)
+            .Distinct();
+
+        foreach (string releaseAsset in releaseAssets)
+        {
+            string pattern = $"{releaseAsset}-";
+            string suffix = $"-{platform}.{ext}";
+            InstallCommand.ReleaseAsset? asset = assets.FirstOrDefault(a =>
+                a.Name.StartsWith(pattern, StringComparison.OrdinalIgnoreCase) &&
+                a.Name.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+
+            int versionLength = asset == null ? 0 : asset.Name.Length - pattern.Length - suffix.Length;
+            string? wanted = versionLength > 0 ? asset!.Name.Substring(pattern.Length, versionLength) : null;
+
+            string versionFile = Path.Combine(toolsPath, releaseAsset, "VERSION");
+            string? installed = File.Exists(versionFile) ? File.ReadAllText(versionFile).Trim() : null;
+
+            if (wanted == null)
+            {
+                AnsiConsole.MarkupLine($"  {releaseAsset}: [yellow]no usable {platform} asset in '{InstallCommand.ToolsReleaseTag}'[/]");
+            }
+            else if (installed == null)
+            {
+                AnsiConsole.MarkupLine($"  {releaseAsset}: [dim]no bundle (a matching system tool may be in use)[/] (available: {Markup.Escape(wanted)})");
+            }
+            else if (ToolResolver.VersionsMatch(wanted, installed))
+            {
+                AnsiConsole.MarkupLine($"  {releaseAsset}: [green]{Markup.Escape(installed)}[/] [dim](up to date)[/]");
+            }
+            else
+            {
+                AnsiConsole.MarkupLine($"  {releaseAsset}: [yellow]{Markup.Escape(installed)}[/] -> [green]{Markup.Escape(wanted)}[/]");
+            }
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  Project pin updates
+    // ═══════════════════════════════════════════════════════════════════════
+
+    private static List<PinPlanEntry> BuildPinPlan(string? projectRoot, string? targetVersion, UpdateSettings settings)
+    {
+        List<PinPlanEntry> plan = [];
+        if (projectRoot == null || targetVersion == null)
+        {
+            return plan;
+        }
+
+        List<string> files;
+        try
+        {
+            files = ProjectPinUpdater.FindPinFiles(projectRoot);
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"  [yellow]Could not scan {Markup.Escape(projectRoot)}: {Markup.Escape(ex.Message)}[/]");
+            return plan;
+        }
+
+        if (settings.Project == null && files.Count > MaxPinFilesWithoutExplicitProject)
+        {
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine(
+                $"  [yellow]{files.Count} Cosmos project files found under {Markup.Escape(projectRoot)} — refusing to edit that many without an explicit --project.[/]");
+            return plan;
+        }
+
+        foreach (string file in files)
+        {
+            ProjectPinUpdater.PinEdit edit;
+            try
+            {
+                edit = ProjectPinUpdater.ComputeEdit(file, File.ReadAllText(file), targetVersion);
+            }
+            catch (Exception ex)
+            {
+                plan.Add(new PinPlanEntry(file, new ProjectPinUpdater.PinEdit("", 0, 0, []), $"unreadable: {ex.Message}"));
+                continue;
+            }
+
+            if (edit.PinCount == 0)
+            {
+                // Only token/property/commented pins — nothing literal to move.
+                continue;
+            }
+
+            if (edit.ChangedCount == 0)
+            {
+                plan.Add(new PinPlanEntry(file, edit, $"already {targetVersion}"));
+                continue;
+            }
+
+            // A project pinned to something newer than the target (typically a
+            // date-stamped local dev build) is only moved on an explicit --version;
+            // a plain update must never silently downgrade it.
+            string? newerPin = settings.Version == null
+                ? edit.PreviousVersions.FirstOrDefault(v => NuGetVersions.IsNewer(v, targetVersion))
+                : null;
+            if (newerPin != null)
+            {
+                plan.Add(new PinPlanEntry(file, edit, $"pinned to newer {newerPin} — kept (use --version to override)"));
+                continue;
+            }
+
+            plan.Add(new PinPlanEntry(file, edit, null));
+        }
+
+        return plan;
+    }
+
+    private static void PrintPinPlan(List<PinPlanEntry> plan, string? projectRoot, string? targetVersion)
+    {
+        if (projectRoot == null || plan.Count == 0)
+        {
+            return;
+        }
+
+        AnsiConsole.WriteLine();
+        foreach (PinPlanEntry entry in plan)
+        {
+            string relative = Path.GetRelativePath(projectRoot, entry.FilePath);
+            if (entry.SkipReason != null)
+            {
+                AnsiConsole.MarkupLine($"  {Markup.Escape(relative)}: [dim]{Markup.Escape(entry.SkipReason)}[/]");
+                continue;
+            }
+
+            string previous = string.Join(", ", entry.Edit.PreviousVersions);
+            AnsiConsole.MarkupLine(
+                $"  {Markup.Escape(relative)}: [yellow]{Markup.Escape(previous)}[/] -> [green]{Markup.Escape(targetVersion ?? "?")}[/] ({entry.Edit.ChangedCount} pins)");
+        }
+    }
+
+    private static bool ApplyPinPlan(List<PinPlanEntry> plan, string? projectRoot)
+    {
+        if (projectRoot == null)
+        {
+            return true;
+        }
+
+        List<PinPlanEntry> writable = plan.Where(entry => entry.SkipReason == null).ToList();
+        if (writable.Count == 0)
+        {
+            return true;
+        }
+
+        AnsiConsole.WriteLine();
+        bool ok = true;
+        foreach (PinPlanEntry entry in writable)
+        {
+            string relative = Path.GetRelativePath(projectRoot, entry.FilePath);
+            try
+            {
+                File.WriteAllText(entry.FilePath, entry.Edit.NewContent);
+                string previous = string.Join(", ", entry.Edit.PreviousVersions);
+                AnsiConsole.MarkupLine($"  {Markup.Escape(relative)}: [yellow]{Markup.Escape(previous)}[/] -> [green]updated[/] ({entry.Edit.ChangedCount} pins)");
+            }
+            catch (Exception ex)
+            {
+                ok = false;
+                AnsiConsole.MarkupLine($"  [red]{Markup.Escape(relative)}: {Markup.Escape(ex.Message)}[/]");
+            }
+        }
+
+        return ok;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  CLI self-update — always the last step
+    // ═══════════════════════════════════════════════════════════════════════
+
+    private static async Task<bool> SelfUpdateAsync(UpdateSettings settings, string current, string? latest, bool includePrerelease)
+    {
+        AnsiConsole.WriteLine();
+        if (latest == null || !NuGetVersions.IsNewer(latest, current))
+        {
+            AnsiConsole.MarkupLine($"  cosmos CLI [green]{Markup.Escape(current)}[/] is up to date.");
+            return true;
+        }
+
+        // settings.Version passed IsValidVersionRequest, so interpolating it into
+        // a command line is safe.
+        string versionArgs = settings.Version != null
+            ? $" --version {settings.Version}"
+            : includePrerelease ? " --prerelease" : "";
+
+        if (OperatingSystem.IsWindows())
+        {
+            // A running global tool cannot replace itself on Windows: the .store
+            // directory move fails on the locked DLLs mid-transaction and can leave
+            // the shim broken. Hand the update to a detached shell that gives this
+            // process ~2 seconds to exit first; the outcome shows on the next run.
+            AnsiConsole.Markup($"  Updating cosmos CLI to {Markup.Escape(latest)} in the background... ");
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = "cmd.exe",
+                    Arguments = $"/C timeout /T 2 /NOBREAK >nul & dotnet tool update --global Cosmos.Tools{versionArgs}",
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                });
+                AnsiConsole.MarkupLine("[green]OK[/]");
+                AnsiConsole.MarkupLine($"  [dim]Version {Markup.Escape(latest)} becomes active on the next cosmos invocation.[/]");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine("[red]FAILED[/]");
+                AnsiConsole.MarkupLine($"  [red]{Markup.Escape(ex.Message)}[/]");
+                AnsiConsole.MarkupLine("  Run [blue]dotnet tool update -g Cosmos.Tools[/] manually.");
+                return false;
+            }
+        }
+
+        // On Linux/macOS replacing the files of a running process is safe (rename
+        // semantics) — the current process keeps its old inodes.
+        AnsiConsole.Markup($"  Updating cosmos CLI {Markup.Escape(current)} -> {Markup.Escape(latest)}... ");
+        (bool ok, string output) = await RunCaptureAsync("dotnet", $"tool update --global Cosmos.Tools{versionArgs}");
+
+        // Exit code 0 also covers "already installed" — report the tool's own
+        // outcome line instead of trusting the code.
+        string? outcome = output
+            .Split('\n')
+            .Select(line => line.Trim())
+            .LastOrDefault(line =>
+                line.Contains("successfully", StringComparison.OrdinalIgnoreCase)
+                || line.Contains("already installed", StringComparison.OrdinalIgnoreCase));
+
+        if (ok)
+        {
+            AnsiConsole.MarkupLine("[green]OK[/]");
+            if (outcome != null)
+            {
+                AnsiConsole.MarkupLine($"  [dim]{Markup.Escape(outcome)}[/]");
+            }
+
+            return true;
+        }
+
+        AnsiConsole.MarkupLine("[red]FAILED[/]");
+        AnsiConsole.MarkupLine("  Run [blue]dotnet tool update -g Cosmos.Tools[/] manually.");
+        return false;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  Process helpers
+    // ═══════════════════════════════════════════════════════════════════════
+
+    private static async Task RunQuietAsync(string fileName, string arguments)
+    {
+        try
+        {
+            using Process? process = Process.Start(new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            });
+            if (process != null)
+            {
+                await process.WaitForExitAsync();
+            }
+        }
+        catch
+        {
+            // Best-effort — the follow-up install reports the real outcome.
+        }
+    }
+
+    private static async Task<(bool Ok, string Output)> RunCaptureAsync(string fileName, string arguments)
+    {
+        try
+        {
+            using Process? process = Process.Start(new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            });
+            if (process == null)
+            {
+                return (false, "");
+            }
+
+            string stdout = await process.StandardOutput.ReadToEndAsync();
+            string stderr = await process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync();
+            return (process.ExitCode == 0, stdout + "\n" + stderr);
+        }
+        catch (Exception ex)
+        {
+            return (false, ex.Message);
+        }
+    }
+}

--- a/src/Cosmos.Tools/Cosmos.Tools.csproj
+++ b/src/Cosmos.Tools/Cosmos.Tools.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Cosmos.Tests.Patcher" />
+    <InternalsVisibleTo Include="Cosmos.Tests.Tools" />
   </ItemGroup>
 
 </Project>

--- a/src/Cosmos.Tools/Platform/ToolChecker.cs
+++ b/src/Cosmos.Tools/Platform/ToolChecker.cs
@@ -56,11 +56,18 @@ public static class ToolChecker
         return results;
     }
 
+    /// <summary>Per-user Cosmos state directory (parent of the tools dir; holds e.g. the update-check state).</summary>
+    public static string GetCosmosRootPath()
+    {
+        return PlatformInfo.CurrentOS == OSPlatform.Windows
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Cosmos")
+            : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".cosmos");
+    }
+
     public static string GetCosmosToolsPath()
     {
-        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         return PlatformInfo.CurrentOS == OSPlatform.Windows
-            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Cosmos", "Tools")
-            : Path.Combine(home, ".cosmos", "tools");
+            ? Path.Combine(GetCosmosRootPath(), "Tools")
+            : Path.Combine(GetCosmosRootPath(), "tools");
     }
 }

--- a/src/Cosmos.Tools/Program.cs
+++ b/src/Cosmos.Tools/Program.cs
@@ -19,6 +19,9 @@ class Program
             config.AddCommand<InstallCommand>("install")
                 .WithDescription("Install required development tools");
 
+            config.AddCommand<UpdateCommand>("update")
+                .WithDescription("Update Cosmos tools, templates, and the current project to the latest release");
+
             config.AddCommand<NewCommand>("new")
                 .WithDescription("Create a new Cosmos kernel project");
 

--- a/src/Cosmos.Tools/Update/NuGetVersions.cs
+++ b/src/Cosmos.Tools/Update/NuGetVersions.cs
@@ -1,0 +1,245 @@
+using System.Reflection;
+using System.Text.Json;
+
+namespace Cosmos.Tools.Update;
+
+/// <summary>
+/// Latest-version lookup against nuget.org plus the version-ordering rules Cosmos
+/// needs: release versions are 3-part (3.0.71) while dev builds are 4-part
+/// date-stamped (3.0.71.20260719), and a dev stamp must never be reported as
+/// outdated by the release it was derived from.
+/// </summary>
+public static class NuGetVersions
+{
+    private const string ServiceIndexUrl = "https://api.nuget.org/v3/index.json";
+
+    /// <summary>
+    /// Resolves the highest version of a package on nuget.org. Prerelease versions
+    /// are skipped unless <paramref name="includePrerelease"/> is set. Returns null
+    /// when the package or the network is unavailable — callers treat that as
+    /// "no update", never as an error.
+    /// </summary>
+    public static async Task<string?> GetLatestVersionAsync(HttpClient http, string packageId, bool includePrerelease, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // The flatcontainer base URL must come from the service index — the
+            // NuGet docs reserve the right to move the PackageBaseAddress resource.
+            string indexJson = await http.GetStringAsync(ServiceIndexUrl, cancellationToken);
+            string? baseUrl = null;
+            using (JsonDocument index = JsonDocument.Parse(indexJson))
+            {
+                foreach (JsonElement resource in index.RootElement.GetProperty("resources").EnumerateArray())
+                {
+                    if (resource.TryGetProperty("@type", out JsonElement type)
+                        && type.GetString() == "PackageBaseAddress/3.0.0")
+                    {
+                        baseUrl = resource.GetProperty("@id").GetString();
+                        break;
+                    }
+                }
+            }
+
+            if (baseUrl == null)
+            {
+                return null;
+            }
+
+            string url = $"{baseUrl.TrimEnd('/')}/{packageId.ToLowerInvariant()}/index.json";
+            string versionsJson = await http.GetStringAsync(url, cancellationToken);
+            using JsonDocument doc = JsonDocument.Parse(versionsJson);
+
+            List<string> versions = new List<string>();
+            foreach (JsonElement element in doc.RootElement.GetProperty("versions").EnumerateArray())
+            {
+                if (element.GetString() is string version)
+                {
+                    versions.Add(version);
+                }
+            }
+
+            return PickLatest(versions, includePrerelease);
+        }
+        catch
+        {
+            // Offline, rate-limited, 404 on a just-published package still
+            // propagating through the CDN — all mean "no update available".
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Picks the highest version from a flatcontainer version list. The list
+    /// contains prerelease (and unlisted) versions, so stable-only filtering
+    /// happens here.
+    /// </summary>
+    public static string? PickLatest(IEnumerable<string> versions, bool includePrerelease)
+    {
+        string? best = null;
+        foreach (string candidate in versions)
+        {
+            if (!includePrerelease && candidate.Contains('-'))
+            {
+                continue;
+            }
+
+            if (!TryParseNumeric(candidate, out _))
+            {
+                continue;
+            }
+
+            if (best == null || Compare(candidate, best) > 0)
+            {
+                best = candidate;
+            }
+        }
+
+        return best;
+    }
+
+    /// <summary>
+    /// Orders two versions: numeric parts first, then a stable version above any
+    /// prerelease with the same numeric part, then prerelease identifiers by the
+    /// SemVer rules (dot-separated; numeric identifiers compare numerically and
+    /// order below alphanumeric ones — so rc.10 &gt; rc.9).
+    /// </summary>
+    public static int Compare(string a, string b)
+    {
+        bool aParsed = TryParseNumeric(a, out Version aNumeric);
+        bool bParsed = TryParseNumeric(b, out Version bNumeric);
+        if (!aParsed || !bParsed)
+        {
+            return aParsed == bParsed ? 0 : aParsed ? 1 : -1;
+        }
+
+        int numeric = aNumeric.CompareTo(bNumeric);
+        if (numeric != 0)
+        {
+            return numeric;
+        }
+
+        string aPre = PrereleasePart(a);
+        string bPre = PrereleasePart(b);
+        if (aPre.Length == 0 || bPre.Length == 0)
+        {
+            return bPre.Length.CompareTo(aPre.Length);
+        }
+
+        return ComparePrerelease(aPre, bPre);
+    }
+
+    private static string PrereleasePart(string version)
+    {
+        int metadata = version.IndexOf('+');
+        string bare = metadata >= 0 ? version[..metadata] : version;
+        int dash = bare.IndexOf('-');
+        return dash >= 0 ? bare[(dash + 1)..] : "";
+    }
+
+    private static int ComparePrerelease(string a, string b)
+    {
+        string[] aIds = a.Split('.');
+        string[] bIds = b.Split('.');
+        int shared = Math.Min(aIds.Length, bIds.Length);
+        for (int i = 0; i < shared; i++)
+        {
+            bool aIsNumber = long.TryParse(aIds[i], out long aValue);
+            bool bIsNumber = long.TryParse(bIds[i], out long bValue);
+            int comparison = (aIsNumber, bIsNumber) switch
+            {
+                (true, true) => aValue.CompareTo(bValue),
+                (true, false) => -1,
+                (false, true) => 1,
+                (false, false) => string.CompareOrdinal(aIds[i], bIds[i])
+            };
+            if (comparison != 0)
+            {
+                return comparison;
+            }
+        }
+
+        return aIds.Length.CompareTo(bIds.Length);
+    }
+
+    /// <summary>
+    /// Sanity gate for a user-supplied --version: must have a parsable numeric
+    /// part and stay within the NuGet version character set. This also keeps the
+    /// value safe to interpolate into child-process command lines.
+    /// </summary>
+    public static bool IsValidVersionRequest(string version)
+    {
+        return TryParseNumeric(version, out _)
+            && version.All(static c => char.IsAsciiLetterOrDigit(c) || c is '.' or '-' or '+');
+    }
+
+    /// <summary>
+    /// Parses the numeric part of a version, dropping any -prerelease or +metadata
+    /// suffix and padding to four components so "3.0.71" and "3.0.71.0" compare equal.
+    /// </summary>
+    public static bool TryParseNumeric(string? version, out Version parsed)
+    {
+        parsed = new Version(0, 0);
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return false;
+        }
+
+        string numeric = version;
+        int suffix = numeric.IndexOfAny(['-', '+']);
+        if (suffix >= 0)
+        {
+            numeric = numeric[..suffix];
+        }
+
+        if (!numeric.Contains('.'))
+        {
+            numeric += ".0";
+        }
+
+        if (!Version.TryParse(numeric, out Version? result))
+        {
+            return false;
+        }
+
+        parsed = new Version(
+            result.Major,
+            result.Minor,
+            result.Build < 0 ? 0 : result.Build,
+            result.Revision < 0 ? 0 : result.Revision);
+        return true;
+    }
+
+    /// <summary>
+    /// True when <paramref name="candidate"/> is strictly newer than
+    /// <paramref name="current"/> under <see cref="Compare"/>.
+    /// </summary>
+    public static bool IsNewer(string candidate, string current)
+    {
+        if (!TryParseNumeric(candidate, out _) || !TryParseNumeric(current, out _))
+        {
+            return false;
+        }
+
+        return Compare(candidate, current) > 0;
+    }
+
+    /// <summary>
+    /// The version of the running CLI as it appears on NuGet. Read from
+    /// AssemblyInformationalVersion — AssemblyVersion is truncated to three parts
+    /// repo-wide (see Directory.Build.props) and cannot represent the 4-part
+    /// date-stamped dev versions; the "+&lt;commit&gt;" SourceLink suffix is stripped.
+    /// </summary>
+    public static string CurrentCliVersion()
+    {
+        string? informational = typeof(NuGetVersions).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+        if (string.IsNullOrWhiteSpace(informational))
+        {
+            return typeof(NuGetVersions).Assembly.GetName().Version?.ToString(3) ?? "0.0.0";
+        }
+
+        int metadata = informational.IndexOf('+');
+        return metadata >= 0 ? informational[..metadata] : informational;
+    }
+}

--- a/src/Cosmos.Tools/Update/ProjectPinUpdater.cs
+++ b/src/Cosmos.Tools/Update/ProjectPinUpdater.cs
@@ -1,0 +1,192 @@
+using System.Text.RegularExpressions;
+
+namespace Cosmos.Tools.Update;
+
+/// <summary>
+/// Rewrites the Cosmos version pins a kernel project carries. Regex-based text
+/// replacement rather than XML/JSON round-tripping so user formatting survives.
+/// Covers every pin syntax the SDK supports:
+/// <code>
+///   &lt;Project Sdk="Cosmos.Sdk/3.0.71"&gt;                          (template output)
+///   &lt;Sdk Name="Cosmos.Sdk" Version="3.0.71" /&gt;                  (element form)
+///   "msbuild-sdks": { "Cosmos.Sdk": "3.0.71" }                  (global.json)
+///   &lt;PackageReference Include="Cosmos.*" Version="3.0.71" /&gt;    (and CPM PackageVersion)
+/// </code>
+/// The pins must move as one set: the Sdk pin controls the versions of every
+/// transitive Cosmos package via the baked Sdk.props, so a partial bump restores
+/// a mixed-version graph.
+/// </summary>
+public static class ProjectPinUpdater
+{
+    private static readonly Regex s_sdkAttribute = new Regex(
+        "(?<pre>\\bSdk\\s*=\\s*\"Cosmos\\.Sdk/)(?<ver>[^\"]+)(?=\")",
+        RegexOptions.Compiled);
+
+    private static readonly Regex s_sdkElement = new Regex(
+        "(?<pre><Sdk\\b(?=[^>]*\\bName\\s*=\\s*\"Cosmos\\.Sdk\")[^>]*?\\bVersion\\s*=\\s*\")(?<ver>[^\"]+)(?=\")",
+        RegexOptions.Compiled | RegexOptions.Singleline);
+
+    private static readonly Regex s_packagePin = new Regex(
+        "(?<pre><(?:PackageReference|PackageVersion)\\b(?=[^>]*\\bInclude\\s*=\\s*\"Cosmos\\.[^\"]*\")[^>]*?\\bVersion\\s*=\\s*\")(?<ver>[^\"]+)(?=\")",
+        RegexOptions.Compiled | RegexOptions.Singleline);
+
+    private static readonly Regex s_globalJsonSdk = new Regex(
+        "(?<pre>\"Cosmos\\.Sdk\"\\s*:\\s*\")(?<ver>[^\"]+)(?=\")",
+        RegexOptions.Compiled);
+
+    /// <param name="NewContent">File content with every Cosmos pin set to the target version.</param>
+    /// <param name="PinCount">Total Cosmos pins found in the file.</param>
+    /// <param name="ChangedCount">Pins whose value actually changed.</param>
+    /// <param name="PreviousVersions">Distinct versions the file pinned before the edit.</param>
+    public sealed record PinEdit(string NewContent, int PinCount, int ChangedCount, IReadOnlyList<string> PreviousVersions);
+
+    /// <summary>
+    /// Finds the files under <paramref name="rootDir"/> that carry Cosmos version
+    /// pins: *.csproj, Directory.Packages.props (CPM), and global.json
+    /// (msbuild-sdks form). Build output is skipped and recursion is depth-capped
+    /// so running from an unexpectedly broad directory stays cheap.
+    /// </summary>
+    public static List<string> FindPinFiles(string rootDir)
+    {
+        EnumerationOptions options = new EnumerationOptions
+        {
+            RecurseSubdirectories = true,
+            MaxRecursionDepth = 2,
+            IgnoreInaccessible = true
+        };
+
+        List<string> files = new List<string>();
+        foreach (string pattern in (string[])["*.csproj", "Directory.Packages.props", "global.json"])
+        {
+            foreach (string file in Directory.EnumerateFiles(rootDir, pattern, options))
+            {
+                if (IsInBuildOutput(rootDir, file))
+                {
+                    continue;
+                }
+
+                string content;
+                try
+                {
+                    content = File.ReadAllText(file);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (SelectRegexes(file).Any(regex => regex.IsMatch(content)))
+                {
+                    files.Add(file);
+                }
+            }
+        }
+
+        files.Sort(StringComparer.Ordinal);
+        return files;
+    }
+
+    /// <summary>
+    /// Computes the rewritten content of one pin file. Pure — does not touch disk.
+    /// Pins inside XML comments and non-literal pins (MSBuild properties like
+    /// $(VersionPrefix), pack-time tokens like @CosmosPackageVersion@) are left
+    /// untouched and not counted.
+    /// </summary>
+    public static PinEdit ComputeEdit(string filePath, string content, string newVersion)
+    {
+        bool isXml = !Path.GetFileName(filePath).Equals("global.json", StringComparison.OrdinalIgnoreCase);
+        List<(int Start, int End)> commentSpans = isXml ? FindCommentSpans(content) : [];
+
+        int pins = 0;
+        int changed = 0;
+        HashSet<string> previous = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        string result = content;
+        foreach (Regex regex in SelectRegexes(filePath))
+        {
+            // Span positions are relative to the string a Replace pass runs on;
+            // a previous rule's replacements shift them, so recompute.
+            if (isXml && !ReferenceEquals(result, content))
+            {
+                commentSpans = FindCommentSpans(result);
+            }
+
+            result = regex.Replace(result, match =>
+            {
+                string oldVersion = match.Groups["ver"].Value;
+                if (IsInsideSpan(commentSpans, match.Index)
+                    || oldVersion.Contains("$(")
+                    || oldVersion.Contains('@'))
+                {
+                    return match.Value;
+                }
+
+                pins++;
+                previous.Add(oldVersion);
+                if (!string.Equals(oldVersion, newVersion, StringComparison.OrdinalIgnoreCase))
+                {
+                    changed++;
+                }
+
+                return match.Groups["pre"].Value + newVersion;
+            });
+        }
+
+        return new PinEdit(result, pins, changed, previous.ToList());
+    }
+
+    private static List<(int Start, int End)> FindCommentSpans(string content)
+    {
+        List<(int Start, int End)> spans = [];
+        int index = 0;
+        while ((index = content.IndexOf("<!--", index, StringComparison.Ordinal)) >= 0)
+        {
+            int end = content.IndexOf("-->", index + 4, StringComparison.Ordinal);
+            if (end < 0)
+            {
+                spans.Add((index, content.Length));
+                break;
+            }
+
+            spans.Add((index, end + 3));
+            index = end + 3;
+        }
+
+        return spans;
+    }
+
+    private static bool IsInsideSpan(List<(int Start, int End)> spans, int index)
+    {
+        foreach ((int start, int end) in spans)
+        {
+            if (index >= start && index < end)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static Regex[] SelectRegexes(string filePath)
+    {
+        return Path.GetFileName(filePath).Equals("global.json", StringComparison.OrdinalIgnoreCase)
+            ? [s_globalJsonSdk]
+            : [s_sdkAttribute, s_sdkElement, s_packagePin];
+    }
+
+    private static bool IsInBuildOutput(string rootDir, string file)
+    {
+        string relative = Path.GetRelativePath(rootDir, file);
+        foreach (string segment in relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
+        {
+            if (segment is "bin" or "obj" or ".git"
+                || segment.StartsWith("output-", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Cosmos.Tools/Update/UpdateNotifier.cs
+++ b/src/Cosmos.Tools/Update/UpdateNotifier.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using Cosmos.Tools.Platform;
+using Spectre.Console;
+
+namespace Cosmos.Tools.Update;
+
+/// <summary>
+/// Once-a-day "new version available" notice. The check result is cached in
+/// the Cosmos state directory so at most one NuGet query happens per day, and
+/// every failure path (offline, rate-limited, corrupt state) is silent — the
+/// notice must never break, slow down, or pollute the actual command.
+/// </summary>
+public static class UpdateNotifier
+{
+    private const string DisableEnvVar = "COSMOS_NO_UPDATE_NOTIFIER";
+    private static readonly TimeSpan s_checkInterval = TimeSpan.FromHours(24);
+    private static readonly TimeSpan s_checkTimeout = TimeSpan.FromMilliseconds(2500);
+
+    private sealed class State
+    {
+        public DateTimeOffset LastCheckedUtc { get; set; }
+        public string? LatestVersion { get; set; }
+    }
+
+    public static string StateFilePath => Path.Combine(ToolChecker.GetCosmosRootPath(), "update-check.json");
+
+    /// <summary>
+    /// Prints a one-line update notice when a newer Cosmos.Tools is known to exist.
+    /// Suppressed in CI, when output is redirected (piped/parsed output must stay
+    /// clean), and via COSMOS_NO_UPDATE_NOTIFIER. Callers must additionally skip
+    /// this in their own machine-readable modes (--json).
+    /// </summary>
+    public static async Task MaybeNotifyAsync()
+    {
+        try
+        {
+            if (Environment.GetEnvironmentVariable(DisableEnvVar) != null
+                || Environment.GetEnvironmentVariable("CI") != null
+                || Console.IsOutputRedirected)
+            {
+                return;
+            }
+
+            State state = LoadState() ?? new State();
+            string current = NuGetVersions.CurrentCliVersion();
+
+            if (DateTimeOffset.UtcNow - state.LastCheckedUtc >= s_checkInterval)
+            {
+                // Stamp before querying so an offline machine retries once a day,
+                // not on every command.
+                state.LastCheckedUtc = DateTimeOffset.UtcNow;
+
+                using CancellationTokenSource timeout = new CancellationTokenSource(s_checkTimeout);
+                using HttpClient http = new HttpClient();
+                http.DefaultRequestHeaders.Add("User-Agent", "Cosmos-Tools");
+
+                string? latest = await NuGetVersions.GetLatestVersionAsync(
+                    http, "Cosmos.Tools", includePrerelease: current.Contains('-'), timeout.Token);
+                if (latest != null)
+                {
+                    state.LatestVersion = latest;
+                }
+
+                SaveState(state);
+            }
+
+            if (state.LatestVersion is string known && NuGetVersions.IsNewer(known, current))
+            {
+                AnsiConsole.MarkupLine(
+                    $"  [yellow]Cosmos {Markup.Escape(known)} is available[/] [dim](installed {Markup.Escape(current)})[/] — run [blue]cosmos update[/].");
+                AnsiConsole.WriteLine();
+            }
+        }
+        catch
+        {
+            // Never let the notifier interfere with the command that ran.
+        }
+    }
+
+    /// <summary>
+    /// Records that an update just ran so the notice disappears immediately
+    /// instead of lingering until the next 24h check.
+    /// </summary>
+    public static void RecordUpdated(string? latestVersion)
+    {
+        SaveState(new State
+        {
+            LastCheckedUtc = DateTimeOffset.UtcNow,
+            LatestVersion = latestVersion ?? NuGetVersions.CurrentCliVersion()
+        });
+    }
+
+    private static State? LoadState()
+    {
+        try
+        {
+            string path = StateFilePath;
+            return File.Exists(path) ? JsonSerializer.Deserialize<State>(File.ReadAllText(path)) : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void SaveState(State state)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(StateFilePath)!);
+            File.WriteAllText(StateFilePath, JsonSerializer.Serialize(state));
+        }
+        catch
+        {
+            // A read-only home directory just means the check re-runs next time.
+        }
+    }
+}

--- a/tests/Cosmos.Tests.Tools/Cosmos.Tests.Tools.csproj
+++ b/tests/Cosmos.Tests.Tools/Cosmos.Tests.Tools.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Cosmos.Tests.Tools</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit.runner.visualstudio"/>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Cosmos.Tools\Cosmos.Tools.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit"/>
+  </ItemGroup>
+</Project>

--- a/tests/Cosmos.Tests.Tools/NuGetVersionsTests.cs
+++ b/tests/Cosmos.Tests.Tools/NuGetVersionsTests.cs
@@ -1,0 +1,121 @@
+using Cosmos.Tools.Update;
+
+namespace Cosmos.Tests.Tools;
+
+public class NuGetVersionsTests
+{
+    [Fact]
+    public void PickLatest_FiltersPrereleaseByDefault()
+    {
+        string? latest = NuGetVersions.PickLatest(["3.0.70", "3.0.71", "3.1.0-rc.1"], includePrerelease: false);
+        Assert.Equal("3.0.71", latest);
+    }
+
+    [Fact]
+    public void PickLatest_IncludesPrereleaseWhenAsked()
+    {
+        string? latest = NuGetVersions.PickLatest(["3.0.70", "3.0.71", "3.1.0-rc.1"], includePrerelease: true);
+        Assert.Equal("3.1.0-rc.1", latest);
+    }
+
+    [Fact]
+    public void PickLatest_StableOutranksPrereleaseWithSameNumericPart()
+    {
+        string? latest = NuGetVersions.PickLatest(["3.1.0-rc.1", "3.1.0"], includePrerelease: true);
+        Assert.Equal("3.1.0", latest);
+    }
+
+    [Fact]
+    public void PickLatest_FourPartDevStampOrdersAboveItsBaseRelease()
+    {
+        string? latest = NuGetVersions.PickLatest(["3.0.71", "3.0.71.20260719"], includePrerelease: false);
+        Assert.Equal("3.0.71.20260719", latest);
+    }
+
+    [Fact]
+    public void PickLatest_UnparsableAndEmptyInputYieldNull()
+    {
+        Assert.Null(NuGetVersions.PickLatest(["abc", ""], includePrerelease: true));
+        Assert.Null(NuGetVersions.PickLatest([], includePrerelease: true));
+    }
+
+    [Theory]
+    [InlineData("3.0.72", "3.0.71", true)]
+    [InlineData("3.0.71", "3.0.72", false)]
+    [InlineData("3.0.71", "3.0.71", false)]
+    public void IsNewer_OrdersReleaseVersions(string candidate, string current, bool expected)
+    {
+        Assert.Equal(expected, NuGetVersions.IsNewer(candidate, current));
+    }
+
+    [Fact]
+    public void IsNewer_DevStampIsNotOutdatedByItsBaseRelease()
+    {
+        // A machine running a locally built 3.0.71.20260719 must not be nagged
+        // to "update" to the 3.0.71 release it was derived from.
+        Assert.False(NuGetVersions.IsNewer("3.0.71", "3.0.71.20260719"));
+        Assert.True(NuGetVersions.IsNewer("3.0.72", "3.0.71.20260719"));
+    }
+
+    [Fact]
+    public void IsNewer_StableIsNewerThanItsOwnPrerelease()
+    {
+        Assert.True(NuGetVersions.IsNewer("3.1.0", "3.1.0-rc.1"));
+        Assert.False(NuGetVersions.IsNewer("3.1.0-rc.1", "3.1.0"));
+    }
+
+    [Fact]
+    public void IsNewer_OrdersPrereleasesOfTheSameBase()
+    {
+        Assert.True(NuGetVersions.IsNewer("3.1.0-rc.2", "3.1.0-rc.1"));
+        Assert.False(NuGetVersions.IsNewer("3.1.0-rc.1", "3.1.0-rc.2"));
+        // Numeric prerelease identifiers compare numerically, not ordinally.
+        Assert.True(NuGetVersions.IsNewer("3.1.0-beta.10", "3.1.0-beta.9"));
+        // SemVer: alpha < alpha.1 < beta (numeric identifiers below alphanumeric).
+        Assert.True(NuGetVersions.IsNewer("3.1.0-alpha.1", "3.1.0-alpha"));
+        Assert.True(NuGetVersions.IsNewer("3.1.0-beta", "3.1.0-alpha.1"));
+    }
+
+    [Fact]
+    public void PickLatest_OrdersDottedNumericPrereleaseTags()
+    {
+        string? latest = NuGetVersions.PickLatest(["3.1.0-beta.9", "3.1.0-beta.10"], includePrerelease: true);
+        Assert.Equal("3.1.0-beta.10", latest);
+
+        latest = NuGetVersions.PickLatest(["3.1.0-beta.10", "3.1.0-beta.9"], includePrerelease: true);
+        Assert.Equal("3.1.0-beta.10", latest);
+    }
+
+    [Theory]
+    [InlineData("3.0.72", true)]
+    [InlineData("3.0.71.20260719", true)]
+    [InlineData("3.1.0-rc.1", true)]
+    [InlineData("3.0.7l", false)]
+    [InlineData("not-a-version", false)]
+    [InlineData("3.0.72 --something", false)]
+    [InlineData("3.0.72&whoami", false)]
+    public void IsValidVersionRequest_GatesUserInput(string version, bool expected)
+    {
+        Assert.Equal(expected, NuGetVersions.IsValidVersionRequest(version));
+    }
+
+    [Fact]
+    public void IsNewer_TrailingZeroRevisionIsNotNewer()
+    {
+        Assert.False(NuGetVersions.IsNewer("3.0.71.0", "3.0.71"));
+        Assert.False(NuGetVersions.IsNewer("3.0.71", "3.0.71.0"));
+    }
+
+    [Fact]
+    public void TryParseNumeric_StripsPrereleaseAndMetadataSuffixes()
+    {
+        Assert.True(NuGetVersions.TryParseNumeric("3.0.71+abc123", out Version withMetadata));
+        Assert.Equal(new Version(3, 0, 71, 0), withMetadata);
+
+        Assert.True(NuGetVersions.TryParseNumeric("3.1.0-rc.1", out Version withPrerelease));
+        Assert.Equal(new Version(3, 1, 0, 0), withPrerelease);
+
+        Assert.False(NuGetVersions.TryParseNumeric(null, out _));
+        Assert.False(NuGetVersions.TryParseNumeric("not-a-version", out _));
+    }
+}

--- a/tests/Cosmos.Tests.Tools/ProjectPinUpdaterTests.cs
+++ b/tests/Cosmos.Tests.Tools/ProjectPinUpdaterTests.cs
@@ -1,0 +1,294 @@
+using Cosmos.Tools.Update;
+
+namespace Cosmos.Tests.Tools;
+
+public class ProjectPinUpdaterTests
+{
+    private const string NewVersion = "3.0.72";
+
+    // Mirrors src/Cosmos.Build.Templates/templates/cosmos-kernel/KernelName.csproj
+    // after pack-time token substitution — the exact shape every generated project has.
+    private const string TemplateCsproj = """
+        <Project Sdk="Cosmos.Sdk/3.0.70">
+
+          <PropertyGroup>
+            <TargetFramework>net10.0</TargetFramework>
+          </PropertyGroup>
+
+          <ItemGroup>
+            <PackageReference Include="Cosmos.Kernel" Version="3.0.70" />
+            <PackageReference Include="Cosmos.Kernel.System" Version="3.0.70" />
+          </ItemGroup>
+
+        </Project>
+        """;
+
+    [Fact]
+    public void TemplateCsproj_MovesAllThreePinsAsOneSet()
+    {
+        ProjectPinUpdater.PinEdit edit = ProjectPinUpdater.ComputeEdit("Kernel.csproj", TemplateCsproj, NewVersion);
+
+        Assert.Equal(3, edit.PinCount);
+        Assert.Equal(3, edit.ChangedCount);
+        Assert.Contains($"Sdk=\"Cosmos.Sdk/{NewVersion}\"", edit.NewContent);
+        Assert.Contains($"<PackageReference Include=\"Cosmos.Kernel\" Version=\"{NewVersion}\" />", edit.NewContent);
+        Assert.Contains($"<PackageReference Include=\"Cosmos.Kernel.System\" Version=\"{NewVersion}\" />", edit.NewContent);
+        Assert.DoesNotContain("3.0.70", edit.NewContent);
+        Assert.Equal(["3.0.70"], edit.PreviousVersions);
+    }
+
+    [Fact]
+    public void SdkElementForm_IsUpdated()
+    {
+        string content = """
+            <Project>
+              <Sdk Name="Cosmos.Sdk" Version="3.0.70" />
+            </Project>
+            """;
+
+        ProjectPinUpdater.PinEdit edit = ProjectPinUpdater.ComputeEdit("Kernel.csproj", content, NewVersion);
+
+        Assert.Equal(1, edit.ChangedCount);
+        Assert.Contains($"<Sdk Name=\"Cosmos.Sdk\" Version=\"{NewVersion}\" />", edit.NewContent);
+    }
+
+    [Fact]
+    public void SdkElementForm_VersionBeforeName_IsUpdated()
+    {
+        string content = "<Project>\n  <Sdk Version=\"3.0.70\" Name=\"Cosmos.Sdk\" />\n</Project>";
+
+        ProjectPinUpdater.PinEdit edit = ProjectPinUpdater.ComputeEdit("Kernel.csproj", content, NewVersion);
+
+        Assert.Equal(1, edit.ChangedCount);
+        Assert.Contains($"<Sdk Version=\"{NewVersion}\" Name=\"Cosmos.Sdk\" />", edit.NewContent);
+    }
+
+    [Fact]
+    public void SdkElement_ForOtherSdk_IsUntouched()
+    {
+        string content = "<Project>\n  <Sdk Name=\"Other.Sdk\" Version=\"1.0.0\" />\n</Project>";
+
+        ProjectPinUpdater.PinEdit edit = ProjectPinUpdater.ComputeEdit("Kernel.csproj", content, NewVersion);
+
+        Assert.Equal(0, edit.PinCount);
+        Assert.Equal(content, edit.NewContent);
+    }
+
+    [Fact]
+    public void PackageReference_VersionBeforeInclude_IsUpdated()
+    {
+        string content = "<ItemGroup>\n  <PackageReference Version=\"3.0.70\" Include=\"Cosmos.Kernel\" />\n</ItemGroup>";
+
+        ProjectPinUpdater.PinEdit edit = ProjectPinUpdater.ComputeEdit("Kernel.csproj", content, NewVersion);
+
+        Assert.Equal(1, edit.ChangedCount);
+        Assert.Contains($"Version=\"{NewVersion}\" Include=\"Cosmos.Kernel\"", edit.NewContent);
+    }
+
+    [Fact]
+    public void PackageReference_MultiLineAttributes_IsUpdated()
+    {
+        string content = """
+            <ItemGroup>
+              <PackageReference Include="Cosmos.Kernel"
+                                Version="3.0.70" />
+            </ItemGroup>
+            """;
+
+        ProjectPinUpdater.PinEdit edit = ProjectPinUpdater.ComputeEdit("Kernel.csproj", content, NewVersion);
+
+        Assert.Equal(1, edit.ChangedCount);
+        Assert.Contains($"Version=\"{NewVersion}\"", edit.NewContent);
+    }
+
+    [Fact]
+    public void NonCosmosPackages_AreUntouched()
+    {
+        string content = """
+            <ItemGroup>
+              <PackageReference Include="Spectre.Console" Version="0.49.1" />
+              <PackageReference Include="Cosmos.Kernel" Version="3.0.70" />
+            </ItemGroup>
+            """;
+
+        ProjectPinUpdater.PinEdit edit = ProjectPinUpdater.ComputeEdit("Kernel.csproj", content, NewVersion);
+
+        Assert.Equal(1, edit.ChangedCount);
+        Assert.Contains("<PackageReference Include=\"Spectre.Console\" Version=\"0.49.1\" />", edit.NewContent);
+    }
+
+    [Fact]
+    public void UnderscorePrefixedInternalPackage_IsUntouched()
+    {
+        string content = "<ItemGroup>\n  <PackageReference Include=\"_Cosmos.Build.Analyzer.Patcher\" Version=\"3.0.70\" />\n</ItemGroup>";
+
+        ProjectPinUpdater.PinEdit edit = ProjectPinUpdater.ComputeEdit("Kernel.csproj", content, NewVersion);
+
+        Assert.Equal(0, edit.PinCount);
+        Assert.Equal(content, edit.NewContent);
+    }
+
+    [Fact]
+    public void CentralPackageManagementProps_UpdatesOnlyCosmosPins()
+    {
+        string content = """
+            <Project>
+              <ItemGroup>
+                <PackageVersion Include="Cosmos.Kernel" Version="3.0.70" />
+                <PackageVersion Include="Cosmos.Build.Ilc" Version="3.0.70" />
+                <PackageVersion Include="xunit" Version="2.9.3" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        ProjectPinUpdater.PinEdit edit = ProjectPinUpdater.ComputeEdit("Directory.Packages.props", content, NewVersion);
+
+        Assert.Equal(2, edit.ChangedCount);
+        Assert.Contains($"<PackageVersion Include=\"Cosmos.Kernel\" Version=\"{NewVersion}\" />", edit.NewContent);
+        Assert.Contains($"<PackageVersion Include=\"Cosmos.Build.Ilc\" Version=\"{NewVersion}\" />", edit.NewContent);
+        Assert.Contains("<PackageVersion Include=\"xunit\" Version=\"2.9.3\" />", edit.NewContent);
+    }
+
+    [Fact]
+    public void GlobalJson_UpdatesOnlyTheCosmosSdkEntry()
+    {
+        string content = """
+            {
+              "msbuild-sdks": {
+                "Cosmos.Sdk": "3.0.71.20260719",
+                "Other.Sdk": "1.2.3"
+              }
+            }
+            """;
+
+        ProjectPinUpdater.PinEdit edit = ProjectPinUpdater.ComputeEdit("global.json", content, NewVersion);
+
+        Assert.Equal(1, edit.ChangedCount);
+        Assert.Contains($"\"Cosmos.Sdk\": \"{NewVersion}\"", edit.NewContent);
+        Assert.Contains("\"Other.Sdk\": \"1.2.3\"", edit.NewContent);
+        Assert.Equal(["3.0.71.20260719"], edit.PreviousVersions);
+    }
+
+    [Fact]
+    public void GlobalJson_SdkSyntaxIsNotAppliedToCsproj()
+    {
+        // A csproj that merely mentions "Cosmos.Sdk": "..." in a comment/string must
+        // not be edited by the JSON rule — file kind selects the rule set.
+        string content = "<!-- \"Cosmos.Sdk\": \"3.0.70\" -->\n<Project></Project>";
+
+        ProjectPinUpdater.PinEdit edit = ProjectPinUpdater.ComputeEdit("Kernel.csproj", content, NewVersion);
+
+        Assert.Equal(0, edit.PinCount);
+        Assert.Equal(content, edit.NewContent);
+    }
+
+    [Fact]
+    public void MixedVersions_AreUnifiedToTheTarget()
+    {
+        string content = """
+            <Project Sdk="Cosmos.Sdk/3.0.69">
+              <ItemGroup>
+                <PackageReference Include="Cosmos.Kernel" Version="3.0.70" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        ProjectPinUpdater.PinEdit edit = ProjectPinUpdater.ComputeEdit("Kernel.csproj", content, NewVersion);
+
+        Assert.Equal(2, edit.ChangedCount);
+        Assert.DoesNotContain("3.0.69", edit.NewContent);
+        Assert.DoesNotContain("3.0.70", edit.NewContent);
+        Assert.Contains("3.0.69", edit.PreviousVersions);
+        Assert.Contains("3.0.70", edit.PreviousVersions);
+    }
+
+    [Fact]
+    public void NonLiteralPins_PropertiesAndTokens_AreUntouched()
+    {
+        // The repo's own raw template and any project driving versions from an
+        // MSBuild property must never have those replaced with a literal.
+        string content = """
+            <Project Sdk="Cosmos.Sdk/@CosmosPackageVersion@">
+              <ItemGroup>
+                <PackageReference Include="Cosmos.Kernel" Version="$(CosmosVersion)" />
+                <PackageReference Include="Cosmos.Kernel.System" Version="@CosmosPackageVersion@" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        ProjectPinUpdater.PinEdit edit = ProjectPinUpdater.ComputeEdit("Kernel.csproj", content, NewVersion);
+
+        Assert.Equal(0, edit.PinCount);
+        Assert.Equal(0, edit.ChangedCount);
+        Assert.Equal(content, edit.NewContent);
+    }
+
+    [Fact]
+    public void PinsInsideXmlComments_AreUntouched()
+    {
+        string content = """
+            <Project Sdk="Cosmos.Sdk/3.0.70">
+              <ItemGroup>
+                <!-- <PackageReference Include="Cosmos.Kernel" Version="1.0.0" /> -->
+                <PackageReference Include="Cosmos.Kernel" Version="3.0.70" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        ProjectPinUpdater.PinEdit edit = ProjectPinUpdater.ComputeEdit("Kernel.csproj", content, NewVersion);
+
+        Assert.Equal(2, edit.ChangedCount);
+        Assert.Contains("<!-- <PackageReference Include=\"Cosmos.Kernel\" Version=\"1.0.0\" /> -->", edit.NewContent);
+        Assert.Contains($"<PackageReference Include=\"Cosmos.Kernel\" Version=\"{NewVersion}\" />", edit.NewContent);
+    }
+
+    [Fact]
+    public void SecondPass_IsIdempotent()
+    {
+        ProjectPinUpdater.PinEdit first = ProjectPinUpdater.ComputeEdit("Kernel.csproj", TemplateCsproj, NewVersion);
+        ProjectPinUpdater.PinEdit second = ProjectPinUpdater.ComputeEdit("Kernel.csproj", first.NewContent, NewVersion);
+
+        Assert.Equal(3, second.PinCount);
+        Assert.Equal(0, second.ChangedCount);
+        Assert.Equal(first.NewContent, second.NewContent);
+    }
+
+    [Fact]
+    public void FindPinFiles_FindsProjectFilesAndSkipsBuildOutput()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"cosmos-pin-test-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "bin"));
+            Directory.CreateDirectory(Path.Combine(root, "obj"));
+            Directory.CreateDirectory(Path.Combine(root, "output-x64"));
+
+            File.WriteAllText(Path.Combine(root, "Kernel.csproj"), TemplateCsproj);
+            File.WriteAllText(Path.Combine(root, "bin", "Kernel.csproj"), TemplateCsproj);
+            File.WriteAllText(Path.Combine(root, "obj", "Kernel.csproj"), TemplateCsproj);
+            File.WriteAllText(Path.Combine(root, "output-x64", "Kernel.csproj"), TemplateCsproj);
+            File.WriteAllText(Path.Combine(root, "global.json"), "{ \"msbuild-sdks\": { \"Cosmos.Sdk\": \"3.0.70\" } }");
+            File.WriteAllText(Path.Combine(root, "Unrelated.csproj"), "<Project Sdk=\"Microsoft.NET.Sdk\"></Project>");
+            File.WriteAllText(Path.Combine(root, "Directory.Packages.props"),
+                "<Project><ItemGroup><PackageVersion Include=\"Cosmos.Kernel\" Version=\"3.0.70\" /></ItemGroup></Project>");
+
+            List<string> files = ProjectPinUpdater.FindPinFiles(root);
+            List<string> names = files.Select(f => Path.GetRelativePath(root, f)).ToList();
+
+            Assert.Equal(3, files.Count);
+            Assert.Contains("Kernel.csproj", names);
+            Assert.Contains("global.json", names);
+            Assert.Contains("Directory.Packages.props", names);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(root, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Updating a Gen3 install currently means uninstall-and-reinstall by hand at every release: the CLI, `Cosmos.Patcher`, the templates, the `~/.cosmos` tool bundles, and the exact version literals every kernel project pins. This adds `cosmos update` to do all of it in one step, plus a rate-limited "new version available" notice.

---

### `cosmos update`

- **System tool bundles** — reuses the install flow, which already skips bundles matching the `tools-latest` asset versions.
- **`Cosmos.Patcher` + templates** — `dotnet tool update` and uninstall-then-reinstall of `Cosmos.Build.Templates`; the template step is gated on feed reachability so an offline run can never uninstall templates it cannot reinstall.
- **VS Code extension** — re-downloads the latest `.vsix` and force-reinstalls (same shape as `cosmos install`).
- **Project pins** — when run inside a kernel project (or with `--project <DIR>`), moves the `Sdk="Cosmos.Sdk/x"` attribute, `<Sdk Name Version>` element form, `Cosmos.*` `PackageReference`/`PackageVersion` entries, and the `global.json` `msbuild-sdks` pin to the target version. The plan is printed before the confirm prompt.
- **CLI self-update, always last** — in-process on Linux/macOS (rename semantics make replacing a running tool safe); on Windows via a detached shell, because `dotnet tool update -g` on the running tool fails mid-transaction on the locked `.store` directory and can leave the shim broken.

| Option | Effect |
|--------|--------|
| `--check` | Report available updates without installing anything |
| `--no-project` | Leave project files untouched |
| `--version <V>` | Target a specific version (validated; also applied to patcher/templates) |
| `--prerelease` | Include prereleases |

### Update notice

`cosmos build`, `cosmos run` (before QEMU takes stdio), and `cosmos check` print one line when a newer `Cosmos.Tools` exists on nuget.org. Checked at most once per 24h, cached in `~/.cosmos/update-check.json`, silent on any failure, suppressed under `--json`, redirected output, `CI`, and `COSMOS_NO_UPDATE_NOTIFIER`.

### Version-channel safety

- 4-part date-stamped dev builds (`3.0.71.20260719`) order above their 3-part base release, so dev installs are never nagged or downgraded.
- A plain `cosmos update` refuses to downgrade a project pinned to something newer than the latest release; `--version` overrides explicitly.
- Prerelease identifiers compare by SemVer rules (`beta.10` > `beta.9`, `rc.2` > `rc.1`, stable > its prereleases).
- Pins expressed as MSBuild properties (`$(Version...)`), pack-time tokens (`@CosmosPackageVersion@`), or inside XML comments are never rewritten.
- `--version` input is validated (parse + NuGet charset) before anything runs, which also keeps it safe to pass to child processes.
- Without an explicit `--project`, discovery is depth-capped and refuses to edit more than 8 files — running `cosmos update -y` from a broad directory cannot mass-edit a monorepo.

### Tests

`tests/Cosmos.Tests.Tools` (37 tests, new `.NET Tests` job) covers the two pure pieces: version ordering/filtering and pin rewriting across every supported syntax. Verified end-to-end against real nuget.org/tools-latest (`--check`), in a sandboxed full run (fake `HOME`, pins rewritten, correct exit codes), and the notifier on a pty with an artificially old CLI (notice, 24h cache, all three suppressions).
