### PR TITLE
🐛 Stop sweeping the unmanaged malloc heaps in the GC

### DIFF
--- a/docs/articles/dev/garbage-collector.md
+++ b/docs/articles/dev/garbage-collector.md
@@ -385,9 +385,6 @@ flowchart TD
     SWEEP["SweepPhase()"] --> SEG["Walk each regular segment
     SweepSegment()"]
     SWEEP --> PIN["SweepPinnedHeap()"]
-    SWEEP --> SM["SweepSmallHeap()"]
-    SWEEP --> MED["SweepMediumHeap()"]
-    SWEEP --> LG["SweepLargeHeap()"]
 
     SEG --> WALK["Linear walk from Start to Bump"]
     WALK --> READ{Read object at ptr}
@@ -408,7 +405,7 @@ For each regular segment, the sweep walks linearly from `Start` to `Bump`. It ac
 
 When a free run reaches the end of a segment (trailing dead objects), the sweeper reclaims that space by moving `Bump` back instead of creating a free block.
 
-The sweep also covers the pinned heap (same algorithm but free runs are not added to the shared free list) and the Small/Medium/Large heaps. For these, the sweeper calls the respective heap's `Free()` method to release dead objects.
+The sweep also covers the pinned heap (same algorithm but free runs are not added to the shared free list). The unmanaged Small/Medium/Large malloc heaps are not swept: managed allocations never live there, and a live block whose first word happens to hold a GC-heap pointer would be indistinguishable from an unmarked object header.
 
 ### Segment reordering
 

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Sweep.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Sweep.cs
@@ -2,19 +2,21 @@
 
 using System.Runtime.CompilerServices;
 using Cosmos.Kernel.Core.IO;
-using Cosmos.Kernel.Core.Memory.Heap;
 using Internal.Runtime;
 
 namespace Cosmos.Kernel.Core.Memory.GarbageCollector;
 
 /// <summary>
-/// Sweep phase: segment sweeping, heap sweepers, and heap range helpers.
+/// Sweep phase: segment sweeping and heap range helpers.
 /// </summary>
 public static unsafe partial class GarbageCollector
 {
     /// <summary>
-    /// Executes the sweep phase across all heap types: GC segments, pinned heap,
-    /// small heap, medium heap, and large heap.
+    /// Executes the sweep phase across the GC-managed heaps: GC segments and the
+    /// pinned heap. The unmanaged malloc heaps (Small/Medium/Large) must never be
+    /// swept: managed allocations cannot live there, and a live block whose first
+    /// word coincidentally holds a GC-heap pointer is indistinguishable from an
+    /// unmarked object header (issue #386).
     /// </summary>
     /// <returns>Total number of objects freed.</returns>
     private static int SweepPhase()
@@ -29,9 +31,6 @@ public static unsafe partial class GarbageCollector
         }
 
         totalFreed += SweepPinnedHeap();
-        totalFreed += SweepSmallHeap();
-        totalFreed += SweepMediumHeap();
-        totalFreed += SweepLargeHeap();
 
         return totalFreed;
     }
@@ -273,190 +272,6 @@ public static unsafe partial class GarbageCollector
         s_currentSegment = s_lastSegment;
 
         s_heapRangeDirty = true;
