### PR TITLE
Port ICMP echo support for ping from gen2

### DIFF
--- a/src/Cosmos.Kernel.System/Network/IPv4/Address.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/Address.cs
@@ -196,7 +196,9 @@ public class Address : IComparable
     {
         if (obj is Address other)
         {
-            if (other.hash != hash)
+            // Compare through the property: the backing field is lazily
+            // computed and stays 0 until Hash is first read.
+            if (other.Hash != Hash)
             {
                 return -1;
             }

--- a/src/Cosmos.Kernel.System/Network/IPv4/ICMPClient.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/ICMPClient.cs
@@ -1,0 +1,128 @@
+using Cosmos.Kernel.System.Network.Config;
+using Cosmos.Kernel.System.Timer;
+
+namespace Cosmos.Kernel.System.Network.IPv4;
+
+/// <summary>
+/// Used to manage the ICMP connection to a client.
+/// </summary>
+public class ICMPClient : IDisposable
+{
+    private static readonly Dictionary<uint, ICMPClient> clients = new();
+
+    /// <summary>
+    /// The destination address.
+    /// </summary>
+    internal Address? destination;
+
+    /// <summary>
+    /// The RX buffer queue.
+    /// </summary>
+    internal Queue<ICMPPacket> rxBuffer;
+
+    /// <summary>
+    /// Gets a client by its IP address hash.
+    /// </summary>
+    /// <param name="iphash">The IP address hash.</param>
+    /// <returns>If a client is connected to the given address, the <see cref="ICMPClient"/>; otherwise, <see langword="null"/>.</returns>
+    internal static ICMPClient? GetClient(uint iphash)
+    {
+        if (clients.TryGetValue(iphash, out var client))
+        {
+            return client;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ICMPClient"/> class.
+    /// </summary>
+    public ICMPClient()
+    {
+        rxBuffer = new Queue<ICMPPacket>(8);
+    }
+
+    /// <summary>
+    /// Connects to the given client.
+    /// </summary>
+    /// <param name="dest">The destination address.</param>
+    public void Connect(Address dest)
+    {
+        destination = dest;
+        clients[dest.Hash] = this;
+    }
+
+    /// <summary>
+    /// Closes the active connection.
+    /// </summary>
+    public void Close()
+    {
+        if (destination != null && clients.ContainsKey(destination.Hash))
+        {
+            clients.Remove(destination.Hash);
+        }
+    }
+
+    /// <summary>
+    /// Sends an ICMP echo request to the connected destination.
+    /// </summary>
+    /// <param name="id">The echo identifier.</param>
+    /// <param name="sequence">The echo sequence number.</param>
+    public void SendEcho(ushort id = 0x0001, ushort sequence = 0x0001)
+    {
+        if (destination == null)
+        {
+            throw new InvalidOperationException("Must establish a destination by calling Connect() before using SendEcho()");
+        }
+
+        Address source = IPConfig.FindNetwork(destination);
+        if (source == null)
+        {
+            throw new InvalidOperationException("No network route to destination");
+        }
+
+        var request = new ICMPEchoRequest(source, destination, id, sequence);
+        OutgoingBuffer.AddPacket(request);
+        NetworkStack.Update();
+    }
+
+    /// <summary>
+    /// Receives an ICMP echo reply from the remote host.
+    /// </summary>
+    /// <param name="source">The source end point.</param>
+    /// <param name="timeout">The timeout value in milliseconds; by default, 5000ms.</param>
+    /// <returns>The elapsed time in milliseconds, or -1 if a timeout has been reached.</returns>
+    public int Receive(ref EndPoint source, int timeout = 5000)
+    {
+        int waited = 0;
+        while (rxBuffer.Count < 1 && waited < timeout)
+        {
+            TimerManager.Wait(10);
+            waited += 10;
+        }
+
+        if (rxBuffer.Count < 1)
+        {
+            return -1;
+        }
+
+        var packet = new ICMPEchoReply(rxBuffer.Dequeue().RawData);
+        source.Address = packet.SourceIP;
+
+        return waited;
+    }
+
+    /// <summary>
+    /// Receives data from the given packet.
+    /// </summary>
+    /// <param name="packet">The packet to receive.</param>
+    internal void ReceiveData(ICMPPacket packet)
+    {
+        rxBuffer.Enqueue(packet);
+    }
+
+    public void Dispose()
+    {
+        Close();
+    }
+}

--- a/src/Cosmos.Kernel.System/Network/IPv4/ICMPPacket.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/ICMPPacket.cs
@@ -1,0 +1,294 @@
+using Cosmos.Kernel.Core.IO;
+
+namespace Cosmos.Kernel.System.Network.IPv4;
+
+/// <summary>
+/// Represents an ICMP packet.
+/// </summary>
+/// <remarks>
+/// See also: <seealso cref="IPPacket"/>.
+/// </remarks>
+public class ICMPPacket : IPPacket
+{
+    protected byte icmpType;
+    protected byte icmpCode;
+    protected ushort icmpCRC;
+
+    /// <summary>
+    /// Handles an ICMP packet.
+    /// </summary>
+    /// <param name="packetData">The data of the packet.</param>
+    internal static void ICMPHandler(byte[] packetData)
+    {
+        var icmpPacket = new ICMPPacket(packetData);
+
+        switch (icmpPacket.ICMPType)
+        {
+            case 0: // Echo reply
+                Serial.WriteString("[ICMP] Received echo reply from ");
+                Serial.WriteString(icmpPacket.SourceIP.ToString());
+                Serial.WriteString("\n");
+
+                var receiver = ICMPClient.GetClient(icmpPacket.SourceIP.Hash);
+                receiver?.ReceiveData(icmpPacket);
+                break;
+            case 8: // Echo request
+                var request = new ICMPEchoRequest(packetData);
+                var reply = new ICMPEchoReply(request);
+
+                Serial.WriteString("[ICMP] Sending echo reply to ");
+                Serial.WriteString(reply.DestinationIP.ToString());
+                Serial.WriteString("\n");
+
+                OutgoingBuffer.AddPacket(reply);
+                NetworkStack.Update();
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ICMPPacket"/> class.
+    /// </summary>
+    internal ICMPPacket()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ICMPPacket"/> class.
+    /// </summary>
+    /// <param name="rawData">Raw data.</param>
+    internal ICMPPacket(byte[] rawData)
+        : base(rawData)
+    {
+    }
+
+    protected override void InitializeFields()
+    {
+        base.InitializeFields();
+        icmpType = RawData[DataOffset];
+        icmpCode = RawData[DataOffset + 1];
+        icmpCRC = (ushort)((RawData[DataOffset + 2] << 8) | RawData[DataOffset + 3]);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ICMPPacket"/> class.
+    /// </summary>
+    /// <param name="source">Source address.</param>
+    /// <param name="dest">Destination address.</param>
+    /// <param name="type">Type.</param>
+    /// <param name="code">Code.</param>
+    /// <param name="id">ID.</param>
+    /// <param name="seq">SEQ.</param>
+    /// <param name="icmpDataSize">Data size.</param>
+    /// <exception cref="ArgumentException">Thrown if RawData is invalid or null.</exception>
+    internal ICMPPacket(Address source, Address dest, byte type, byte code, ushort id, ushort seq, ushort icmpDataSize)
+        : base(icmpDataSize, 1, source, dest, 0x00)
+    {
+        RawData[DataOffset] = type;
+        RawData[DataOffset + 1] = code;
+        RawData[DataOffset + 2] = 0x00;
+        RawData[DataOffset + 3] = 0x00;
+        RawData[DataOffset + 4] = (byte)((id >> 8) & 0xFF);
+        RawData[DataOffset + 5] = (byte)((id >> 0) & 0xFF);
+        RawData[DataOffset + 6] = (byte)((seq >> 8) & 0xFF);
+        RawData[DataOffset + 7] = (byte)((seq >> 0) & 0xFF);
+
+        icmpCRC = CalcICMPCRC(icmpDataSize);
+
+        RawData[DataOffset + 2] = (byte)((icmpCRC >> 8) & 0xFF);
+        RawData[DataOffset + 3] = (byte)((icmpCRC >> 0) & 0xFF);
+        InitializeFields();
+    }
+
+    /// <summary>
+    /// Calculates the ICMP CRC.
+    /// </summary>
+    /// <param name="length">The length of the packet.</param>
+    protected ushort CalcICMPCRC(ushort length)
+    {
+        return CalcOcCRC(DataOffset, length);
+    }
+
+    /// <summary>
+    /// The ICMP packet type.
+    /// </summary>
+    internal byte ICMPType => icmpType;
+
+    /// <summary>
+    /// The ICMP packet code.
+    /// </summary>
+    internal byte ICMPCode => icmpCode;
+
+    /// <summary>
+    /// The ICMP packet CRC.
+    /// </summary>
+    internal ushort ICMPCRC => icmpCRC;
+
+    /// <summary>
+    /// The ICMP packet data length.
+    /// </summary>
+    internal ushort ICMPDataLength => (ushort)(DataLength - 8);
+
+    /// <summary>
+    /// Returns the ICMP packet data.
+    /// </summary>
+    internal byte[] GetICMPData()
+    {
+        byte[] data = new byte[ICMPDataLength];
+
+        for (int b = 0; b < ICMPDataLength; b++)
+        {
+            data[b] = RawData[DataOffset + 8 + b];
+        }
+
+        return data;
+    }
+
+    public override string ToString()
+    {
+        return "ICMP Packet Src=" + SourceIP + ", Dest=" + DestinationIP + ", Type=" + icmpType + ", Code=" + icmpCode;
+    }
+}
+
+/// <summary>
+/// Represents an ICMP echo request packet.
+/// </summary>
+/// <remarks>
+/// See also: <seealso cref="ICMPPacket"/>.
+/// </remarks>
+internal class ICMPEchoRequest : ICMPPacket
+{
+    protected ushort icmpID;
+    protected ushort icmpSequence;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ICMPEchoRequest"/> class.
+    /// </summary>
+    internal ICMPEchoRequest()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ICMPEchoRequest"/> class.
+    /// </summary>
+    /// <param name="rawData">Raw data.</param>
+    internal ICMPEchoRequest(byte[] rawData)
+        : base(rawData)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ICMPEchoRequest"/> class.
+    /// </summary>
+    /// <param name="source">Source address.</param>
+    /// <param name="dest">Destination address.</param>
+    /// <param name="id">ID.</param>
+    /// <param name="sequence">Sequence.</param>
+    /// <exception cref="ArgumentException">Thrown if RawData is invalid or null.</exception>
+    internal ICMPEchoRequest(Address source, Address dest, ushort id, ushort sequence)
+        : base(source, dest, 8, 0, id, sequence, 40)
+    {
+        for (int b = 8; b < ICMPDataLength; b++)
+        {
+            RawData[DataOffset + b] = (byte)b;
+        }
+
+        RawData[DataOffset + 2] = 0x00;
+        RawData[DataOffset + 3] = 0x00;
+        icmpCRC = CalcICMPCRC((ushort)(ICMPDataLength + 8));
+        RawData[DataOffset + 2] = (byte)((icmpCRC >> 8) & 0xFF);
+        RawData[DataOffset + 3] = (byte)((icmpCRC >> 0) & 0xFF);
+    }
+
+    protected override void InitializeFields()
+    {
+        base.InitializeFields();
+        icmpID = (ushort)((RawData[DataOffset + 4] << 8) | RawData[DataOffset + 5]);
+        icmpSequence = (ushort)((RawData[DataOffset + 6] << 8) | RawData[DataOffset + 7]);
+    }
+
+    /// <summary>
+    /// The ICMP packet ID.
+    /// </summary>
+    internal ushort ICMPID => icmpID;
+
+    /// <summary>
+    /// The ICMP packet sequence.
+    /// </summary>
+    internal ushort ICMPSequence => icmpSequence;
+
+    public override string ToString()
+    {
+        return "ICMP Echo Request Src=" + SourceIP + ", Dest=" + DestinationIP + ", ID=" + icmpID + ", Sequence=" + icmpSequence;
+    }
+}
+
+/// <summary>
+/// Represents an ICMP echo reply packet.
+/// </summary>
+/// <remarks>
+/// See also: <seealso cref="ICMPPacket"/>.
+/// </remarks>
+internal class ICMPEchoReply : ICMPPacket
+{
+    protected ushort icmpID;
+    protected ushort icmpSequence;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ICMPEchoReply"/> class.
+    /// </summary>
+    internal ICMPEchoReply()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ICMPEchoReply"/> class.
+    /// </summary>
+    /// <param name="rawData">Raw data.</param>
+    internal ICMPEchoReply(byte[] rawData)
+        : base(rawData)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ICMPEchoReply"/> class.
+    /// </summary>
+    /// <param name="request">ICMP echo request.</param>
+    /// <exception cref="ArgumentException">Thrown if RawData is invalid or null.</exception>
+    internal ICMPEchoReply(ICMPEchoRequest request)
+        : base(request.DestinationIP, request.SourceIP, 0, 0, request.ICMPID, request.ICMPSequence, (ushort)(request.ICMPDataLength + 8))
+    {
+        for (int b = 0; b < ICMPDataLength; b++)
+        {
+            RawData[DataOffset + 8 + b] = request.RawData[DataOffset + 8 + b];
+        }
+
+        RawData[DataOffset + 2] = 0x00;
+        RawData[DataOffset + 3] = 0x00;
+        icmpCRC = CalcICMPCRC((ushort)(ICMPDataLength + 8));
+        RawData[DataOffset + 2] = (byte)((icmpCRC >> 8) & 0xFF);
+        RawData[DataOffset + 3] = (byte)((icmpCRC >> 0) & 0xFF);
+    }
+
+    protected override void InitializeFields()
+    {
+        base.InitializeFields();
+        icmpID = (ushort)((RawData[DataOffset + 4] << 8) | RawData[DataOffset + 5]);
+        icmpSequence = (ushort)((RawData[DataOffset + 6] << 8) | RawData[DataOffset + 7]);
+    }
+
+    /// <summary>
+    /// The ICMP packet ID.
+    /// </summary>
+    internal ushort ICMPID => icmpID;
+
+    /// <summary>
+    /// The ICMP packet sequence.
+    /// </summary>
+    internal ushort ICMPSequence => icmpSequence;
+
+    public override string ToString()
+    {
+        return "ICMP Echo Reply Src=" + SourceIP + ", Dest=" + DestinationIP + ", ID=" + icmpID + ", Sequence=" + icmpSequence;
+    }
+}

--- a/src/Cosmos.Kernel.System/Network/IPv4/ICMPPacket.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/ICMPPacket.cs
@@ -14,6 +14,19 @@ public class ICMPPacket : IPPacket
     protected byte icmpCode;
     protected ushort icmpCRC;
 
+    private static int s_echoRequestsReplied;
+    private static byte[]? s_lastEchoRequestData;
+
+    /// <summary>
+    /// Number of echo requests answered with an echo reply.
+    /// </summary>
+    public static int EchoRequestsReplied => s_echoRequestsReplied;
+
+    /// <summary>
+    /// ICMP payload of the most recently answered echo request.
+    /// </summary>
+    public static byte[]? LastEchoRequestData => s_lastEchoRequestData;
+
     /// <summary>
     /// Handles an ICMP packet.
     /// </summary>
@@ -42,6 +55,9 @@ public class ICMPPacket : IPPacket
 
                 OutgoingBuffer.AddPacket(reply);
                 NetworkStack.Update();
+
+                s_lastEchoRequestData = request.GetICMPData();
+                s_echoRequestsReplied++;
                 break;
         }
     }

--- a/src/Cosmos.Kernel.System/Network/IPv4/IPPacket.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/IPPacket.cs
@@ -52,6 +52,9 @@ public class IPPacket : EthernetPacket
         {
             switch (ipPacket.Protocol)
             {
+                case 1: // ICMP
+                    ICMPPacket.ICMPHandler(packetData);
+                    break;
                 case 6: // TCP
                     TCPPacket.TCPHandler(packetData);
                     break;

--- a/src/Cosmos.Tools/Launcher/QemuLauncher.cs
+++ b/src/Cosmos.Tools/Launcher/QemuLauncher.cs
@@ -121,6 +121,13 @@ public static class QemuLauncher
     /// <summary>TCP port forwarded host-to-guest for the network test runner's stream traffic.</summary>
     private const int NetworkTestTcpPort = 5558;
 
+    /// <summary>
+    /// TCP port of the test runner's raw-Ethernet listener (IcmpTestServer). Slirp's
+    /// hostfwd only forwards TCP/UDP, so host-sourced ICMP rides a stream netdev
+    /// hubbed with slirp: frames are 4-byte big-endian-length-prefixed Ethernet.
+    /// </summary>
+    private const int NetworkTestRawSocketPort = 5560;
+
     public static async Task<QemuLaunchPlan> BuildAsync(QemuLaunchOptions options)
     {
         CommandToolDefinition tool = options.Architecture switch
@@ -189,7 +196,16 @@ public static class QemuLauncher
         if (options.EnableNetworkTesting)
         {
             string nic = ResolveNetworkTestNic(options.Architecture, options.NetworkCard);
-            args.Append($" -netdev user,id=net0,hostfwd=udp::{NetworkTestUdpPort}-:{NetworkTestUdpPort},hostfwd=tcp::{NetworkTestTcpPort}-:{NetworkTestTcpPort} -device {nic},netdev=net0");
+            // One hub joins three ports: slirp (DHCP/NAT + the UDP/TCP hostfwds),
+            // a raw-Ethernet stream socket to the runner's IcmpTestServer, and the
+            // guest NIC. The stream port exists because slirp cannot forward
+            // host-sourced ICMP; the runner must be listening before QEMU starts.
+            args.Append($" -netdev user,id=net0,hostfwd=udp::{NetworkTestUdpPort}-:{NetworkTestUdpPort},hostfwd=tcp::{NetworkTestTcpPort}-:{NetworkTestTcpPort}");
+            args.Append($" -netdev stream,id=rawnet0,addr.type=inet,addr.host=127.0.0.1,addr.port={NetworkTestRawSocketPort}");
+            args.Append(" -netdev hubport,id=hubport0,hubid=0,netdev=net0");
+            args.Append(" -netdev hubport,id=hubport1,hubid=0,netdev=rawnet0");
+            args.Append(" -netdev hubport,id=hubport2,hubid=0");
+            args.Append($" -device {nic},netdev=hubport2");
         }
         else if (options.NetworkCard is not null)
         {

--- a/tests/Cosmos.TestRunner.Engine/Hosts/IcmpTestServer.cs
+++ b/tests/Cosmos.TestRunner.Engine/Hosts/IcmpTestServer.cs
@@ -1,0 +1,566 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cosmos.TestRunner.Engine.Hosts;
+
+/// <summary>
+/// Raw-Ethernet ICMP test peer for network testing with QEMU guests.
+/// Slirp's hostfwd only forwards TCP/UDP, so host-sourced ICMP cannot reach the
+/// guest through the user-mode backend. QEMU instead connects a stream netdev
+/// (hubbed with slirp and the guest NIC) to this server, which speaks just
+/// enough ARP and ICMP to ping the guest:
+/// 1. Resolves the guest MAC via ARP (and answers ARP requests for its own IP)
+/// 2. Sends periodic ICMP echo requests with a COSMOS_PING payload
+/// 3. After validating an echo reply, switches the payload to HOST_OK so the
+///    kernel test can assert the full host-to-guest-to-host round trip
+/// </summary>
+public class IcmpTestServer : IDisposable
+{
+    private const string ProbePayloadPrefix = "COSMOS_PING";
+    private const string AckPayloadPrefix = "HOST_OK";
+    private const int IcmpPayloadLength = 32;
+    private const ushort EchoId = 0x4353; // 'CS'
+
+    private static readonly byte[] HostMac = { 0x52, 0x54, 0x00, 0x12, 0x34, 0x99 };
+    private static readonly byte[] HostIp = { 10, 0, 2, 99 };
+    private static readonly byte[] GuestIp = { 10, 0, 2, 15 }; // slirp's first DHCP address
+    private static readonly byte[] BroadcastMac = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+
+    private readonly int _port;
+    private TcpListener? _listener;
+    private TcpClient? _qemuClient;
+    private NetworkStream? _stream;
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private CancellationTokenSource? _cts;
+    private Task? _serverTask;
+    private bool _disposed;
+
+    private byte[]? _guestMac;
+    private ushort _nextSequence;
+    private ushort _nextIpId = 0x4200;
+    private bool _replyValidated;
+    private readonly Dictionary<ushort, byte[]> _sentPayloads = new();
+
+    /// <summary>
+    /// Number of ICMP echo requests sent to the guest.
+    /// </summary>
+    public int EchoRequestsSent { get; private set; }
+
+    /// <summary>
+    /// Number of echo replies that matched a sent request (id, sequence,
+    /// payload and ICMP checksum all verified).
+    /// </summary>
+    public int ValidEchoRepliesReceived { get; private set; }
+
+    /// <summary>
+    /// Whether the guest MAC was resolved (via its ARP reply or a learned frame).
+    /// </summary>
+    public bool GuestMacResolved => _guestMac != null;
+
+    /// <summary>
+    /// Creates a new ICMP test server.
+    /// </summary>
+    /// <param name="port">TCP port QEMU's stream netdev connects to (default 5560)</param>
+    public IcmpTestServer(int port = 5560)
+    {
+        _port = port;
+    }
+
+    /// <summary>
+    /// Starts listening. Must be called before QEMU starts: the stream netdev
+    /// connects at QEMU startup and aborts the VM if the connection is refused.
+    /// </summary>
+    public void Start()
+    {
+        if (_cts != null)
+        {
+            return;
+        }
+
+        _cts = new CancellationTokenSource();
+        EchoRequestsSent = 0;
+        ValidEchoRepliesReceived = 0;
+        _guestMac = null;
+        _replyValidated = false;
+        _sentPayloads.Clear();
+
+        try
+        {
+            _listener = new TcpListener(IPAddress.Loopback, _port);
+            _listener.Start();
+            _serverTask = RunAsync(_cts.Token);
+            Console.WriteLine($"[IcmpTestServer] Listening for QEMU stream netdev on port {_port}");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[IcmpTestServer] Failed to start listener: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Stops the ICMP server.
+    /// </summary>
+    public async Task StopAsync()
+    {
+        if (_cts == null)
+        {
+            return;
+        }
+
+        _cts.Cancel();
+        _qemuClient?.Close();
+        _listener?.Stop();
+
+        try
+        {
+            if (_serverTask != null)
+            {
+                await _serverTask.ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (ObjectDisposedException) { }
+
+        _cts.Dispose();
+        _cts = null;
+        _qemuClient = null;
+        _stream = null;
+        _listener = null;
+
+        Console.WriteLine($"[IcmpTestServer] Stopped. Requests sent: {EchoRequestsSent}, valid replies: {ValidEchoRepliesReceived}");
+    }
+
+    private async Task RunAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            _qemuClient = await _listener!.AcceptTcpClientAsync(cancellationToken);
+            _stream = _qemuClient.GetStream();
+            Console.WriteLine("[IcmpTestServer] QEMU connected");
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[IcmpTestServer] Accept failed: {ex.Message}");
+            return;
+        }
+
+        var readTask = ReadFramesAsync(cancellationToken);
+        var pingTask = PingLoopAsync(cancellationToken);
+
+        try
+        {
+            await Task.WhenAll(readTask, pingTask);
+        }
+        catch (OperationCanceledException) { }
+        catch (ObjectDisposedException) { }
+        catch (IOException) { }
+    }
+
+    /// <summary>
+    /// Sends an ARP request until the guest MAC is known, then periodic ICMP
+    /// echo requests. Payload starts as COSMOS_PING and switches to HOST_OK
+    /// once a reply validated, acknowledging the round trip to the kernel.
+    /// </summary>
+    private async Task PingLoopAsync(CancellationToken cancellationToken)
+    {
+        // Wait a bit for kernel to initialize network stack
+        await Task.Delay(3000, cancellationToken);
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (_guestMac == null)
+                {
+                    await SendFrameAsync(BuildArpRequest(), cancellationToken);
+                }
+                else
+                {
+                    ushort sequence = _nextSequence++;
+                    byte[] payload = BuildPayload(_replyValidated ? AckPayloadPrefix : ProbePayloadPrefix);
+                    lock (_sentPayloads)
+                    {
+                        _sentPayloads[sequence] = payload;
+                    }
+
+                    await SendFrameAsync(BuildEchoRequest(_guestMac, sequence, payload), cancellationToken);
+                    EchoRequestsSent++;
+                    Console.WriteLine($"[IcmpTestServer] Sent echo request seq={sequence} ({(_replyValidated ? AckPayloadPrefix : ProbePayloadPrefix)})");
+                }
+
+                await Task.Delay(500, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (ObjectDisposedException)
+            {
+                break;
+            }
+            catch (IOException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[IcmpTestServer] Ping error: {ex.Message}");
+                await Task.Delay(1000, cancellationToken);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads length-prefixed Ethernet frames from QEMU and handles ARP and
+    /// ICMP addressed to the host peer; everything else on the hub is ignored.
+    /// </summary>
+    private async Task ReadFramesAsync(CancellationToken cancellationToken)
+    {
+        var lengthBuffer = new byte[4];
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ReadExactAsync(lengthBuffer, 4, cancellationToken);
+                int frameLength = (lengthBuffer[0] << 24) | (lengthBuffer[1] << 16) | (lengthBuffer[2] << 8) | lengthBuffer[3];
+                if (frameLength <= 0 || frameLength > 65535)
+                {
+                    Console.WriteLine($"[IcmpTestServer] Bad frame length {frameLength}, closing");
+                    break;
+                }
+
+                var frame = new byte[frameLength];
+                await ReadExactAsync(frame, frameLength, cancellationToken);
+                HandleFrame(frame);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (ObjectDisposedException)
+            {
+                break;
+            }
+            catch (IOException)
+            {
+                break;
+            }
+        }
+    }
+
+    private async Task ReadExactAsync(byte[] buffer, int count, CancellationToken cancellationToken)
+    {
+        int offset = 0;
+        while (offset < count)
+        {
+            int read = await _stream!.ReadAsync(buffer.AsMemory(offset, count - offset), cancellationToken);
+            if (read == 0)
+            {
+                throw new IOException("QEMU stream closed");
+            }
+            offset += read;
+        }
+    }
+
+    private void HandleFrame(byte[] frame)
+    {
+        if (frame.Length < 14)
+        {
+            return;
+        }
+
+        ushort etherType = (ushort)((frame[12] << 8) | frame[13]);
+        if (etherType == 0x0806)
+        {
+            HandleArp(frame);
+        }
+        else if (etherType == 0x0800)
+        {
+            HandleIpv4(frame);
+        }
+    }
+
+    private void HandleArp(byte[] frame)
+    {
+        // Ethernet(14) + ARP: htype(2) ptype(2) hlen(1) plen(1) op(2)
+        //                     sha(6) spa(4) tha(6) tpa(4)
+        if (frame.Length < 42)
+        {
+            return;
+        }
+
+        ushort operation = (ushort)((frame[20] << 8) | frame[21]);
+        var senderMac = frame.AsSpan(22, 6);
+        var senderIp = frame.AsSpan(28, 4);
+        var targetIp = frame.AsSpan(38, 4);
+
+        // Learn the guest MAC from any ARP frame it authored
+        if (senderIp.SequenceEqual(GuestIp) && _guestMac == null)
+        {
+            _guestMac = senderMac.ToArray();
+            Console.WriteLine($"[IcmpTestServer] Guest MAC resolved: {FormatMac(_guestMac)}");
+        }
+
+        // Answer requests for the host peer's IP so the guest can send us replies
+        if (operation == 1 && targetIp.SequenceEqual(HostIp))
+        {
+            byte[] reply = BuildArpReply(senderMac.ToArray(), senderIp.ToArray());
+            _ = SendFrameAsync(reply, _cts?.Token ?? CancellationToken.None);
+            Console.WriteLine("[IcmpTestServer] Answered ARP request for host peer IP");
+        }
+    }
+
+    private void HandleIpv4(byte[] frame)
+    {
+        if (frame.Length < 34)
+        {
+            return;
+        }
+
+        int ipStart = 14;
+        int ipHeaderLength = (frame[ipStart] & 0x0F) * 4;
+        byte protocol = frame[ipStart + 9];
+        var destIp = frame.AsSpan(ipStart + 16, 4);
+
+        if (protocol != 1 || !destIp.SequenceEqual(HostIp))
+        {
+            return;
+        }
+
+        int icmpStart = ipStart + ipHeaderLength;
+        int totalLength = (frame[ipStart + 2] << 8) | frame[ipStart + 3];
+        int icmpLength = totalLength - ipHeaderLength;
+        if (icmpLength < 8 || icmpStart + icmpLength > frame.Length)
+        {
+            return;
+        }
+
+        byte icmpType = frame[icmpStart];
+        if (icmpType != 0)
+        {
+            return;
+        }
+
+        ushort id = (ushort)((frame[icmpStart + 4] << 8) | frame[icmpStart + 5]);
+        ushort sequence = (ushort)((frame[icmpStart + 6] << 8) | frame[icmpStart + 7]);
+
+        if (id != EchoId)
+        {
+            return;
+        }
+
+        if (ComputeChecksum(frame, icmpStart, icmpLength) != 0)
+        {
+            Console.WriteLine($"[IcmpTestServer] Echo reply seq={sequence} has a bad ICMP checksum");
+            return;
+        }
+
+        byte[]? sentPayload;
+        lock (_sentPayloads)
+        {
+            _sentPayloads.TryGetValue(sequence, out sentPayload);
+        }
+
+        if (sentPayload == null || icmpLength - 8 != sentPayload.Length ||
+            !frame.AsSpan(icmpStart + 8, sentPayload.Length).SequenceEqual(sentPayload))
+        {
+            Console.WriteLine($"[IcmpTestServer] Echo reply seq={sequence} payload mismatch");
+            return;
+        }
+
+        ValidEchoRepliesReceived++;
+        if (!_replyValidated)
+        {
+            _replyValidated = true;
+            Console.WriteLine($"[IcmpTestServer] Valid echo reply seq={sequence} — switching payload to {AckPayloadPrefix}");
+        }
+        else
+        {
+            Console.WriteLine($"[IcmpTestServer] Valid echo reply seq={sequence}");
+        }
+    }
+
+    private async Task SendFrameAsync(byte[] frame, CancellationToken cancellationToken)
+    {
+        // Pad to the Ethernet minimum; real NIC models may drop runt frames
+        if (frame.Length < 60)
+        {
+            Array.Resize(ref frame, 60);
+        }
+
+        var lengthPrefix = new byte[4]
+        {
+            (byte)(frame.Length >> 24),
+            (byte)(frame.Length >> 16),
+            (byte)(frame.Length >> 8),
+            (byte)frame.Length
+        };
+
+        await _writeLock.WaitAsync(cancellationToken);
+        try
+        {
+            await _stream!.WriteAsync(lengthPrefix, cancellationToken);
+            await _stream.WriteAsync(frame, cancellationToken);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    private static byte[] BuildPayload(string prefix)
+    {
+        var payload = new byte[IcmpPayloadLength];
+        byte[] prefixBytes = Encoding.ASCII.GetBytes(prefix);
+        Array.Copy(prefixBytes, payload, prefixBytes.Length);
+        for (int i = prefixBytes.Length; i < payload.Length; i++)
+        {
+            payload[i] = (byte)i;
+        }
+
+        return payload;
+    }
+
+    private static byte[] BuildArpRequest()
+    {
+        var frame = new byte[42];
+        WriteEthernetHeader(frame, BroadcastMac, 0x0806);
+        WriteArpBody(frame, 1, HostMac, HostIp, new byte[6], GuestIp);
+        return frame;
+    }
+
+    private static byte[] BuildArpReply(byte[] targetMac, byte[] targetIp)
+    {
+        var frame = new byte[42];
+        WriteEthernetHeader(frame, targetMac, 0x0806);
+        WriteArpBody(frame, 2, HostMac, HostIp, targetMac, targetIp);
+        return frame;
+    }
+
+    private static void WriteEthernetHeader(byte[] frame, byte[] destMac, ushort etherType)
+    {
+        Array.Copy(destMac, 0, frame, 0, 6);
+        Array.Copy(HostMac, 0, frame, 6, 6);
+        frame[12] = (byte)(etherType >> 8);
+        frame[13] = (byte)etherType;
+    }
+
+    private static void WriteArpBody(byte[] frame, ushort operation, byte[] senderMac, byte[] senderIp, byte[] targetMac, byte[] targetIp)
+    {
+        frame[14] = 0x00;
+        frame[15] = 0x01; // Ethernet
+        frame[16] = 0x08;
+        frame[17] = 0x00; // IPv4
+        frame[18] = 6;
+        frame[19] = 4;
+        frame[20] = (byte)(operation >> 8);
+        frame[21] = (byte)operation;
+        Array.Copy(senderMac, 0, frame, 22, 6);
+        Array.Copy(senderIp, 0, frame, 28, 4);
+        Array.Copy(targetMac, 0, frame, 32, 6);
+        Array.Copy(targetIp, 0, frame, 38, 4);
+    }
+
+    private byte[] BuildEchoRequest(byte[] guestMac, ushort sequence, byte[] payload)
+    {
+        int icmpLength = 8 + payload.Length;
+        int ipLength = 20 + icmpLength;
+        var frame = new byte[14 + ipLength];
+
+        WriteEthernetHeader(frame, guestMac, 0x0800);
+
+        // IPv4 header
+        frame[14] = 0x45;
+        frame[15] = 0x00;
+        frame[16] = (byte)(ipLength >> 8);
+        frame[17] = (byte)ipLength;
+        ushort ipId = _nextIpId++;
+        frame[18] = (byte)(ipId >> 8);
+        frame[19] = (byte)ipId;
+        frame[20] = 0x00;
+        frame[21] = 0x00;
+        frame[22] = 64; // TTL
+        frame[23] = 1;  // ICMP
+        frame[24] = 0x00;
+        frame[25] = 0x00;
+        Array.Copy(HostIp, 0, frame, 26, 4);
+        Array.Copy(GuestIp, 0, frame, 30, 4);
+        ushort ipChecksum = ComputeChecksum(frame, 14, 20);
+        frame[24] = (byte)(ipChecksum >> 8);
+        frame[25] = (byte)ipChecksum;
+
+        // ICMP echo request
+        frame[34] = 8;
+        frame[35] = 0;
+        frame[36] = 0x00;
+        frame[37] = 0x00;
+        frame[38] = (byte)(EchoId >> 8);
+        frame[39] = (byte)(EchoId & 0xFF);
+        frame[40] = (byte)(sequence >> 8);
+        frame[41] = (byte)sequence;
+        Array.Copy(payload, 0, frame, 42, payload.Length);
+        ushort icmpChecksum = ComputeChecksum(frame, 34, icmpLength);
+        frame[36] = (byte)(icmpChecksum >> 8);
+        frame[37] = (byte)icmpChecksum;
+
+        return frame;
+    }
+
+    /// <summary>
+    /// RFC 1071 ones'-complement checksum. Returns 0 when run over a section
+    /// whose stored checksum is valid.
+    /// </summary>
+    private static ushort ComputeChecksum(byte[] buffer, int offset, int length)
+    {
+        uint sum = 0;
+        int i = offset;
+        int end = offset + (length & ~1);
+
+        while (i < end)
+        {
+            sum += (uint)((buffer[i] << 8) | buffer[i + 1]);
+            i += 2;
+        }
+
+        if ((length & 1) != 0)
+        {
+            sum += (uint)(buffer[end] << 8);
+        }
+
+        while ((sum >> 16) != 0)
+        {
+            sum = (sum & 0xFFFF) + (sum >> 16);
+        }
+
+        return (ushort)~sum;
+    }
+
+    private static string FormatMac(byte[] mac) =>
+        $"{mac[0]:X2}:{mac[1]:X2}:{mac[2]:X2}:{mac[3]:X2}:{mac[4]:X2}:{mac[5]:X2}";
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _cts?.Cancel();
+        _qemuClient?.Dispose();
+        _listener?.Stop();
+        _cts?.Dispose();
+        _writeLock.Dispose();
+    }
+}

--- a/tests/Cosmos.TestRunner.Engine/Hosts/QemuARM64Host.cs
+++ b/tests/Cosmos.TestRunner.Engine/Hosts/QemuARM64Host.cs
@@ -108,19 +108,24 @@ public class QemuARM64Host : IQemuHost
         // Only create test servers for network tests
         UdpTestServer? udpServer = null;
         TcpTestServer? tcpServer = null;
+        IcmpTestServer? icmpServer = null;
         if (enableNetworkTesting)
         {
             udpServer = new UdpTestServer();
             tcpServer = new TcpTestServer();
+            icmpServer = new IcmpTestServer();
         }
 
         bool testSuiteCompleted = false;
 
         try
         {
-            // Start test servers for network tests
+            // Start test servers for network tests. The ICMP server must be
+            // listening before QEMU starts: the stream netdev connects at
+            // startup and aborts the VM if the connection is refused.
             udpServer?.Start();
             tcpServer?.Start();
+            icmpServer?.Start();
 
             process.Start();
 
@@ -163,6 +168,11 @@ public class QemuARM64Host : IQemuHost
             if (tcpServer != null)
             {
                 await tcpServer.StopAsync();
+            }
+
+            if (icmpServer != null)
+            {
+                await icmpServer.StopAsync();
             }
 
             // Log stderr for diagnostics
@@ -210,6 +220,11 @@ public class QemuARM64Host : IQemuHost
                 await tcpServer.StopAsync();
             }
 
+            if (icmpServer != null)
+            {
+                await icmpServer.StopAsync();
+            }
+
             // Read whatever UART output we got
             string uartLog = string.Empty;
             if (File.Exists(uartLogPath))
@@ -236,6 +251,11 @@ public class QemuARM64Host : IQemuHost
             if (tcpServer != null)
             {
                 await tcpServer.StopAsync();
+            }
+
+            if (icmpServer != null)
+            {
+                await icmpServer.StopAsync();
             }
 
             return new QemuRunResult

--- a/tests/Cosmos.TestRunner.Engine/Hosts/QemuX64Host.cs
+++ b/tests/Cosmos.TestRunner.Engine/Hosts/QemuX64Host.cs
@@ -96,19 +96,24 @@ public class QemuX64Host : IQemuHost
         // Only create test servers for network tests
         UdpTestServer? udpServer = null;
         TcpTestServer? tcpServer = null;
+        IcmpTestServer? icmpServer = null;
         if (enableNetworkTesting)
         {
             udpServer = new UdpTestServer();
             tcpServer = new TcpTestServer();
+            icmpServer = new IcmpTestServer();
         }
 
         bool testSuiteCompleted = false;
 
         try
         {
-            // Start test servers for network tests
+            // Start test servers for network tests. The ICMP server must be
+            // listening before QEMU starts: the stream netdev connects at
+            // startup and aborts the VM if the connection is refused.
             udpServer?.Start();
             tcpServer?.Start();
+            icmpServer?.Start();
 
             process.Start();
 
@@ -157,6 +162,11 @@ public class QemuX64Host : IQemuHost
                 await tcpServer.StopAsync();
             }
 
+            if (icmpServer != null)
+            {
+                await icmpServer.StopAsync();
+            }
+
             // Log stderr for diagnostics
             string stderr = await stderrTask;
             if (!string.IsNullOrWhiteSpace(stderr))
@@ -202,6 +212,11 @@ public class QemuX64Host : IQemuHost
                 await tcpServer.StopAsync();
             }
 
+            if (icmpServer != null)
+            {
+                await icmpServer.StopAsync();
+            }
+
             // Read whatever UART output we got
             string uartLog = string.Empty;
             if (File.Exists(uartLogPath))
@@ -228,6 +243,11 @@ public class QemuX64Host : IQemuHost
             if (tcpServer != null)
             {
                 await tcpServer.StopAsync();
+            }
+
+            if (icmpServer != null)
+            {
+                await icmpServer.StopAsync();
             }
 
             return new QemuRunResult

--- a/tests/Kernels/Cosmos.Kernel.Tests.Network/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Network/Kernel.cs
@@ -47,7 +47,7 @@ public class Kernel : Sys.Kernel
         Serial.WriteString("[Network Tests] Starting test suite\n");
 
         // x64 has E1000E network driver
-        TR.Start("Network Tests", expectedTests: 14);
+        TR.Start("Network Tests", expectedTests: 15);
 
         // Network initialization tests
         TR.Run("Network_DeviceDetected", TestNetworkDeviceDetected);
@@ -57,6 +57,7 @@ public class Kernel : Sys.Kernel
 
         // ICMP tests
         TR.Run("ICMP_PingGateway", TestICMPPingGateway);
+        TR.Run("ICMP_HostPing", TestICMPHostPing);
 
         // UDP tests
         TR.Run("UDP_SendPacket", TestUDPSendPacket);
@@ -243,6 +244,80 @@ public class Kernel : Sys.Kernel
         }
 
         icmpClient.Close();
+    }
+
+    private static void TestICMPHostPing()
+    {
+        var device = NetworkManager.PrimaryDevice;
+        if (device == null || !device.Ready)
+        {
+            Assert.True(false, "Network device not ready");
+            return;
+        }
+
+        if (!_networkConfigured)
+        {
+            TestDHCPConfiguration();
+        }
+
+        // The test runner's IcmpTestServer pings our IP every 500 ms through
+        // the raw-Ethernet hub port (slirp cannot forward host-sourced ICMP).
+        // Phase 1: wait until the echo responder answered at least one request.
+        Serial.WriteString("[Test] Waiting for ICMP echo request from host...\n");
+
+        int waited = 0;
+        while (ICMPPacket.EchoRequestsReplied < 1 && waited < 10000)
+        {
+            TimerManager.Wait(100);
+            waited += 100;
+        }
+
+        if (ICMPPacket.EchoRequestsReplied < 1)
+        {
+            Serial.WriteString("[Test] No echo request received from host within timeout\n");
+            Assert.True(false, "Host echo request should reach the kernel and be answered");
+            return;
+        }
+
+        Serial.WriteString("[Test] Answered ");
+        Serial.WriteNumber((ulong)ICMPPacket.EchoRequestsReplied);
+        Serial.WriteString(" echo request(s) from host\n");
+        Assert.True(true, "Host echo request received and answered");
+
+        // Phase 2: the host validates our echo reply (checksum + payload) and
+        // only then switches its request payload from COSMOS_PING to HOST_OK —
+        // seeing it proves the full host->guest->host round trip.
+        Serial.WriteString("[Test] Waiting for HOST_OK acknowledgment payload...\n");
+
+        bool hostAck = false;
+        waited = 0;
+        while (!hostAck && waited < 10000)
+        {
+            byte[]? data = ICMPPacket.LastEchoRequestData;
+            if (data != null && data.Length >= 7 &&
+                data[0] == (byte)'H' && data[1] == (byte)'O' && data[2] == (byte)'S' &&
+                data[3] == (byte)'T' && data[4] == (byte)'_' && data[5] == (byte)'O' &&
+                data[6] == (byte)'K')
+            {
+                hostAck = true;
+            }
+            else
+            {
+                TimerManager.Wait(100);
+                waited += 100;
+            }
+        }
+
+        if (hostAck)
+        {
+            Serial.WriteString("[Test] Host acknowledged a valid echo reply\n");
+        }
+        else
+        {
+            Serial.WriteString("[Test] No HOST_OK payload within timeout\n");
+        }
+
+        Assert.True(hostAck, "Host should confirm it received a valid echo reply");
     }
 
     // ==================== UDP Tests ====================

--- a/tests/Kernels/Cosmos.Kernel.Tests.Network/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Network/Kernel.cs
@@ -47,13 +47,16 @@ public class Kernel : Sys.Kernel
         Serial.WriteString("[Network Tests] Starting test suite\n");
 
         // x64 has E1000E network driver
-        TR.Start("Network Tests", expectedTests: 13);
+        TR.Start("Network Tests", expectedTests: 14);
 
         // Network initialization tests
         TR.Run("Network_DeviceDetected", TestNetworkDeviceDetected);
         TR.Run("Network_DeviceReady", TestNetworkDeviceReady);
         TR.Run("Network_StackInitialize", TestNetworkStackInitialize);
         TR.Run("DHCP_AutoConfigure", TestDHCPConfiguration);
+
+        // ICMP tests
+        TR.Run("ICMP_PingGateway", TestICMPPingGateway);
 
         // UDP tests
         TR.Run("UDP_SendPacket", TestUDPSendPacket);
@@ -190,6 +193,56 @@ public class Kernel : Sys.Kernel
 
         // Verify we got a valid IP (not 0.0.0.0)
         Assert.True(_localIP.Hash != 0, "DHCP should assign a non-zero IP address");
+    }
+
+    // ==================== ICMP Tests ====================
+
+    private static void TestICMPPingGateway()
+    {
+        var device = NetworkManager.PrimaryDevice;
+        if (device == null || !device.Ready)
+        {
+            Assert.True(false, "Network device not ready");
+            return;
+        }
+
+        if (!_networkConfigured)
+        {
+            TestDHCPConfiguration();
+        }
+
+        // QEMU user networking: slirp answers ICMP echo requests to the
+        // gateway address itself, so no host-side helper is needed.
+        var target = new Address(10, 0, 2, 2);
+
+        Serial.WriteString("[Test] Pinging ");
+        Serial.WriteString(target.ToString());
+        Serial.WriteString("...\n");
+
+        var icmpClient = new ICMPClient();
+        icmpClient.Connect(target);
+        icmpClient.SendEcho();
+
+        var endpoint = new EndPoint(Address.Zero, 0);
+        int time = icmpClient.Receive(ref endpoint, 5000);
+
+        if (time >= 0)
+        {
+            Serial.WriteString("[Test] Echo reply from ");
+            Serial.WriteString(endpoint.Address.ToString());
+            Serial.WriteString(" in ");
+            Serial.WriteNumber((ulong)time);
+            Serial.WriteString(" ms\n");
+
+            Assert.True(endpoint.Address.CompareTo(target) == 0, "Echo reply should come from the pinged address");
+        }
+        else
+        {
+            Serial.WriteString("[Test] No echo reply within timeout\n");
+            Assert.True(false, "Should receive ICMP echo reply from gateway");
+        }
+
+        icmpClient.Close();
     }
 
     // ==================== UDP Tests ====================

--- a/tests/Kernels/Cosmos.Kernel.Tests.Network/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Network/Kernel.cs
@@ -13,6 +13,7 @@ using Cosmos.Kernel.System.Network.IPv4.UDP.DHCP;
 using Cosmos.Kernel.System.Network.IPv4.UDP.DNS;
 using Cosmos.Kernel.System.Timer;
 using Cosmos.TestRunner.Framework;
+using CosmosEndPoint = Cosmos.Kernel.System.Network.IPv4.EndPoint;
 using DotNetTcpClient = System.Net.Sockets.TcpClient;
 using DotNetTcpListener = System.Net.Sockets.TcpListener;
 using DotNetUdpClient = System.Net.Sockets.UdpClient;
@@ -224,7 +225,7 @@ public class Kernel : Sys.Kernel
         icmpClient.Connect(target);
         icmpClient.SendEcho();
 
-        var endpoint = new EndPoint(Address.Zero, 0);
+        CosmosEndPoint endpoint = new CosmosEndPoint(Address.Zero, 0);
         int time = icmpClient.Receive(ref endpoint, 5000);
 
         if (time >= 0)


### PR DESCRIPTION
Ports `ICMPPacket`/`ICMPEchoRequest`/`ICMPEchoReply` and `ICMPClient` from gen2 (`Cosmos.System2/Network/IPv4`) onto the gen3 network stack, and validates both ping directions in the Network suite.

---

## ICMP port

- `ICMPPacket.cs` — packet classes on the gen3 `IPPacket` base. `ICMPHandler` routes echo replies (type 0) to the matching `ICMPClient` by source-IP hash and answers echo requests (type 8) via `OutgoingBuffer`, so the kernel responds to pings.
- `ICMPClient.cs` — `Connect`/`SendEcho`/`Receive`/`Close`, same shape as `UdpClient`.
- `IPPacket.cs` — IPv4 protocol 1 dispatched to `ICMPPacket.ICMPHandler`.
- `Address.cs` — `CompareTo` now compares through the `Hash` property: the lazily computed backing field made freshly parsed packet addresses compare unequal to equal addresses (surfaced by `ICMP_PingGateway`; `UpdateARPCache` and `EndPoint.CompareTo` sat on the same path).

## Guest-to-host ping test

`ICMP_PingGateway` pings 10.0.2.2; slirp answers echo requests to the gateway itself.

## Host-to-guest ping test

Slirp's hostfwd only forwards TCP/UDP, so host-sourced ICMP cannot reach the guest through the user-mode backend. The network-testing QEMU topology now joins three ports on one hub: the slirp backend (DHCP/NAT + existing hostfwds), a raw-Ethernet `stream` netdev to the new `IcmpTestServer` (port 5560), and the guest NIC.

`IcmpTestServer` is a minimal Ethernet peer in the test runner (host 10.0.2.99): it resolves the guest MAC via ARP, answers ARP requests for its own IP, and pings 10.0.2.15 every 500 ms. Payloads start as `COSMOS_PING`; once an echo reply validates (id, sequence, payload, ICMP checksum), they switch to `HOST_OK`. The `ICMP_HostPing` kernel test asserts the responder answered a request, then waits for the `HOST_OK` payload — proving the full host→guest→host round trip. `ICMPPacket` exposes `EchoRequestsReplied` and `LastEchoRequestData` for the assertions.

Verification:

| Check | Result |
|---|---|
| Hub topology parses and stream netdev connects (bundled QEMU 10.2.2, q35 + virt) | OK |
| `IcmpTestServer` against a scripted fake guest over the real 4-byte length-prefixed framing (ARP resolve, checksum validation both directions, `HOST_OK` switch) | OK |
| Test runner engine build | OK |
| Full Network suite in CI — 30/30 on x64 (e1000e, virtio-net-pci), 30/30 on arm64 (virtio-net-pci, virtio-net-mmio) | OK |

## Deviations from gen2

| Change | Reason |
|---|---|
| `ICMPEchoReply(request)` passes `ICMPDataLength + 8` as total ICMP length | gen2 passed payload length where the base ctor expects header + payload, truncating every echo reply by 8 bytes |
| `Receive` polls with `TimerManager.Wait(10)` and returns elapsed ms (-1 on timeout) | gen2 used `RTC.Second` with 1 s resolution; matches the gen3 DHCP/DNS client pattern |
| `SendEcho` takes optional `id`/`sequence` (defaults match gen2) | lets a ping loop increment the sequence number |
| `Connect` uses the dictionary indexer instead of `Add` | reconnecting to the same address no longer throws; matches `UdpClient` |
