### PR TITLE
refactor: optimizes Tcp and byte buffers handling by using shared pools

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,6 +40,8 @@
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Mono.Cecil" Version="0.11.6" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.0" />
     <PackageVersion Include="MonoMod.Utils" Version="25.0.8" />
     <PackageVersion Include="Moq" Version="4.20.72" />

--- a/nativeaot-patcher.slnx
+++ b/nativeaot-patcher.slnx
@@ -1,37 +1,40 @@
 <Solution>
     <Folder Name="/examples/">
-        <Project Path="examples\DevKernel\DevKernel.csproj"/>
+        <Project Path="examples\DevKernel\DevKernel.csproj" />
     </Folder>
     <Folder Name="/src/">
-        <Project Path="src/Cosmos.Kernel.Boot.Limine/Cosmos.Kernel.Boot.Limine.csproj"/>
-        <Project Path="src/Cosmos.Kernel.Core/Cosmos.Kernel.Core.csproj"/>
-        <Project Path="src/Cosmos.Kernel.Core.X64/Cosmos.Kernel.Core.X64.csproj"/>
-        <Project Path="src/Cosmos.Kernel.Core.ARM64/Cosmos.Kernel.Core.ARM64.csproj"/>
-        <Project Path="src/Cosmos.Kernel.Debug/Cosmos.Kernel.Debug.csproj"/>
-        <Project Path="src/Cosmos.Kernel.HAL.ARM64/Cosmos.Kernel.HAL.ARM64.csproj"/>
-        <Project Path="src/Cosmos.Kernel.HAL.X64/Cosmos.Kernel.HAL.X64.csproj"/>
-        <Project Path="src/Cosmos.Kernel.HAL/Cosmos.Kernel.HAL.csproj"/>
-        <Project Path="src/Cosmos.Kernel.Native.ARM64/Cosmos.Kernel.Native.ARM64.csproj"/>
-        <Project Path="src/Cosmos.Kernel.Native.X64/Cosmos.Kernel.Native.X64.csproj"/>
-        <Project Path="src/Cosmos.Kernel.Plugs/Cosmos.Kernel.Plugs.csproj"/>
-        <Project Path="src/Cosmos.Kernel.SourceGenerators/Cosmos.Kernel.SourceGenerators.csproj"/>
-        <Project Path="src/Cosmos.Kernel.System/Cosmos.Kernel.System.csproj"/>
-        <Project Path="src/Cosmos.Kernel/Cosmos.Kernel.csproj"/>
-        <Project Path="src\Cosmos.Kernel.HAL.Interfaces\Cosmos.Kernel.HAL.Interfaces.csproj" Type="C#"/>
+        <Project Path="src/Cosmos.Kernel.Boot.Limine/Cosmos.Kernel.Boot.Limine.csproj" />
+        <Project Path="src/Cosmos.Kernel.Core/Cosmos.Kernel.Core.csproj" />
+        <Project Path="src/Cosmos.Kernel.Core.X64/Cosmos.Kernel.Core.X64.csproj" />
+        <Project Path="src/Cosmos.Kernel.Core.ARM64/Cosmos.Kernel.Core.ARM64.csproj" />
+        <Project Path="src/Cosmos.Kernel.Debug/Cosmos.Kernel.Debug.csproj" />
+        <Project Path="src/Cosmos.Kernel.HAL.ARM64/Cosmos.Kernel.HAL.ARM64.csproj" />
+        <Project Path="src/Cosmos.Kernel.HAL.X64/Cosmos.Kernel.HAL.X64.csproj" />
+        <Project Path="src/Cosmos.Kernel.HAL/Cosmos.Kernel.HAL.csproj" />
+        <Project Path="src/Cosmos.Kernel.Native.ARM64/Cosmos.Kernel.Native.ARM64.csproj" />
+        <Project Path="src/Cosmos.Kernel.Native.X64/Cosmos.Kernel.Native.X64.csproj" />
+        <Project Path="src/Cosmos.Kernel.Plugs/Cosmos.Kernel.Plugs.csproj" />
+        <Project Path="src/Cosmos.Kernel.SourceGenerators/Cosmos.Kernel.SourceGenerators.csproj" />
+        <Project Path="src/Cosmos.Kernel.System/Cosmos.Kernel.System.csproj" />
+        <Project Path="src/Cosmos.Kernel/Cosmos.Kernel.csproj" />
+        <Project Path="src\Cosmos.Kernel.HAL.Interfaces\Cosmos.Kernel.HAL.Interfaces.csproj" />
     </Folder>
     <Folder Name="/src/Build/">