-    }
-
-    /// <summary>
-    /// Sweeps the small heap (SMT pages) for unmarked objects.
-    /// </summary>
-    /// <returns>The number of objects freed from the small heap.</returns>
-    private static int SweepSmallHeap()
-    {
-        int freed = 0;
-        SMTPage* page = SmallHeap.SMT;
-
-        while (page != null)
-        {
-            RootSMTBlock* root = page->First;
-            while (root != null && root->Size > 0)
-            {
-                SMTBlock* block = root->First;
-                while (block != null)
-                {
-                    freed += SweepSMTBlock(block, root->Size);
-                    block = block->NextBlock;
-                }
-
-                root = root->LargerSize;
-            }
-
-            page = page->Next;
-        }
-
-        return freed;
-    }
-
-    /// <summary>
-    /// Sweeps a single SMT block, freeing unmarked objects and clearing marks on live ones.
-    /// </summary>
-    /// <param name="block">The SMT block to sweep.</param>
-    /// <param name="itemSize">The allocation item size for this block's size class.</param>
-    /// <returns>The number of objects freed in this block.</returns>
-    private static int SweepSMTBlock(SMTBlock* block, uint itemSize)
-    {
-        int freed = 0;
-        ulong elementSize = itemSize + SmallHeap.PrefixBytes;
-        ulong positions = PageAllocator.PageSize / elementSize;
-
-        for (ulong i = 0; i < positions; i++)
-        {
-            byte* slotPtr = block->PagePtr + i * elementSize;
-            ushort* header = (ushort*)slotPtr;
-
-            ushort size = header[0];
-            if (size == 0)
-            {
-                continue; // Not allocated
-            }
-
-            // Get object pointer
-            byte* objPtr = slotPtr + SmallHeap.PrefixBytes;
-            var obj = (GCObject*)objPtr;
-
-            // Validate MethodTable - must point outside heap (to kernel code)
-            nuint mtPtr = (nuint)obj->MethodTable & ~(nuint)1;
-            if (mtPtr == 0 || !IsInGCHeap((nint)mtPtr))
-            {
-                continue;
-            }
-
-            if (!obj->IsMarked)
-            {
-                // Unmarked - free the object
-                SmallHeap.Free(objPtr);
-                freed++;
-            }
-            else
-            {
-                // Marked - clear the mark for next cycle
-                obj->Unmark();
-            }
-        }
-
-        return freed;
-    }
-
-    /// <summary>
-    /// Sweeps the medium heap by scanning all HeapMedium pages in the RAT.
-    /// </summary>
-    /// <returns>The number of objects freed from the medium heap.</returns>
-    private static int SweepMediumHeap()
-    {
-        int freed = 0;
-
-        // Iterate through RAT looking for HeapMedium pages
-        byte* ramStart = PageAllocator.RamStart;
-        for (ulong pageIdx = 0; pageIdx < PageAllocator.TotalPageCount; pageIdx++)
-        {
-            PageType type = PageAllocator.GetPageType(ramStart + pageIdx * PageAllocator.PageSize);
-            if (type != PageType.HeapMedium)
-            {
-                continue;
-            }
-
-            byte* pagePtr = ramStart + pageIdx * PageAllocator.PageSize;
-            var header = (MediumHeapHeader*)pagePtr;
-
-            if (header->Size == 0)
-            {
-                continue; // Not allocated
-            }
-
-            byte* objPtr = pagePtr + MediumHeap.PrefixBytes;
-            var obj = (GCObject*)objPtr;
-
-            // Validate MethodTable - must point outside heap (to kernel code)
-            nuint mtPtr = (nuint)obj->MethodTable & ~(nuint)1;
-            if (mtPtr == 0 || !IsInGCHeap((nint)mtPtr))
-            {
-                continue;
-            }
-
-            if (!obj->IsMarked)
-            {
-                // Unmarked - free the object
-                MediumHeap.Free(objPtr);
-                freed++;
-            }
-            else
-            {
-                // Marked - clear the mark for next cycle
-                obj->Unmark();
-            }
-        }
-
-        return freed;
-    }
-
-    /// <summary>
-    /// Sweeps the large heap by scanning all HeapLarge pages in the RAT.
-    /// </summary>
-    /// <returns>The number of objects freed from the large heap.</returns>
-    private static int SweepLargeHeap()
-    {
-        int freed = 0;
-
-        // Iterate through RAT looking for HeapLarge pages
-        byte* ramStart = PageAllocator.RamStart;
-        for (ulong pageIdx = 0; pageIdx < PageAllocator.TotalPageCount; pageIdx++)
-        {
-            PageType type = PageAllocator.GetPageType(ramStart + pageIdx * PageAllocator.PageSize);
-            if (type != PageType.HeapLarge)
-            {
-                continue;
-            }
-
-            byte* pagePtr = ramStart + pageIdx * PageAllocator.PageSize;
-            var header = (LargeHeapHeader*)pagePtr;
-
-            if (header->Size == 0)
-            {
-                continue; // Not allocated
-            }
-
-            byte* objPtr = pagePtr + LargeHeap.PrefixBytes;
-            var obj = (GCObject*)objPtr;
-
-            // Validate MethodTable - must point outside heap (to kernel code)
-            nuint mtPtr = (nuint)obj->MethodTable & ~(nuint)1;
-            if (mtPtr == 0 || !IsInGCHeap((nint)mtPtr))
-            {
-                continue;
-            }
-
-            if (!obj->IsMarked)
-            {
-                // Unmarked - free the object
-                LargeHeap.Free(objPtr);
-                freed++;
-            }
-            else
-            {
-                // Marked - clear the mark for next cycle
-                obj->Unmark();
-            }
-        }
-
-        return freed;
     }
 
     // --- Helpers ---

--- a/tests/Kernels/Cosmos.Kernel.Tests.GarbageCollector/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.GarbageCollector/Kernel.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Cosmos.Kernel.Core.IO;
 using Cosmos.Kernel.Core.Memory;
 using Cosmos.Kernel.Core.Memory.GarbageCollector.GcInfo;
+using Cosmos.Kernel.Core.Memory.Heap;
 using Cosmos.Kernel.Core.Runtime.GcInfo;
 using Cosmos.Kernel.System.Timer;
 using Cosmos.TestRunner.Framework;
@@ -23,7 +24,7 @@ public class Kernel : Sys.Kernel
         Serial.WriteString("[GarbageCollector] BeforeRun() reached!\n");
         Serial.WriteString("[GarbageCollector] Starting tests...\n");
 
-        TR.Start("GarbageCollector Tests", expectedTests: 43);
+        TR.Start("GarbageCollector Tests", expectedTests: 44);
 
         // Garbage Collection Tests
         TR.Run("GC_IsEnabled", TestGCIsEnabled);
@@ -59,6 +60,7 @@ public class Kernel : Sys.Kernel
         // is parked in #384 until interior-pointer support (#376) lands — it fails today.
         TR.Run("GC_StaticOnlyReachability", TestGCStaticOnlyReachability);
         TR.Run("GC_MultithreadChurnUnderCollect", TestGCMultithreadChurnUnderCollect);
