### PR TITLE
refactor: directory separator char is now based on Path.DirectorySeparatorChar

### DIFF
--- a/src/Cosmos.Kernel.System/Vfs/VfsManager.Paths.cs
+++ b/src/Cosmos.Kernel.System/Vfs/VfsManager.Paths.cs
@@ -57,12 +57,14 @@ public static partial class VfsManager
             return null;
         }
 
-        string result = path[0] == '/'
+        string result = path[0] == Path.DirectorySeparatorChar
             ? path
-            : (s_currentDirectory == "/" ? $"/{path}" : $"{s_currentDirectory}/{path}");
+            : (s_currentDirectory == s_directorySeparatorString
+                ? Path.Combine(s_directorySeparatorString, path)
+                : Path.Combine(s_currentDirectory, path));
 
         int end = result.Length;
-        while (end > 1 && result[end - 1] == '/')
+        while (end > 1 && result[end - 1] == Path.DirectorySeparatorChar)
         {
             end--;
         }
@@ -77,7 +79,7 @@ public static partial class VfsManager
         int lastSeparator = fullPath.LastIndexOf('/');
         if (lastSeparator <= 0)
         {
-            parentPath = "/";
+            parentPath = s_directorySeparatorString;
             leaf = fullPath.Length > 1 ? fullPath.Substring(1) : string.Empty;
             return;
         }
@@ -89,7 +91,7 @@ public static partial class VfsManager
     /// <summary>True for "/" and for every active mount point.</summary>
     public static bool IsMountPoint(string fullPath)
     {
-        if (fullPath == "/")
+        if (fullPath == s_directorySeparatorString)
         {
             return true;
         }
@@ -115,7 +117,7 @@ public static partial class VfsManager
             return inode.InodeOperations.GetAttr(inode, out stat);
         }
 
-        if (fullPath == "/")
+        if (fullPath == s_directorySeparatorString)
         {
             stat = VirtualRootStat();
             return true;
@@ -133,12 +135,12 @@ public static partial class VfsManager
         for (int i = 0; i < s_mounts.Count; i++)
         {
             string mountPoint = s_mounts[i].MountPoint;
-            if (mountPoint == "/")
+            if (mountPoint == s_directorySeparatorString)
             {
                 continue;
             }
 
-            int nextSeparator = mountPoint.IndexOf('/', 1);
+            int nextSeparator = mountPoint.IndexOf(Path.DirectorySeparatorChar, 1);
             string firstSegment = nextSeparator < 0
                 ? mountPoint.Substring(1)
                 : mountPoint.Substring(1, nextSeparator - 1);
@@ -248,7 +250,7 @@ public static partial class VfsManager
         }
 
         bool oldIsDirectory = (oldStat.Mode & ModeEnum.FileTypeMask) == ModeEnum.Directory;
-        if (oldIsDirectory && newFullPath.StartsWith($"{oldFullPath}/", StringComparison.Ordinal))
+        if (oldIsDirectory && newFullPath.StartsWith($"{oldFullPath}{s_directorySeparatorString}", StringComparison.Ordinal))
         {
             return false;
         }
@@ -403,7 +405,9 @@ public static partial class VfsManager
             return;
         }
 
-        string backupPath = parentPath == "/" ? $"/{backupLeaf}" : $"{parentPath}/{backupLeaf}";
+        string backupPath = parentPath == s_directorySeparatorString
+            ? Path.Combine(s_directorySeparatorString, backupLeaf)
+            : Path.Combine(parentPath, backupLeaf);
 
         IVfsInode? backupInode = null;
         if (parent.TryLookup(backupLeaf, out IVfsNodeHandle? backupNode))

--- a/src/Cosmos.Kernel.System/Vfs/VfsManager.cs
+++ b/src/Cosmos.Kernel.System/Vfs/VfsManager.cs
@@ -60,6 +60,7 @@ public static partial class VfsManager
 
     private static readonly Dictionary<string, IVfsFilesystemType> s_registeredTypes = new(StringComparer.Ordinal);
     private static readonly List<VfsMount> s_mounts = new();
+    private static readonly string s_directorySeparatorString = Path.DirectorySeparatorChar.ToString();
 
     /// <summary>
     /// All currently active mounts in registration order.
@@ -297,7 +298,7 @@ public static partial class VfsManager
             return true;
         }
 
-        string[] parts = relativePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        string[] parts = relativePath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
         for (int i = 0; i < parts.Length; i++)
         {
             string segment = parts[i];
@@ -332,7 +333,7 @@ public static partial class VfsManager
     /// </summary>
     public static bool MountCovers(string mountPoint, string path)
     {
-        if (mountPoint == "/")
+        if (mountPoint == s_directorySeparatorString)
         {
             return true;
         }
@@ -342,7 +343,7 @@ public static partial class VfsManager
             return false;
         }
 
-        return path.Length == mountPoint.Length || path[mountPoint.Length] == '/';
+        return path.Length == mountPoint.Length || path[mountPoint.Length] == Path.DirectorySeparatorChar;
     }
 
     private static VfsMount? FindMount(string path)
@@ -370,18 +371,18 @@ public static partial class VfsManager
     {
         if (string.IsNullOrWhiteSpace(mountPoint))
         {
-            return "/";
+            return s_directorySeparatorString;
         }
 
         string normalized = mountPoint;
-        if (!normalized.StartsWith("/", StringComparison.Ordinal))
+        if (!normalized.StartsWith(s_directorySeparatorString, StringComparison.Ordinal))
         {
-            normalized = "/" + normalized;
+            normalized = Path.Combine(s_directorySeparatorString, normalized);
         }
 
-        if (normalized.Length > 1 && normalized.EndsWith("/", StringComparison.Ordinal))
+        if (normalized.Length > 1 && normalized.EndsWith(s_directorySeparatorString, StringComparison.Ordinal))
         {
-            normalized = normalized.TrimEnd('/');
+            normalized = normalized.TrimEnd(Path.DirectorySeparatorChar);
         }
 
         return normalized;
@@ -389,15 +390,15 @@ public static partial class VfsManager
 
     private static string TrimMountPrefix(string mountPoint, string path)
     {
-        if (mountPoint == "/")
+        if (mountPoint == s_directorySeparatorString)
         {
-            return path.TrimStart('/');
+            return path.TrimStart(Path.DirectorySeparatorChar);
         }
 
         string trimmed = path.StartsWith(mountPoint, StringComparison.Ordinal)
             ? path.Substring(mountPoint.Length)
             : path;
 
-        return trimmed.TrimStart('/');
+        return trimmed.TrimStart(Path.DirectorySeparatorChar);
     }
 }


### PR DESCRIPTION
directory separator char is now based on Path.DirectorySeparatorChar