-        <Project Path="src/Cosmos.Build.Analyzer.Patcher.CodeFixes/Cosmos.Build.Analyzer.Patcher.CodeFixes.csproj"/>
-        <Project Path="src/Cosmos.Build.Analyzer.Patcher.Package/Cosmos.Build.Analyzer.Patcher.Package.csproj"/>
-        <Project Path="src/Cosmos.Build.Analyzer.Patcher/Cosmos.Build.Analyzer.Patcher.csproj"/>
-        <Project Path="src/Cosmos.Build.API/Cosmos.Build.API.csproj"/>
-        <Project Path="src/Cosmos.Build.Asm/Cosmos.Build.Asm.csproj"/>
-        <Project Path="src/Cosmos.Build.Common/Cosmos.Build.Common.csproj"/>
-        <Project Path="src/Cosmos.Build.Ilc/Cosmos.Build.Ilc.csproj"/>
-        <Project Path="src/Cosmos.Build.Patcher/Cosmos.Build.Patcher.csproj"/>
-        <Project Path="src/Cosmos.Build.Templates/Cosmos.Build.Templates.csproj"/>
-        <Project Path="src/Cosmos.Build.CC/Cosmos.Build.CC.csproj"/>
-        <Project Path="src/Cosmos.Tools/Cosmos.Tools.csproj"/>
-        <Project Path="src/Cosmos.Patcher/Cosmos.Patcher.csproj"/>
-        <Project Path="src/Cosmos.Sdk/Cosmos.Sdk.csproj"/>
+        <Project Path="src/Cosmos.Build.Analyzer.Patcher.CodeFixes/Cosmos.Build.Analyzer.Patcher.CodeFixes.csproj" />
+        <Project Path="src/Cosmos.Build.Analyzer.Patcher.Package/Cosmos.Build.Analyzer.Patcher.Package.csproj" />
+        <Project Path="src/Cosmos.Build.Analyzer.Patcher/Cosmos.Build.Analyzer.Patcher.csproj" />
+        <Project Path="src/Cosmos.Build.API/Cosmos.Build.API.csproj" />
+        <Project Path="src/Cosmos.Build.Asm/Cosmos.Build.Asm.csproj" />
+        <Project Path="src/Cosmos.Build.Common/Cosmos.Build.Common.csproj" />
+        <Project Path="src/Cosmos.Build.Ilc/Cosmos.Build.Ilc.csproj" />
+        <Project Path="src/Cosmos.Build.Patcher/Cosmos.Build.Patcher.csproj" />
+        <Project Path="src/Cosmos.Build.Templates/Cosmos.Build.Templates.csproj" />
+        <Project Path="src/Cosmos.Build.CC/Cosmos.Build.CC.csproj" />
+        <Project Path="src/Cosmos.Tools/Cosmos.Tools.csproj" />
+        <Project Path="src/Cosmos.Patcher/Cosmos.Patcher.csproj" />
+        <Project Path="src/Cosmos.Sdk/Cosmos.Sdk.csproj" />
+    </Folder>
+    <Folder Name="/src/Tests/">
+        <Project Path="src/tests/Cosmos.Kernel.Tests.System/Cosmos.Kernel.Tests.System.csproj" />
     </Folder>
 </Solution>

--- a/src/Cosmos.Kernel.Plugs/System/Net/Sockets/SocketPlug.cs
+++ b/src/Cosmos.Kernel.Plugs/System/Net/Sockets/SocketPlug.cs
@@ -113,7 +113,7 @@ public static class SocketPlug
         {
             if (_tcpStateMachines.TryGetValue(id, out var sm))
             {
-                return sm.Data?.Length ?? 0;
+                return sm.Data.Length;
             }
         }
         else if (proto == ProtocolType.Udp)
@@ -208,17 +208,16 @@ public static class SocketPlug
     public static void StartTcp(Socket aThis)
     {
         int id = GetId(aThis);
-        if (!_endpoints.TryGetValue(id, out var ep) || ep == null)
+        if (!_endpoints.TryGetValue(id, out var ep))
         {
             Serial.WriteString("[SocketPlug] Socket not bound\n");
             throw new InvalidOperationException("Socket not bound");
         }
 
-        var sm = new Tcp((ushort)ep.Port, 0, Address.Zero, Address.Zero);
+        var sm = Tcp.CreateConnection((ushort)ep.Port, 0, Address.Zero, Address.Zero);
         sm.LocalEndPoint.Port = (ushort)ep.Port;
         sm.Status = Status.LISTEN;
 
-        Tcp.Connections.Add(sm);
         _tcpStateMachines[id] = sm;
     }
 
@@ -645,21 +644,20 @@ public static class SocketPlug
         }
 
         // If data is already available, return it immediately (even if connection closed)