+        TR.Run("GC_MallocHeapNotSwept", TestGCMallocHeapNotSwept);
 
         // GC Info & Configuration Tests
         TR.Run("GC_Info_SimpleMemoryInfo", TestGCInfoSimpleMemoryInfo);
@@ -1022,6 +1024,68 @@ public class Kernel : Sys.Kernel
         Assert.True(s_churnIterations > 0, "GC: churn workers must have completed at least one iteration");
         Assert.Equal(0, s_churnErrorCount,
             "GC: parked-thread survivors must never be corrupted by collections (" + s_churnErrorCount + " errors)");
+    }
+
+    /// <summary>
+    /// A live <see cref="Heap"/> allocation whose first word happens to hold a pointer into
+    /// the GC heap (a native struct caching a managed buffer address). The GC must never free
+    /// it: managed objects cannot live in the malloc heaps, so the sweep has no business there.
+    /// Issue #386 — the malloc-heap sweepers' inverted MethodTable check treated exactly this
+    /// shape as an unmarked managed object and freed it while live.
+    /// </summary>
+    private static unsafe void TestGCMallocHeapNotSwept()
+    {
+        byte[] managedBuffer = new byte[128];
+
+        byte* small = Heap.Alloc(64);     // SmallHeap (SMT slot)
+        byte* medium = Heap.Alloc(3000);  // MediumHeap (page + header)
+        byte* large = Heap.Alloc(8192);   // LargeHeap (multi-page + header)
+
+        // First word: a real GC-heap pointer with the LSB clear — reads as an
+        // "unmarked object whose MethodTable is inside the GC heap" to the sweeper.
+        fixed (byte* bp = managedBuffer)
+        {
+            *(byte**)small = bp;
+            *(byte**)medium = bp;
+            *(byte**)large = bp;
+        }
+
+        small[8] = 0xC5;
+
+        CoreGC.Collect();
+
+        // SmallHeap.Free zeroes the slot header's size and the data;
+        // Medium/LargeHeap.Free return the pages to the page allocator (RAT -> Empty).
+        bool smallAlive = SmallHeap.GetHeader(small)->Size != 0;
+        bool mediumAlive = PageAllocator.GetPageType(medium) == PageType.HeapMedium;
+        bool largeAlive = PageAllocator.GetPageType(large) == PageType.HeapLarge;
+
+        Assert.True(smallAlive,
+            "GC: live small-heap block must remain allocated across a collect (issue #386)");
+        Assert.True(smallAlive && small[8] == 0xC5,
+            "GC: live small-heap block data must be intact after a collect (issue #386)");
+        Assert.True(mediumAlive,
+            "GC: live medium-heap block must remain allocated across a collect (issue #386)");
+        Assert.True(largeAlive,
+            "GC: live large-heap block must remain allocated across a collect (issue #386)");
+
+        GC.KeepAlive(managedBuffer);
+
+        // Free only what survived — Heap.Free on an already-freed block panics the kernel.
+        if (smallAlive)
+        {
+            Heap.Free(small);
+        }
+
+        if (mediumAlive)
+        {
+            Heap.Free(medium);
+        }
+
+        if (largeAlive)
+        {
+            Heap.Free(large);
+        }
     }
 
     // ==================== GC Info & Configuration Tests ====================


### PR DESCRIPTION
Fixes #386

## Problem

`SweepPhase` called `SweepSmallHeap`, `SweepMediumHeap` and `SweepLargeHeap`, which walked the unmanaged malloc heaps looking for GC objects with an inverted MethodTable check: a block was treated as a managed object only when its first word pointed **into** the GC heap — which no real MethodTable ever does. Managed allocations never land in the malloc heaps (all managed allocation exports route to `GarbageCollector.AllocObject`), so the sweepers could never reclaim anything. Instead, any live unmanaged block whose first word happened to hold a GC-heap pointer (e.g. a native struct caching a managed buffer address) read as an unmarked object and was freed while live — silent corruption of unmanaged memory, plus two full RAT walks per collection.

## Fix

- Remove the three sweepers (and `SweepSMTBlock`) and their `SweepPhase` calls; the sweep now covers only the GC segments and the pinned heap. The invariant is stated on `SweepPhase`'s doc comment so the sweepers do not come back.
- Update the sweep-phase diagram and text in `docs/articles/dev/garbage-collector.md`.

## Reproduction and verification

New test `GC_MallocHeapNotSwept` in the GC test kernel plants a GC-heap pointer (LSB clear, so it reads as an unmarked object header) in the first word of live small (64 B), medium (3000 B) and large (8192 B) `Heap.Alloc` blocks, forces a collect, and asserts the blocks are still allocated.

| Run | Result |
| --- | --- |
| Before fix, x64 | 43/44 — `GC_MallocHeapNotSwept` fails: `live small-heap block must remain allocated across a collect` |
| After fix, x64 | 44/44 passed |
| After fix, arm64 | 44/44 passed |