### PR TITLE
Fix: svgaii char drawing and device scanning

### DIFF
--- a/src/Cosmos.Kernel.System/Graphics/FullScreenCanvas.cs
+++ b/src/Cosmos.Kernel.System/Graphics/FullScreenCanvas.cs
@@ -1,3 +1,4 @@
+using Cosmos.Kernel.Core;
 using Cosmos.Kernel.HAL.Pci;
 using Cosmos.Kernel.HAL.Pci.Enums;
 
@@ -34,10 +35,13 @@ public static class FullScreenCanvas
     /// </summary>
     private static Canvas GetVideoDriver()
     {
-        PciDevice? svgaDevice = PciManager.GetDevice(VendorId.VmWare, DeviceId.SvgaiiAdapter);
-        if (svgaDevice is not null)
+        if (CosmosFeatures.PCIEnabled)
         {
-            return new SVGAII3DCanvas(svgaDevice);
+            PciDevice? svgaDevice = PciManager.GetDevice(VendorId.VmWare, DeviceId.SvgaiiAdapter);
+            if (svgaDevice is not null)
+            {
+                return new SVGAII3DCanvas(svgaDevice);
+            }
         }
 
         return new GopCanvas();
@@ -50,10 +54,13 @@ public static class FullScreenCanvas
     /// </summary>
     private static Canvas GetVideoDriver(Mode mode)
     {
-        PciDevice? svgaDevice = PciManager.GetDevice(VendorId.VmWare, DeviceId.SvgaiiAdapter);
-        if (svgaDevice is not null)
+        if (CosmosFeatures.PCIEnabled)
         {
-            return new SVGAII3DCanvas(svgaDevice, mode);
+            PciDevice? svgaDevice = PciManager.GetDevice(VendorId.VmWare, DeviceId.SvgaiiAdapter);
+            if (svgaDevice is not null)
+            {
+                return new SVGAII3DCanvas(svgaDevice);
+            }
         }
 
         return new GopCanvas(mode);

--- a/src/Cosmos.Kernel.System/Graphics/SVGAII3DCanvas.cs
+++ b/src/Cosmos.Kernel.System/Graphics/SVGAII3DCanvas.cs
@@ -301,37 +301,6 @@ public class SVGAII3DCanvas : Canvas
         Driver.Swap();
     }
 
-    public override void DrawString(string str, Font font, Color color, int x, int y)
-    {
-        int length = str.Length;
-        int width = font.Width;
-
-        for (int i = 0; i < length; i++)
-        {
-            DrawChar(str[i], font, color, x, y);
-            x += width;
-        }
-    }
-
-    public override void DrawChar(char c, Font font, Color color, int x, int y)
-    {
-        int height = font.Height;
-        int width = font.Width;
-        byte[] data = font.Data;
-        int p = height * c;
-
-        for (int cy = 0; cy < height; cy++)
-        {
-            for (int cx = 0; cx < width; cx++)
-            {
-                if (font.ConvertByteToBitAddress(data[p + cy], cx + 1))
-                {
-                    DrawPoint(color, x + cx, y + cy);
-                }
-            }
-        }
-    }
-
     public override void DrawImage(Image image, int x, int y, bool preventOffBoundPixels = true)
     {
         int width = (int)image.Width;


### PR DESCRIPTION
There was a missing condition to avoid searching for SVGAII if PCI is disabled, otherwise this resulted on an exception throw when initializing KernelConsole if PCI is disabled.

Also fixed character drawing when using SVGAII3DCanvas, there wasn't any need to override the DrawChar and DrawString methods of the Canvas class.