-        if (sm.Data != null && sm.Data.Length > 0)
+        if (sm.Data.Length > 0)
         {
             int bytesToCopy = Math.Min(sm.Data.Length, size);
-            Buffer.BlockCopy(sm.Data, 0, buffer, offset, bytesToCopy);
+            var target = buffer.AsSpan(offset, bytesToCopy);
+            sm.Data.Slice(0, bytesToCopy).CopyTo(target);
 
-            byte[] remainingData = new byte[sm.Data.Length - bytesToCopy];
-            Buffer.BlockCopy(sm.Data, bytesToCopy, remainingData, 0, remainingData.Length);
-            sm.Data = remainingData;
+            sm.AdvanceDataOffset(bytesToCopy);
 
             return bytesToCopy;
         }
 
         // Wait for data only if connection is still active
         int timeout = 0;
-        while ((sm.Data == null || sm.Data.Length == 0) && timeout < 100000)
+        while (sm.Data.Length == 0 && timeout < 100000)
         {
             // Allow reading data in ESTABLISHED, CLOSE_WAIT, or FIN_WAIT states
             if (sm.Status != Status.ESTABLISHED &&
@@ -672,17 +670,16 @@ public static class SocketPlug
             timeout++;
         }
 
-        if (sm.Data == null || sm.Data.Length == 0)
+        if (sm.Data.Length == 0)
         {
             return 0;
         }
 
         int bytes = Math.Min(sm.Data.Length, size);
-        Buffer.BlockCopy(sm.Data, 0, buffer, offset, bytes);
+        var finalTarget = buffer.AsSpan(offset, bytes);
+        sm.Data.Slice(0, bytes).CopyTo(finalTarget);
 
-        byte[] remaining = new byte[sm.Data.Length - bytes];
-        Buffer.BlockCopy(sm.Data, bytes, remaining, 0, remaining.Length);
-        sm.Data = remaining;
+        sm.AdvanceDataOffset(bytes);
 
         return bytes;
     }

--- a/src/Cosmos.Kernel.System/Cosmos.Kernel.System.csproj
+++ b/src/Cosmos.Kernel.System/Cosmos.Kernel.System.csproj
@@ -61,4 +61,11 @@
 
   <!-- Multi-arch packaging support -->
   <Import Project="../Directory.MultiArch.targets" />
+
+  <ItemGroup>
+    <!-- makes internal members visible to target project - unit tests -->
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Cosmos.Kernel.Tests.System</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/src/Cosmos.Kernel.System/Network/IPv4/TCP/TCPPacket.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/TCP/TCPPacket.cs
@@ -12,6 +12,7 @@ namespace Cosmos.Kernel.System.Network.IPv4.TCP;
 /// <summary>
 /// TCP Flags
 /// </summary>
+[Flags]
 public enum Flags : byte
 {
     /// <summary>

--- a/src/Cosmos.Kernel.System/Network/IPv4/TCP/Tcp.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/TCP/Tcp.cs
@@ -898,11 +898,21 @@ public class Tcp : IDisposable
             return;
         }
 
+        Span<byte> target;
+        // if new data fits into existing buffer, then no need to allocate a new one and write there
+        // just append to existing buffer
+        if (_dataOffset + _dataLength + other.Length <= _dataLength)
+        {
+            target = _data.AsSpan(_dataOffset + _dataLength);
+            other.CopyTo(target);
+            _dataLength += other.Length;
+            return;
+        }
         int realDataLength = _dataLength - _dataOffset;
         int requiredLength = realDataLength + other.Length;
         byte[] result = ArrayPool<byte>.Shared.Rent(requiredLength);
         Buffer.BlockCopy(_data, _dataOffset, result, 0, realDataLength);
-        var target = result.AsSpan(realDataLength);
+        target = result.AsSpan(realDataLength);
         other.CopyTo(target);
         if (_data.Length > 0)
         {

--- a/src/Cosmos.Kernel.System/Network/IPv4/TCP/Tcp.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/TCP/Tcp.cs
@@ -144,7 +144,7 @@ public class TransmissionControlBlock
 /// <remarks>
 /// See <a href="https://datatracker.ietf.org/doc/html/rfc793">RFC 793</a> for more information.
 /// </remarks>
-public class Tcp: IDisposable
+public class Tcp : IDisposable
 {
     public static readonly ushort DynamicPortStart = 49152;
 
@@ -245,7 +245,7 @@ public class Tcp: IDisposable
     /// </summary>
     internal static Tcp? GetConnection(ushort localPort, ushort remotePort, Address localIp, Address remoteIp)
     {
-        for (int i=0; i<Connections.Count; i++)
+        for (int i = 0; i < Connections.Count; i++)
         {
             var con = Connections[i];
             if (con.Equals(localPort, remotePort, localIp, remoteIp))

--- a/src/Cosmos.Kernel.System/Network/IPv4/TCP/Tcp.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/TCP/Tcp.cs
@@ -5,6 +5,7 @@
 *                   Port of Cosmos Code.
 */
 
+using System.Buffers;
 using Cosmos.Kernel.Core.IO;
 using Cosmos.Kernel.System.Network.Config;
 
@@ -143,11 +144,15 @@ public class TransmissionControlBlock
 /// <remarks>
 /// See <a href="https://datatracker.ietf.org/doc/html/rfc793">RFC 793</a> for more information.
 /// </remarks>
-public class Tcp
+public class Tcp: IDisposable
 {
-    public static ushort DynamicPortStart = 49152;
+    public static readonly ushort DynamicPortStart = 49152;
 
-    private static ushort nextPort = 49152;
+    private static ushort s_nextPort = 49152;
+    /// <summary>
+    /// Array pool used to rent buffers.
+    /// </summary>
+    private static readonly ArrayPool<byte> s_arrayPool = ArrayPool<byte>.Shared;
 
     /// <summary>
     /// Gets a dynamic port (simple incrementing approach for AOT compatibility).
@@ -156,10 +161,10 @@ public class Tcp
     {
         for (int i = 0; i < tries; i++)
         {
-            ushort port = nextPort++;
-            if (nextPort >= 65535)
+            ushort port = s_nextPort++;
+            if (s_nextPort >= 65535)
             {
-                nextPort = DynamicPortStart;
+                s_nextPort = DynamicPortStart;
             }
 
             bool portInUse = false;
@@ -187,19 +192,19 @@ public class Tcp
     public const ushort TcpWindowSize = 8192;
 
     // Simple sequence number generator
-    private static uint sequenceCounter = 1000;
+    private static uint s_sequenceCounter = 1000;
 
     #region Static
     /// <summary>
     /// A list of currently active connections.
     /// </summary>
-    public static List<Tcp> Connections = new();
+    private static List<Tcp> Connections { get; } = new();
 
     /// <summary>
     /// String / enum correspondance (used for debugging)
     /// </summary>
-    public static readonly string[] Table = new string[11]
-    {
+    public static readonly string[] Table =
+    [
         "LISTEN",
         "SYN_SENT",
         "SYN_RECEIVED",
@@ -211,20 +216,44 @@ public class Tcp
         "LAST_ACK",
         "TIME_WAIT",
         "CLOSED"
-    };
+    ];
+
+    /// <summary>
+    /// Creates a TCP connection object.
+    /// </summary>
+    /// <param name="localPort"></param>
+    /// <param name="remotePort"></param>
+    /// <param name="localIp"></param>
+    /// <param name="remoteIp"></param>
+    /// <returns>A <see cref="Tcp"/> connection instance.</returns>
+    internal static Tcp CreateNewConnection(ushort localPort, ushort remotePort, Address localIp, Address remoteIp)
+    {
+        var tcp = new Tcp(localPort, remotePort, localIp, remoteIp);
+        Connections.Add(tcp);
+        return tcp;
+    }
+
+    public static Tcp CreateConnection(ushort localPort, ushort remotePort, Address localIp, Address remoteIp)
+    {
+        var tcp = new Tcp(localPort, remotePort, localIp, remoteIp);
+        Connections.Add(tcp);
+        return tcp;
+    }
 
     /// <summary>
     /// Gets a TCP connection object that matches the specified local and remote ports and addresses.
     /// </summary>
     internal static Tcp? GetConnection(ushort localPort, ushort remotePort, Address localIp, Address remoteIp)
     {
-        foreach (var con in Connections)
+        for (int i=0; i<Connections.Count; i++)
         {
+            var con = Connections[i];
             if (con.Equals(localPort, remotePort, localIp, remoteIp))
             {
                 return con;
             }
-            else if (con.LocalEndPoint.Port.Equals(localPort) && con.Status == Status.LISTEN)
+            // Is this correct if clause? Shouldn't be there another loop?
+            if (con.LocalEndPoint.Port.Equals(localPort) && con.Status == Status.LISTEN)
             {
                 return con;
             }
@@ -235,31 +264,41 @@ public class Tcp
     /// <summary>
     /// Removes a TCP connection object that matches the specified local and remote ports and addresses.
     /// </summary>
-    public static void RemoveConnection(ushort localPort, ushort remotePort, Address localIp, Address remoteIp)
+    /// <returns>True when connection was removed, false when one was not found and removed.</returns>
+    public static bool RemoveConnection(ushort localPort, ushort remotePort, Address localIp, Address remoteIp)
     {
         for (int i = 0; i < Connections.Count; i++)
         {
-            if (Connections[i].Equals(localPort, remotePort, localIp, remoteIp))
+            var conn = Connections[i];
+            if (conn.Equals(localPort, remotePort, localIp, remoteIp))
             {
+                conn.Dispose();
                 Connections.RemoveAt(i);
-                return;
+                return true;
             }
         }
+
+        return false;
     }
 
     /// <summary>
     /// Removes a TCP connection object by reference.
     /// </summary>
-    public static void RemoveConnection(Tcp connection)
+    /// <returns>True when connection was removed, false when one was not found and removed.</returns>
+    public static bool RemoveConnection(Tcp connection)
     {
         for (int i = 0; i < Connections.Count; i++)
         {
-            if (object.ReferenceEquals(Connections[i], connection))
+            var conn = Connections[i];
+            if (ReferenceEquals(conn, connection))
             {
+                conn.Dispose();
                 Connections.RemoveAt(i);
-                return;
+                return true;
             }
         }
+
+        return false;
     }
 
     #endregion
@@ -269,24 +308,24 @@ public class Tcp
     /// <summary>
     /// The local end-point.
     /// </summary>
-    public EndPoint LocalEndPoint;
+    public EndPoint LocalEndPoint { get; private set; }
 
     /// <summary>
     /// The remote end-point.
     /// </summary>
-    public EndPoint RemoteEndPoint;
+    public EndPoint RemoteEndPoint { get; private set; }
 
     /// <summary>
     /// The connection Transmission Control Block.
     /// </summary>
-    public TransmissionControlBlock TCB { get; set; }
+    public TransmissionControlBlock TCB { get; private set; }
 
     #endregion
 
     /// <summary>
     /// The connection status.
     /// </summary>
-    public Status Status;
+    public Status Status { get; set; }
 
     /// <summary>
     /// Whether the connection has been detached from its owning socket:
@@ -295,18 +334,28 @@ public class Tcp
     /// the background and is removed from <see cref="Connections"/> as soon
     /// as it reaches <see cref="Status.CLOSED"/>.
     /// </summary>
-    public bool Detached;
+    public bool Detached { get; set; }
 
     /// <summary>
     /// The received data buffer.
     /// </summary>
-    public byte[]? Data { get; set; }
+    private byte[] _data = [];
+    /// <summary>
+    /// Holds real data length as _data might be longer due to being rented.
+    /// </summary>
+    private int _dataLength = 0;
+    public ReadOnlySpan<byte> Data => _data[.._dataLength];
 
-    public Tcp(ushort localPort, ushort remotePort, Address localIp, Address remoteIp)
+    private Tcp(ushort localPort, ushort remotePort, Address localIp, Address remoteIp)
     {
         LocalEndPoint = new EndPoint(localIp, localPort);
         RemoteEndPoint = new EndPoint(remoteIp, remotePort);
         TCB = new TransmissionControlBlock();
+    }
+
+    public void AssignData(ReadOnlySpan<byte> source, int offset, int count, int length)
+    {
+
     }
 
     /// <summary>
@@ -327,7 +376,7 @@ public class Tcp
 
     private void ReceiveDataInternal(TCPPacket packet)
     {
-        Serial.WriteString("[" + Table[(int)Status] + "] " + packet.ToString() + "\n");
+        Serial.WriteString($"[{Table[(int)Status]}] {packet}\n");
 
         if (Status == Status.LISTEN)
         {
@@ -404,7 +453,6 @@ public class Tcp
         if (packet.RST)
         {
             Serial.WriteString("[TCP] RST received at LISTEN state, packet passed.\n");
-            return;
         }
         else if (packet.FIN)
         {
@@ -424,7 +472,7 @@ public class Tcp
             RemoteEndPoint.Port = packet.SourcePort;
 
             // Simple sequence number generation
-            uint sequenceNumber = sequenceCounter++;
+            uint sequenceNumber = s_sequenceCounter++;
 
             //Fill TCB
             TCB.SndUna = sequenceNumber;
@@ -503,7 +551,7 @@ public class Tcp
         else if (packet.ACK)
         {
             //Check for bad ACK packet
-            if (packet.AckNumber - TCB.ISS < 0 || packet.AckNumber - TCB.SndNxt > 0)
+            if ((int)packet.AckNumber - TCB.ISS < 0 || packet.AckNumber - TCB.SndNxt > 0)
             {
                 SendEmptyPacket(Flags.RST, packet.AckNumber);
                 Serial.WriteString("[TCP] Bad ACK received at SYN_SENT.\n");
@@ -571,10 +619,10 @@ public class Tcp
 
                 TCB.RcvNxt += packet.TCP_DataLength;
 
-                Data = ArrayConcat(Data, packet.TCP_Data);
+                AppendToData(packet.TCP_Data);
 
                 Serial.WriteString("[TCP] Data buffer now has ");
-                Serial.WriteNumber((ulong)(Data?.Length ?? 0));
+                Serial.WriteNumber((ulong)(_data?.Length ?? 0));
                 Serial.WriteString(" bytes\n");
 
                 // Handle FIN flag within PSH handling if both are set
@@ -615,14 +663,14 @@ public class Tcp
             {
                 TCB.RcvNxt += packet.TCP_DataLength;
 
-                Data = ArrayConcat(Data, packet.TCP_Data);
+                AppendToData(packet.TCP_Data);
             }
         }
         if (packet.RST)
         {
             Status = Status.CLOSED;
 
-            Serial.WriteString("[TCP] Connection resetted!\n");
+            Serial.WriteString("[TCP] Connection reset!\n");
         }
         else if (packet.FIN)
         {
@@ -787,7 +835,8 @@ public class Tcp
     /// </summary>
     public void SendEmptyPacket(Flags flag)
     {
-        SendPacket(new TCPPacket(LocalEndPoint.Address, RemoteEndPoint.Address, LocalEndPoint.Port, RemoteEndPoint.Port, TCB.SndNxt, TCB.RcvNxt, 20, (byte)flag, TCB.SndWnd, 0));
+        SendPacket(new TCPPacket(LocalEndPoint.Address, RemoteEndPoint.Address, LocalEndPoint.Port, RemoteEndPoint.Port,
+            TCB.SndNxt, TCB.RcvNxt, 20, (byte)flag, TCB.SndWnd, 0));
     }
 
     /// <summary>
@@ -795,7 +844,8 @@ public class Tcp
     /// </summary>
     internal void SendEmptyPacket(Flags flag, uint sequenceNumber)
     {
-        SendPacket(new TCPPacket(LocalEndPoint.Address, RemoteEndPoint.Address, LocalEndPoint.Port, RemoteEndPoint.Port, sequenceNumber, TCB.RcvNxt, 20, (byte)flag, TCB.SndWnd, 0));
+        SendPacket(new TCPPacket(LocalEndPoint.Address, RemoteEndPoint.Address, LocalEndPoint.Port, RemoteEndPoint.Port,
+            sequenceNumber, TCB.RcvNxt, 20, (byte)flag, TCB.SndWnd, 0));
     }
 
     /// <summary>
@@ -815,36 +865,71 @@ public class Tcp
         NetworkStack.Update();
     }
 
-    /// <summary>
-    /// Concatenates two byte arrays.
-    /// </summary>
-    private static byte[]? ArrayConcat(byte[]? first, byte[]? second)
+    public void AdvanceDataOffset(int offset)
     {
-        if (first == null)
+        if (offset == 0)
         {
-            return second;
+            return;
         }
-        if (second == null)
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(offset, _dataLength);
+
+        if (offset == _dataLength && _dataLength != 0)
         {
-            return first;
+            s_arrayPool.Return(_data);
+            _data = [];
+            _dataLength = 0;
+            return;
         }
 
-        byte[] result = new byte[first.Length + second.Length];
-        for (int i = 0; i < first.Length; i++)
+        int requiredLength = _dataLength - offset;
+        byte[] result = ArrayPool<byte>.Shared.Rent(requiredLength);
+        Buffer.BlockCopy(_data, offset, result, 0, requiredLength);
+        if (_data.Length > 0)
         {
-            result[i] = first[i];
+            s_arrayPool.Return(_data);
         }
-        for (int i = 0; i < second.Length; i++)
+
+        _data = result;
+        _dataLength = requiredLength;
+    }
+
+    /// <summary>
+    /// Appends bytes to <see cref="_data"/>.
+    /// </summary>
+    internal void AppendToData(byte[] other)
+    {
+        if (other.Length == 0)
         {
-            result[first.Length + i] = second[i];
+            return;
         }
-        return result;
+
+        int requiredLength = _dataLength + other.Length;
+        byte[] result = ArrayPool<byte>.Shared.Rent(requiredLength);
+        Buffer.BlockCopy(_data, 0, result, 0, _dataLength);
+        Buffer.BlockCopy(other, 0, result, _dataLength, other.Length);
+        if (_data.Length > 0)
+        {
+            s_arrayPool.Return(_data);
+        }
+
+        _data = result;
+        _dataLength = requiredLength;
     }
 
     internal bool Equals(ushort localPort, ushort remotePort, Address localIp, Address remoteIp)
     {
-        return LocalEndPoint.Port.Equals(localPort) && RemoteEndPoint.Port.Equals(remotePort) && LocalEndPoint.Address.Hash.Equals(localIp.Hash) && RemoteEndPoint.Address.Hash.Equals(remoteIp.Hash);
+        return LocalEndPoint.Port.Equals(localPort) && RemoteEndPoint.Port.Equals(remotePort) &&
+               LocalEndPoint.Address.Hash.Equals(localIp.Hash) && RemoteEndPoint.Address.Hash.Equals(remoteIp.Hash);
     }
 
     #endregion
+
+    public void Dispose()
+    {
+        if (_data.Length > 0)
+        {
+            s_arrayPool.Return(_data);
+        }
+        // TODO release managed resources here
+    }
 }

--- a/src/Cosmos.Kernel.System/Network/IPv4/TCP/Tcp.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/TCP/Tcp.cs
@@ -344,7 +344,9 @@ public class Tcp : IDisposable
     /// Holds real data length as _data might be longer due to being rented.
     /// </summary>
     private int _dataLength = 0;
-    public ReadOnlySpan<byte> Data => _data[.._dataLength];
+
+    private int _dataOffset = 0;
+    public ReadOnlySpan<byte> Data => _data.AsSpan().Slice(_dataOffset, _dataLength);
 
     private Tcp(ushort localPort, ushort remotePort, Address localIp, Address remoteIp)
     {
@@ -877,20 +879,13 @@ public class Tcp : IDisposable
         {
             s_arrayPool.Return(_data);
             _data = [];
+            _dataOffset = 0;
             _dataLength = 0;
             return;
         }
 
-        int requiredLength = _dataLength - offset;
-        byte[] result = ArrayPool<byte>.Shared.Rent(requiredLength);
-        Buffer.BlockCopy(_data, offset, result, 0, requiredLength);
-        if (_data.Length > 0)
-        {
-            s_arrayPool.Return(_data);
-        }
-
-        _data = result;
-        _dataLength = requiredLength;
+        _dataOffset += offset;
+        _dataLength -= offset;
     }
 
     /// <summary>
@@ -903,16 +898,18 @@ public class Tcp : IDisposable
             return;
         }
 
-        int requiredLength = _dataLength + other.Length;
+        int realDataLength = _dataLength - _dataOffset;
+        int requiredLength = realDataLength + other.Length;
         byte[] result = ArrayPool<byte>.Shared.Rent(requiredLength);
-        Buffer.BlockCopy(_data, 0, result, 0, _dataLength);
-        Buffer.BlockCopy(other, 0, result, _dataLength, other.Length);
+        Buffer.BlockCopy(_data, _dataOffset, result, 0, realDataLength);
+        Buffer.BlockCopy(other, 0, result, realDataLength, other.Length);
         if (_data.Length > 0)
         {
             s_arrayPool.Return(_data);
         }
 
         _data = result;
+        _dataOffset = 0;
         _dataLength = requiredLength;
     }
 

--- a/src/Cosmos.Kernel.System/Network/IPv4/TCP/Tcp.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/TCP/Tcp.cs
@@ -891,7 +891,7 @@ public class Tcp : IDisposable
     /// <summary>
     /// Appends bytes to <see cref="_data"/>.
     /// </summary>
-    internal void AppendToData(byte[] other)
+    internal void AppendToData(ReadOnlySpan<byte> other)
     {
         if (other.Length == 0)
         {
@@ -902,7 +902,8 @@ public class Tcp : IDisposable
         int requiredLength = realDataLength + other.Length;
         byte[] result = ArrayPool<byte>.Shared.Rent(requiredLength);
         Buffer.BlockCopy(_data, _dataOffset, result, 0, realDataLength);
-        Buffer.BlockCopy(other, 0, result, realDataLength, other.Length);
+        var target = result.AsSpan(realDataLength);
+        other.CopyTo(target);
         if (_data.Length > 0)
         {
             s_arrayPool.Return(_data);

--- a/src/tests/Cosmos.Kernel.Tests.System/Cosmos.Kernel.Tests.System.csproj
+++ b/src/tests/Cosmos.Kernel.Tests.System/Cosmos.Kernel.Tests.System.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" />
+      <PackageReference Include="NUnit" />
+      <PackageReference Include="NUnit3TestAdapter" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\Cosmos.Kernel.System\Cosmos.Kernel.System.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/tests/Cosmos.Kernel.Tests.System/Network/IPv4/TCP/TcpTest.cs
+++ b/src/tests/Cosmos.Kernel.Tests.System/Network/IPv4/TCP/TcpTest.cs
@@ -30,7 +30,7 @@ public class TcpTest
         [Test]
         public void WhenDataIsNotEmpty_AndOtherIsEmpty_DataDoesNotChange()
         {
-            target.AppendToData([0,1]);
+            target.AppendToData([0, 1]);
 
             target.AppendToData([]);
 
@@ -40,7 +40,7 @@ public class TcpTest
         [Test]
         public void WhenDataIsNotEmpty_AndOtherIsNotEmpty_OtherIsAppendedToData()
         {
-            target.AppendToData([0,1]);
+            target.AppendToData([0, 1]);
 
             target.AppendToData([2, 3]);
 
@@ -54,7 +54,7 @@ public class TcpTest
         [Test]
         public void WhenAdvancingByZero_NoChangesAreMade()
         {
-            target.AppendToData([0,1]);
+            target.AppendToData([0, 1]);
 
             target.AdvanceDataOffset(0);
 
@@ -64,7 +64,7 @@ public class TcpTest
         [Test]
         public void WhenAdvancingByOneAndLengthIsTwo_OnlyLastElementRemains()
         {
-            target.AppendToData([0,1]);
+            target.AppendToData([0, 1]);
 
             target.AdvanceDataOffset(1);
 
@@ -73,7 +73,7 @@ public class TcpTest
         [Test]
         public void WhenAdvancingByTwoAndLengthIsTwo_DataLengthIsZero()
         {
-            target.AppendToData([0,1]);
+            target.AppendToData([0, 1]);
 
             target.AdvanceDataOffset(2);
 

--- a/src/tests/Cosmos.Kernel.Tests.System/Network/IPv4/TCP/TcpTest.cs
+++ b/src/tests/Cosmos.Kernel.Tests.System/Network/IPv4/TCP/TcpTest.cs
@@ -1,0 +1,83 @@
+// This code is licensed under MIT license (see LICENSE for details)
+
+using Cosmos.Kernel.System.Network.IPv4;
+using Cosmos.Kernel.System.Network.IPv4.TCP;
+using NUnit.Framework;
+
+namespace Cosmos.Kernel.Tests.System.Network.IPv4.TCP;
+
+public class TcpTest
+{
+    private Tcp target = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        target = Tcp.CreateConnection(0, 0, new Address(1, 2, 3, 4), new Address(1, 2, 3, 4));
+    }
+
+    [TestFixture]
+    public class AppendToData : TcpTest
+    {
+        [Test]
+        public void WhenBothData_AndOtherAreEmpty_DataIsEmpty()
+        {
+            target.AppendToData([]);
+
+            Assert.That(target.Data.Length, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void WhenDataIsNotEmpty_AndOtherIsEmpty_DataDoesNotChange()
+        {
+            target.AppendToData([0,1]);
+
+            target.AppendToData([]);
+
+            Assert.That(target.Data.ToArray(), Is.EquivalentTo([0, 1]));
+        }
+
+        [Test]
+        public void WhenDataIsNotEmpty_AndOtherIsNotEmpty_OtherIsAppendedToData()
+        {
+            target.AppendToData([0,1]);
+
+            target.AppendToData([2, 3]);
+
+            Assert.That(target.Data.ToArray(), Is.EquivalentTo([0, 1, 2, 3]));
+        }
+    }
+
+    [TestFixture]
+    public class AdvanceDataOffset : TcpTest
+    {
+        [Test]
+        public void WhenAdvancingByZero_NoChangesAreMade()
+        {
+            target.AppendToData([0,1]);
+
+            target.AdvanceDataOffset(0);
+
+            Assert.That(target.Data.ToArray(), Is.EquivalentTo([0, 1]));
+        }
+
+        [Test]
+        public void WhenAdvancingByOneAndLengthIsTwo_OnlyLastElementRemains()
+        {
+            target.AppendToData([0,1]);
+
+            target.AdvanceDataOffset(1);
+
+            Assert.That(target.Data.ToArray(), Is.EquivalentTo([1]));
+        }
+        [Test]
+        public void WhenAdvancingByTwoAndLengthIsTwo_DataLengthIsZero()
+        {
+            target.AppendToData([0,1]);
+
+            target.AdvanceDataOffset(2);
+
+            Assert.That(target.Data.Length, Is.Zero);
+        }
+    }
+}


### PR DESCRIPTION
Optimizes Tcp:
- uses ArrayPool<byte> for buffers
- makes Data access private
- Tcp instances are created only through static Tcp.CreateConnection method, so they can be tracked and disposed eventually to release rented buffers
- introduces unit tests