### PR TITLE
Fix field naming violations breaking the format CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,21 @@ trim_trailing_whitespace = true
 [*{_AssemblyInfo.cs,.notsupported.cs,AsmOffsets.cs}]
 generated_code = true
 
+# Vendored and upstream-mirroring code: keep diffable with its origin, skip style analysis
+[src/Cosmos.Kernel.System/IO/Compression/SharpZipLib/**.cs]
+generated_code = true
+
+[src/Cosmos.Kernel.System/Graphics/Images/Png/**.cs]
+generated_code = true
+
+# fdlibm port (via Cosmos Gen2)
+[src/Cosmos.Kernel.Core/Runtime/Math.cs]
+generated_code = true
+
+# Mirrors dotnet/runtime internals
+[src/Cosmos.Kernel.Core/Runtime/Internal/**.cs]
+generated_code = true
+
 # C# files
 [*.cs]
 # New line preferences
@@ -190,6 +205,10 @@ dotnet_diagnostic.CA2201.severity = warning
 # MSBuild task contract requires array-typed properties (ITaskItem[], string[])
 [src/Cosmos.Build.*/**.cs]
 dotnet_diagnostic.CA1819.severity = none
+
+# Plug members are matched by name against their patch targets (BCL/runtime internals) - do not rename
+[src/Cosmos.Kernel.Plugs/**.cs]
+dotnet_diagnostic.IDE1006.severity = none
 
 [*.{cpp,h,in}]
 curly_bracket_next_line = true

--- a/src/Cosmos.Kernel.Boot.Limine/LimineFramebuffer.cs
+++ b/src/Cosmos.Kernel.Boot.Limine/LimineFramebuffer.cs
@@ -69,7 +69,7 @@ public readonly unsafe struct LimineFramebuffer
     public readonly byte GreenMaskShift;
     public readonly byte BlueMaskSize;
     public readonly byte BlueMaskShift;
-    private readonly byte p1, p2, p3, p4, p5, p6, p7;
+    private readonly byte _p1, _p2, _p3, _p4, _p5, _p6, _p7;
     public readonly ulong EdidSize;
     public readonly void* Edid;
 }

--- a/src/Cosmos.Kernel.Core.ARM64/Cpu/DeviceMapper.cs
+++ b/src/Cosmos.Kernel.Core.ARM64/Cpu/DeviceMapper.cs
@@ -27,7 +27,7 @@ public static unsafe class DeviceMapper
     private const ulong BLOCK_2MB_ADDR_MASK = 0x0000FFFFFFE00000UL;
     private const ulong BLOCK_1GB_ADDR_MASK = 0x0000FFFFC0000000UL;
 
-    private static bool _spareL2Used;
+    private static bool s_spareL2Used;
 
     // ── Public API ──────────────────────────────────────────────────
 
@@ -202,7 +202,7 @@ public static unsafe class DeviceMapper
     /// </summary>
     private static ulong* SplitL1Block(ulong* l1, int l1idx, ulong l1entry, ulong hhdmOffset)
     {
-        if (_spareL2Used)
+        if (s_spareL2Used)
         {
             Serial.Write("[DeviceMapper] ERROR: Spare L2 table already used\n");
             return null;
@@ -252,7 +252,7 @@ public static unsafe class DeviceMapper
         // (vale1 only flushes one page; we need broader flush)
         DeviceMapperNative.FlushTlb(0); // will be followed by individual flushes if needed
 
-        _spareL2Used = true;
+        s_spareL2Used = true;
 
         Serial.Write("[DeviceMapper] Split L1 block into L2 table at PA 0x");
         Serial.WriteHex(l2pa);

--- a/src/Cosmos.Kernel.Core.ARM64/Cpu/Gic/GIC.cs
+++ b/src/Cosmos.Kernel.Core.ARM64/Cpu/Gic/GIC.cs
@@ -49,9 +49,9 @@ public static class GIC
     /// <summary>Mask of the offset bits within a 2 MiB device block, used to align addresses down to a block boundary.</summary>
     private const ulong DeviceBlockOffsetMask = 0x1FFFFFUL;
 
-    private static bool _isV3;
-    private static bool _initialized;
-    private static ulong _distBase;
+    private static bool s_isV3;
+    private static bool s_initialized;
+    private static ulong s_distBase;
 
     /// <summary>
     /// Translates a physical address to a virtual address using Limine's HHDM offset.
@@ -83,12 +83,12 @@ public static class GIC
     /// <summary>
     /// Whether the GIC has been initialized.
     /// </summary>
-    public static bool IsInitialized => _initialized;
+    public static bool IsInitialized => s_initialized;
 
     /// <summary>
     /// Whether GICv3 is being used (false = GICv2).
     /// </summary>
-    public static bool IsVersion3 => _isV3;
+    public static bool IsVersion3 => s_isV3;
 
     /// <summary>
     /// Brings the LPI/ITS path online if the platform reports an ITS, then
@@ -98,7 +98,7 @@ public static class GIC
     /// </summary>
     private static unsafe void InitializeMsi(ulong itsBase)
     {
-        if (!_isV3)
+        if (!s_isV3)
         {
             Serial.Write("[GIC] MSI/ITS only supported on GICv3, skipping\n");
             return;
@@ -158,10 +158,10 @@ public static class GIC
         var acpiGic = AcpiGic.GetGicInfo();
         if (acpiGic != null && acpiGic->Found != 0)
         {
-            _distBase = acpiGic->DistBase;
-            _isV3 = acpiGic->Version >= GicVersionV3;
+            s_distBase = acpiGic->DistBase;
+            s_isV3 = acpiGic->Version >= GicVersionV3;
 
-            if (_isV3 && acpiGic->RedistBase != 0)
+            if (s_isV3 && acpiGic->RedistBase != 0)
             {
                 // Default to sysreg-only (safe on hardware where GICD/GICR
                 // MMIO is inaccessible). When the firmware advertises an
@@ -214,13 +214,13 @@ public static class GIC
                     GICv3.Initialize(sysregOnly: false);
                 }
             }
-            else if (_isV3)
+            else if (s_isV3)
             {
                 // GICv3 but no GICR in MADT - still use sysreg-only
                 Serial.Write("[GIC] ACPI: GICv3 detected (no GICR in MADT, sysreg-only)\n");
                 GICv3.Initialize(sysregOnly: true);
             }
-            else if (!_isV3 && acpiGic->CpuIfBase != 0)
+            else if (!s_isV3 && acpiGic->CpuIfBase != 0)
             {
                 // GICv2 always needs MMIO
                 DeviceMapper.EnsureMapped(acpiGic->DistBase);
@@ -241,22 +241,22 @@ public static class GIC
                 GICv2.Initialize();
             }
 
-            _initialized = true;
+            s_initialized = true;
             InitializeMsi(acpiGic->ItsFound != 0 ? acpiGic->ItsBase : 0);
             return;
         }
 
         // Priority 3: Default QEMU virt machine addresses (no DTB, no ACPI)
         Serial.Write("[GIC] No DTB/ACPI, using default QEMU addresses\n");
-        _distBase = PhysToVirt(QemuVirtGicdBase);
+        s_distBase = PhysToVirt(QemuVirtGicdBase);
 
         // Map device MMIO into TTBR1 page tables before any MMIO access
         DeviceMapper.EnsureMapped(QemuVirtGicdBase);
 
         // Detect GIC version via distributor PIDR2.ArchRev
-        _isV3 = GICv3.IsGICv3Available(_distBase);
+        s_isV3 = GICv3.IsGICv3Available(s_distBase);
 
-        if (_isV3)
+        if (s_isV3)
         {
             Serial.Write("[GIC] Detected GICv3\n");
             GICv3.Initialize();
@@ -267,7 +267,7 @@ public static class GIC
             GICv2.Initialize();
         }
 
-        _initialized = true;
+        s_initialized = true;
 
         // No MADT means no authoritative ITS address. Probing QEMU's
         // default 0x08080000 blindly reads GITS_CTLR on whatever sits
@@ -275,7 +275,7 @@ public static class GIC
         // this fallback) that's unbacked address space and the read
         // faults or hangs the bus at boot. Without a safe probe, leave
         // MSI off and let the drivers take their polled fallback.
-        if (_isV3)
+        if (s_isV3)
         {
             Serial.Write("[GIC] No ACPI: ITS discovery unavailable, MSI path disabled\n");
         }
@@ -286,7 +286,7 @@ public static class GIC
     /// </summary>
     public static void InitializeCpuInterface()
     {
-        if (_isV3)
+        if (s_isV3)
         {
             GICv3.InitializeCpuInterface();
         }
@@ -301,7 +301,7 @@ public static class GIC
     /// </summary>
     public static void EnableInterrupt(uint intId)
     {
-        if (_isV3)
+        if (s_isV3)
         {
             GICv3.EnableInterrupt(intId);
         }
@@ -316,7 +316,7 @@ public static class GIC
     /// </summary>
     public static void DisableInterrupt(uint intId)
     {
-        if (_isV3)
+        if (s_isV3)
         {
             GICv3.DisableInterrupt(intId);
         }
@@ -331,7 +331,7 @@ public static class GIC
     /// </summary>
     public static void SetPriority(uint intId, byte priority)
     {
-        if (_isV3)
+        if (s_isV3)
         {
             GICv3.SetPriority(intId, priority);
         }
@@ -346,7 +346,7 @@ public static class GIC
     /// </summary>
     public static uint AcknowledgeInterrupt()
     {
-        return _isV3
+        return s_isV3
             ? GICv3.AcknowledgeInterrupt()
             : GICv2.AcknowledgeInterrupt();
     }
@@ -356,7 +356,7 @@ public static class GIC
     /// </summary>
     public static void EndOfInterrupt(uint intId)
     {
-        if (_isV3)
+        if (s_isV3)
         {
             GICv3.EndOfInterrupt(intId);
         }
@@ -371,7 +371,7 @@ public static class GIC
     /// </summary>
     public static bool IsInterruptPending(uint intId)
     {
-        return _isV3
+        return s_isV3
             ? GICv3.IsInterruptPending(intId)
             : GICv2.IsInterruptPending(intId);
     }
@@ -381,7 +381,7 @@ public static class GIC
     /// </summary>
     public static void ClearPending(uint intId)
     {
-        if (_isV3)
+        if (s_isV3)
         {
             GICv3.ClearPending(intId);
         }
@@ -396,7 +396,7 @@ public static class GIC
     /// </summary>
     public static void ConfigureInterrupt(uint intId, bool edgeTriggered)
     {
-        if (_isV3)
+        if (s_isV3)
         {
             GICv3.ConfigureInterrupt(intId, edgeTriggered);
         }

--- a/src/Cosmos.Kernel.Core.ARM64/Cpu/Gic/GICv2.cs
+++ b/src/Cosmos.Kernel.Core.ARM64/Cpu/Gic/GICv2.cs
@@ -15,8 +15,8 @@ public static class GICv2
     private const ulong QemuVirtGiccBase = 0x08010000;
 
     // Default QEMU virt machine GIC base addresses (overridable via Configure)
-    private static ulong _gicDistBase = GIC.QemuVirtGicdBase;
-    private static ulong _gicCpuBase = QemuVirtGiccBase;
+    private static ulong s_gicDistBase = GIC.QemuVirtGicdBase;
+    private static ulong s_gicCpuBase = QemuVirtGiccBase;
 
     // Distributor registers (offsets from GICD_BASE)
     private const uint GICD_CTLR = 0x000;        // Distributor Control
@@ -58,12 +58,12 @@ public static class GICv2
     /// <summary>Width in bits of one GICD_ICFGR configuration field.</summary>
     private const uint CfgBitsPerIrq = 2;
 
-    private static bool _initialized;
+    private static bool s_initialized;
 
     /// <summary>
     /// Whether the GIC has been initialized.
     /// </summary>
-    public static bool IsInitialized => _initialized;
+    public static bool IsInitialized => s_initialized;
 
     /// <summary>
     /// Configures the GICv2 base addresses. Must be called before Initialize()
@@ -73,8 +73,8 @@ public static class GICv2
     /// <param name="cpuBase">GICC base address.</param>
     public static void Configure(ulong distBase, ulong cpuBase)
     {
-        _gicDistBase = distBase;
-        _gicCpuBase = cpuBase;
+        s_gicDistBase = distBase;
+        s_gicCpuBase = cpuBase;
         Serial.Write("[GIC] Configured GICD=0x");
         Serial.WriteHex(distBase);
         Serial.Write(" GICC=0x");
@@ -134,7 +134,7 @@ public static class GICv2
         // Initialize CPU interface
         InitializeCpuInterface();
 
-        _initialized = true;
+        s_initialized = true;
         Serial.Write("[GIC] GICv2 initialized\n");
     }
 
@@ -197,7 +197,7 @@ public static class GICv2
         // Write single byte at the correct offset
         unsafe
         {
-            byte* ptr = (byte*)(_gicDistBase + regOffset);
+            byte* ptr = (byte*)(s_gicDistBase + regOffset);
             *ptr = priority;
         }
     }
@@ -274,7 +274,7 @@ public static class GICv2
     {
         unsafe
         {
-            uint* ptr = (uint*)(_gicDistBase + offset);
+            uint* ptr = (uint*)(s_gicDistBase + offset);
             return System.Threading.Volatile.Read(ref *ptr);
         }
     }
@@ -284,7 +284,7 @@ public static class GICv2
     {
         unsafe
         {
-            uint* ptr = (uint*)(_gicDistBase + offset);
+            uint* ptr = (uint*)(s_gicDistBase + offset);
             System.Threading.Volatile.Write(ref *ptr, value);
         }
     }
@@ -294,7 +294,7 @@ public static class GICv2
     {
         unsafe
         {
-            uint* ptr = (uint*)(_gicCpuBase + offset);
+            uint* ptr = (uint*)(s_gicCpuBase + offset);
             return System.Threading.Volatile.Read(ref *ptr);
         }
     }
@@ -304,7 +304,7 @@ public static class GICv2
     {
         unsafe
         {
-            uint* ptr = (uint*)(_gicCpuBase + offset);
+            uint* ptr = (uint*)(s_gicCpuBase + offset);
             System.Threading.Volatile.Write(ref *ptr, value);
         }
     }

--- a/src/Cosmos.Kernel.Core.ARM64/Cpu/Gic/GICv3.cs
+++ b/src/Cosmos.Kernel.Core.ARM64/Cpu/Gic/GICv3.cs
@@ -19,12 +19,12 @@ public static class GICv3
     private const ulong QemuVirtGicrBase = 0x080A0000;
 
     // Default QEMU virt machine GICv3 base addresses (overridable via Configure)
-    private static ulong _gicDistBase = GIC.QemuVirtGicdBase;
-    private static ulong _gicReDistBase = QemuVirtGicrBase;
+    private static ulong s_gicDistBase = GIC.QemuVirtGicdBase;
+    private static ulong s_gicReDistBase = QemuVirtGicrBase;
 
     // Discovered redistributor base for the current CPU (found by TYPER walk)
-    private static ulong _currentCpuRdBase;
-    private static ulong _currentCpuSgiBase;
+    private static ulong s_currentCpuRdBase;
+    private static ulong s_currentCpuSgiBase;
 
     /// <summary>
     /// Physical address field (bits [51:12], 4 KiB aligned) shared by GITS_CBASER and
@@ -133,26 +133,26 @@ public static class GICv3
     /// <summary>Spin iterations allowed for GICD_CTLR.RWP to clear after a distributor write.</summary>
     private const uint RwpTimeoutIterations = 1000000;
 
-    private static bool _initialized;
-    private static bool _mmioAvailable;
+    private static bool s_initialized;
+    private static bool s_mmioAvailable;
 
     /// <summary>
     /// Whether the GICv3 has been initialized.
     /// </summary>
-    public static bool IsInitialized => _initialized;
+    public static bool IsInitialized => s_initialized;
 
     /// <summary>
     /// Whether GICD/GICR MMIO is accessible. False on devices where
     /// the GIC bus doesn't respond (e.g., Qualcomm wearable SoCs).
     /// </summary>
-    public static bool IsMmioAvailable => _mmioAvailable;
+    public static bool IsMmioAvailable => s_mmioAvailable;
 
     /// <summary>
     /// RD_base of the redistributor for the current (boot) CPU, discovered
     /// via TYPER walk. Exposed so the LPI / ITS drivers can program
     /// PROPBASER/PENDBASER and the ITS collection-mapping target.
     /// </summary>
-    public static ulong CurrentCpuRdBase => _currentCpuRdBase;
+    public static ulong CurrentCpuRdBase => s_currentCpuRdBase;
 
     /// <summary>
     /// Configures the GICv3 base addresses. Must be called before Initialize()
@@ -166,8 +166,8 @@ public static class GICv3
     /// <param name="redistBase">GICR base address (virtual).</param>
     public static void Configure(ulong distBase, ulong redistBase)
     {
-        _gicDistBase = distBase;
-        _gicReDistBase = redistBase;
+        s_gicDistBase = distBase;
+        s_gicReDistBase = redistBase;
         Serial.Write("[GIC] Configured GICD=0x");
         Serial.WriteHex(distBase);
         Serial.Write(" GICR=0x");
@@ -187,9 +187,9 @@ public static class GICv3
     {
         Serial.Write("[GIC] Initializing GICv3...\n");
         Serial.Write("[GIC] GICD base: 0x");
-        Serial.WriteHex(_gicDistBase);
+        Serial.WriteHex(s_gicDistBase);
         Serial.Write(" GICR base: 0x");
-        Serial.WriteHex(_gicReDistBase);
+        Serial.WriteHex(s_gicReDistBase);
         Serial.Write("\n");
 
         // Step 1: Enable system register access (critical for real hardware)
@@ -198,11 +198,11 @@ public static class GICv3
         if (sysregOnly)
         {
             Serial.Write("[GIC] Sysreg-only mode: skipping GICD/GICR MMIO\n");
-            _mmioAvailable = false;
+            s_mmioAvailable = false;
             InitializeSysregOnly();
             return;
         }
-        _mmioAvailable = true;
+        s_mmioAvailable = true;
 
         // Step 3: Read GIC type to get number of interrupt lines
         uint typer = ReadDistributor(GICD_TYPER);
@@ -278,15 +278,15 @@ public static class GICv3
         {
             Serial.Write("[GIC] WARNING: Failed to find redistributor, trying index 0\n");
             // Fallback: assume first redistributor
-            _currentCpuRdBase = _gicReDistBase;
-            _currentCpuSgiBase = _gicReDistBase + GICR_SGI_OFFSET;
-            InitializeRedistributorAt(_currentCpuRdBase, _currentCpuSgiBase);
+            s_currentCpuRdBase = s_gicReDistBase;
+            s_currentCpuSgiBase = s_gicReDistBase + GICR_SGI_OFFSET;
+            InitializeRedistributorAt(s_currentCpuRdBase, s_currentCpuSgiBase);
         }
 
         // Step 9: Initialize CPU interface via system registers
         InitializeCpuInterface();
 
-        _initialized = true;
+        s_initialized = true;
         Serial.Write("[GIC] GICv3 initialized (full MMIO)\n");
     }
 
@@ -307,7 +307,7 @@ public static class GICv3
         // We just need to set up the CPU interface for our EL1 context.
         InitializeCpuInterface();
 
-        _initialized = true;
+        s_initialized = true;
         Serial.Write("[GIC] GICv3 initialized (sysreg-only)\n");
     }
 
@@ -368,7 +368,7 @@ public static class GICv3
     private static bool FindAndInitRedistributor(ulong mpidr)
     {
         ulong cpuAff = ExtractAffinity(mpidr);
-        ulong rdBase = _gicReDistBase;
+        ulong rdBase = s_gicReDistBase;
 
         // Walk redistributor frames using GICR_TYPER.Last bit
         for (int i = 0; i < MaxRedistFrames; i++) // safety limit
@@ -400,8 +400,8 @@ public static class GICv3
                 Serial.WriteHex(rdBase);
                 Serial.Write("\n");
 
-                _currentCpuRdBase = rdBase;
-                _currentCpuSgiBase = rdBase + GICR_SGI_OFFSET;
+                s_currentCpuRdBase = rdBase;
+                s_currentCpuSgiBase = rdBase + GICR_SGI_OFFSET;
                 InitializeRedistributorAt(rdBase, rdBase + GICR_SGI_OFFSET);
                 return true;
             }
@@ -497,7 +497,7 @@ public static class GICv3
     /// <param name="intId">Interrupt ID (0-1019).</param>
     public static void EnableInterrupt(uint intId)
     {
-        if (!_mmioAvailable)
+        if (!s_mmioAvailable)
         {
             Serial.Write("[GIC] EnableInterrupt(");
             Serial.WriteNumber(intId);
@@ -509,7 +509,7 @@ public static class GICv3
         {
             // SGI/PPI: use redistributor SGI_base frame
             uint bit = 1u << (int)(intId % IntsPerBitmapReg);
-            WriteRedistributor(_currentCpuSgiBase, GICR_ISENABLER0, bit);
+            WriteRedistributor(s_currentCpuSgiBase, GICR_ISENABLER0, bit);
         }
         else
         {
@@ -531,7 +531,7 @@ public static class GICv3
     /// <param name="intId">Interrupt ID.</param>
     public static void DisableInterrupt(uint intId)
     {
-        if (!_mmioAvailable)
+        if (!s_mmioAvailable)
         {
             return;
         }
@@ -539,7 +539,7 @@ public static class GICv3
         if (intId < GIC.SPI_START)
         {
             uint bit = 1u << (int)(intId % IntsPerBitmapReg);
-            WriteRedistributor(_currentCpuSgiBase, GICR_ICENABLER0, bit);
+            WriteRedistributor(s_currentCpuSgiBase, GICR_ICENABLER0, bit);
         }
         else
         {
@@ -557,7 +557,7 @@ public static class GICv3
     /// <param name="priority">Priority (0 = highest, 0xFF = lowest).</param>
     public static void SetPriority(uint intId, byte priority)
     {
-        if (!_mmioAvailable)
+        if (!s_mmioAvailable)
         {
             Serial.Write("[GIC] SetPriority(");
             Serial.WriteNumber(intId);
@@ -572,7 +572,7 @@ public static class GICv3
             // SGI/PPI: use redistributor SGI_base frame
             unsafe
             {
-                byte* ptr = (byte*)(_currentCpuSgiBase + GICR_IPRIORITYR + intId);
+                byte* ptr = (byte*)(s_currentCpuSgiBase + GICR_IPRIORITYR + intId);
                 *ptr = priority;
             }
         }
@@ -582,7 +582,7 @@ public static class GICv3
             uint regOffset = GICD_IPRIORITYR + intId;
             unsafe
             {
-                byte* ptr = (byte*)(_gicDistBase + regOffset);
+                byte* ptr = (byte*)(s_gicDistBase + regOffset);
                 *ptr = priority;
             }
         }
@@ -618,7 +618,7 @@ public static class GICv3
     /// <returns>True if pending.</returns>
     public static bool IsInterruptPending(uint intId)
     {
-        if (!_mmioAvailable)
+        if (!s_mmioAvailable)
         {
             // Best effort: check if the highest pending interrupt matches
             uint hppir = GICv3Native.ReadHppir1() & Hppir1IntIdMask;
@@ -628,7 +628,7 @@ public static class GICv3
         if (intId < GIC.SPI_START)
         {
             uint bit = 1u << (int)(intId % IntsPerBitmapReg);
-            return (ReadRedistributor(_currentCpuSgiBase, GICR_ISPENDR0) & bit) != 0;
+            return (ReadRedistributor(s_currentCpuSgiBase, GICR_ISPENDR0) & bit) != 0;
         }
         else
         {
@@ -645,7 +645,7 @@ public static class GICv3
     /// <param name="intId">Interrupt ID.</param>
     public static void ClearPending(uint intId)
     {
-        if (!_mmioAvailable)
+        if (!s_mmioAvailable)
         {
             return;
         }
@@ -653,7 +653,7 @@ public static class GICv3
         if (intId < GIC.SPI_START)
         {
             uint bit = 1u << (int)(intId % IntsPerBitmapReg);
-            WriteRedistributor(_currentCpuSgiBase, GICR_ICPENDR0, bit);
+            WriteRedistributor(s_currentCpuSgiBase, GICR_ICPENDR0, bit);
         }
         else
         {
@@ -671,7 +671,7 @@ public static class GICv3
     /// <param name="edgeTriggered">True for edge-triggered, false for level-triggered.</param>
     public static void ConfigureInterrupt(uint intId, bool edgeTriggered)
     {
-        if (!_mmioAvailable)
+        if (!s_mmioAvailable)
         {
             return;
         }
@@ -683,7 +683,7 @@ public static class GICv3
             uint regOffset = (regIdx == 0) ? GICR_ICFGR0 : GICR_ICFGR1;
             uint localId = intId - (regIdx * IntsPerCfgReg);
             uint shift = localId * CfgBitsPerInt;
-            uint value = ReadRedistributor(_currentCpuSgiBase, regOffset);
+            uint value = ReadRedistributor(s_currentCpuSgiBase, regOffset);
 
             if (edgeTriggered)
             {
@@ -694,7 +694,7 @@ public static class GICv3
                 value &= ~(GicArch.IcfgrEdgeTriggered << (int)shift);
             }
 
-            WriteRedistributor(_currentCpuSgiBase, regOffset, value);
+            WriteRedistributor(s_currentCpuSgiBase, regOffset, value);
         }
         else
         {
@@ -806,13 +806,13 @@ public static class GICv3
         }
     }
 
-    // Distributor MMIO access (uses runtime _gicDistBase)
+    // Distributor MMIO access (uses runtime s_gicDistBase)
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.NoInlining)]
     private static uint ReadDistributor(uint offset)
     {
         unsafe
         {
-            uint* ptr = (uint*)(_gicDistBase + offset);
+            uint* ptr = (uint*)(s_gicDistBase + offset);
             return System.Threading.Volatile.Read(ref *ptr);
         }
     }
@@ -822,7 +822,7 @@ public static class GICv3
     {
         unsafe
         {
-            uint* ptr = (uint*)(_gicDistBase + offset);
+            uint* ptr = (uint*)(s_gicDistBase + offset);
             System.Threading.Volatile.Write(ref *ptr, value);
         }
     }
@@ -832,7 +832,7 @@ public static class GICv3
     {
         unsafe
         {
-            ulong* ptr = (ulong*)(_gicDistBase + offset);
+            ulong* ptr = (ulong*)(s_gicDistBase + offset);
             System.Threading.Volatile.Write(ref *ptr, value);
         }
     }

--- a/src/Cosmos.Kernel.Core.ARM64/Cpu/Gic/GICv3Its.cs
+++ b/src/Cosmos.Kernel.Core.ARM64/Cpu/Gic/GICv3Its.cs
@@ -172,26 +172,26 @@ public static unsafe class GICv3Its
     // ITT buffer sizing.
     private const uint IttMinEvents = 2;
 
-    private static ulong _itsBase;          // HHDM virtual base — every GITS_* MMIO access goes through this
-    private static ulong _translaterPhys;   // GITS_TRANSLATER physical address; written by devices via MSI
-    private static ulong _cmdQueueVirt;
-    private static ulong _cmdQueuePhys;
-    private static uint _cmdQueueSize;      // bytes
-    private static ulong _cmdWriteOff;      // mirror of GITS_CWRITER
-    private static ulong _maxDeviceId;      // highest DeviceID the flat device table can index
-    private static int _ittEntrySize;
-    private static bool _physicalTargetAddress;
-    private static ulong _bootRedistTarget; // target value for collection 0 (phys addr or proc number<<16)
-    private static SchedSpinLock _cmdLock;
-    private static bool _initialized;
+    private static ulong s_itsBase;          // HHDM virtual base — every GITS_* MMIO access goes through this
+    private static ulong s_translaterPhys;   // GITS_TRANSLATER physical address; written by devices via MSI
+    private static ulong s_cmdQueueVirt;
+    private static ulong s_cmdQueuePhys;
+    private static uint s_cmdQueueSize;      // bytes
+    private static ulong s_cmdWriteOff;      // mirror of GITS_CWRITER
+    private static ulong s_maxDeviceId;      // highest DeviceID the flat device table can index
+    private static int s_ittEntrySize;
+    private static bool s_physicalTargetAddress;
+    private static ulong s_bootRedistTarget; // target value for collection 0 (phys addr or proc number<<16)
+    private static SchedSpinLock s_cmdLock;
+    private static bool s_initialized;
 
-    public static bool IsInitialized => _initialized;
+    public static bool IsInitialized => s_initialized;
 
     /// <summary>
     /// The physical address devices write their <c>data</c> dword to when
     /// signalling an MSI. Becomes the MSI-X table entry's address field.
     /// </summary>
-    public static ulong TranslaterPhysAddr => _translaterPhys;
+    public static ulong TranslaterPhysAddr => s_translaterPhys;
 
     /// <summary>
     /// Initialize the ITS. Must be called after
@@ -209,23 +209,23 @@ public static unsafe class GICv3Its
     /// <param name="rdPhysBase">Boot CPU redistributor RD_base, physical (MAPC RDbase when GITS_TYPER.PTA=1).</param>
     public static void Initialize(ulong itsVirtBase, ulong itsPhysBase, ulong rdVirtBase, ulong rdPhysBase)
     {
-        if (_initialized)
+        if (s_initialized)
         {
             return;
         }
 
-        _itsBase = itsVirtBase;
-        _translaterPhys = itsPhysBase + GITS_TRANSLATER_OFF;
+        s_itsBase = itsVirtBase;
+        s_translaterPhys = itsPhysBase + GITS_TRANSLATER_OFF;
 
         // Make sure the ITS is disabled while we configure tables.
-        uint ctlr = Native.MMIO.Read32(_itsBase + GITS_CTLR);
+        uint ctlr = Native.MMIO.Read32(s_itsBase + GITS_CTLR);
         if ((ctlr & GITS_CTLR_ENABLED) != 0)
         {
-            Native.MMIO.Write32(_itsBase + GITS_CTLR, ctlr & ~GITS_CTLR_ENABLED);
+            Native.MMIO.Write32(s_itsBase + GITS_CTLR, ctlr & ~GITS_CTLR_ENABLED);
             bool quiesced = false;
             for (int i = 0; i < QuiescentSpinLimit; i++)
             {
-                if ((Native.MMIO.Read32(_itsBase + GITS_CTLR) & GITS_CTLR_QUIESCENT) != 0)
+                if ((Native.MMIO.Read32(s_itsBase + GITS_CTLR) & GITS_CTLR_QUIESCENT) != 0)
                 {
                     quiesced = true;
                     break;
@@ -240,16 +240,16 @@ public static unsafe class GICv3Its
             }
         }
 
-        ulong typer = Native.MMIO.Read64(_itsBase + GITS_TYPER);
-        _ittEntrySize = (int)(((typer >> TYPER_ITT_ENTRY_SIZE_SHIFT) & TYPER_ITT_ENTRY_SIZE_MASK) + 1);
-        _physicalTargetAddress = ((typer >> TYPER_PTA_SHIFT) & TYPER_PTA_MASK) != 0;
+        ulong typer = Native.MMIO.Read64(s_itsBase + GITS_TYPER);
+        s_ittEntrySize = (int)(((typer >> TYPER_ITT_ENTRY_SIZE_SHIFT) & TYPER_ITT_ENTRY_SIZE_MASK) + 1);
+        s_physicalTargetAddress = ((typer >> TYPER_PTA_SHIFT) & TYPER_PTA_MASK) != 0;
 
         // Compute target address for MAPC / SYNC. With PTA=1 the RDbase
         // field carries the redistributor's PHYSICAL address (it is a bus
         // address the ITS emits, not something the CPU dereferences).
-        if (_physicalTargetAddress)
+        if (s_physicalTargetAddress)
         {
-            _bootRedistTarget = rdPhysBase;
+            s_bootRedistTarget = rdPhysBase;
         }
         else
         {
@@ -257,21 +257,21 @@ public static unsafe class GICv3Its
             // is almost always right, but read it for correctness.
             ulong rdTyper = Native.MMIO.Read64(rdVirtBase + GICv3.GICR_TYPER);
             ulong procNum = (rdTyper >> GICR_TYPER_PROCNUM_SHIFT) & GICR_TYPER_PROCNUM_MASK;
-            _bootRedistTarget = procNum << CMD_TARGET_PROCNUM_SHIFT;
+            s_bootRedistTarget = procNum << CMD_TARGET_PROCNUM_SHIFT;
         }
 
         // Configure GITS_BASER[i] for Device and Collection tables.
         for (int i = 0; i < BaserCount; i++)
         {
             ulong off = GITS_BASER0 + (ulong)i * BaserStride;
-            ulong baser = Native.MMIO.Read64(_itsBase + (uint)off);
+            ulong baser = Native.MMIO.Read64(s_itsBase + (uint)off);
             byte type = (byte)((baser >> BASER_TYPE_SHIFT) & BASER_TYPE_MASK);
             if (type == BASER_TYPE_DEVICE || type == BASER_TYPE_COLLECTION)
             {
                 uint pages = type == BASER_TYPE_DEVICE ? DeviceTablePages : CollectionTablePages;
                 if (!ConfigureBaser(off, baser, type, pages))
                 {
-                    // Leave _initialized false: InitializeMsi reports the
+                    // Leave s_initialized false: InitializeMsi reports the
                     // failure and the MSI path downgrades to polled.
                     return;
                 }
@@ -280,9 +280,9 @@ public static unsafe class GICv3Its
         }
 
         // Allocate command queue (one 4 KiB page, 128 commands of 32 bytes each).
-        _cmdQueueSize = CommandQueueBytes;
-        _cmdQueueVirt = (ulong)PageAllocator.AllocPages(PageType.Unmanaged, CommandQueuePages, zero: true);
-        if (_cmdQueueVirt == 0)
+        s_cmdQueueSize = CommandQueueBytes;
+        s_cmdQueueVirt = (ulong)PageAllocator.AllocPages(PageType.Unmanaged, CommandQueuePages, zero: true);
+        if (s_cmdQueueVirt == 0)
         {
             // Without this check CBASER would point the ITS at physical
             // page 0 — corruption instead of the clean MSI-off downgrade.
@@ -290,34 +290,34 @@ public static unsafe class GICv3Its
             return;
         }
 
-        _cmdQueuePhys = PageAllocator.VirtualToPhysical(_cmdQueueVirt);
+        s_cmdQueuePhys = PageAllocator.VirtualToPhysical(s_cmdQueueVirt);
 
         ulong cbaser = CBASER_VALID
                      | CBASER_INNERSHAREABLE
                      | BASER_INNER_CACHE_RaWaWb
-                     | (_cmdQueuePhys & GICv3.BASER_PHYS_ADDR_MASK)
+                     | (s_cmdQueuePhys & GICv3.BASER_PHYS_ADDR_MASK)
                      | 0; // size = (4KB / 4KB) - 1 = 0
-        Native.MMIO.Write64(_itsBase + GITS_CBASER, cbaser);
+        Native.MMIO.Write64(s_itsBase + GITS_CBASER, cbaser);
         // Same policy as the BASER tables: a command queue whose
         // shareability reads back 0 is fetched without snooping CPU
         // caches, and command writes would sit in cache while the ITS
         // executes stale DRAM. Refuse rather than corrupt.
-        ulong cbRb = Native.MMIO.Read64(_itsBase + GITS_CBASER);
+        ulong cbRb = Native.MMIO.Read64(s_itsBase + GITS_CBASER);
         if ((cbRb & (BASER_SHAREABILITY_MASK << BASER_SHAREABILITY_SHIFT)) == 0)
         {
             Serial.WriteString("[GICv3-ITS] ERROR: CBASER shareability forced to 0 (non-coherent ITS), no dcache maintenance available\n");
             return;
         }
 
-        Native.MMIO.Write64(_itsBase + GITS_CWRITER, 0);
-        _cmdWriteOff = 0;
+        Native.MMIO.Write64(s_itsBase + GITS_CWRITER, 0);
+        s_cmdWriteOff = 0;
 
         // Enable ITS.
-        Native.MMIO.Write32(_itsBase + GITS_CTLR, GITS_CTLR_ENABLED);
+        Native.MMIO.Write32(s_itsBase + GITS_CTLR, GITS_CTLR_ENABLED);
 
         // Map collection 0 -> boot CPU's redistributor.
-        _initialized = true;
-        EnqueueMapc(BootCollectionId, _bootRedistTarget, valid: true);
+        s_initialized = true;
+        EnqueueMapc(BootCollectionId, s_bootRedistTarget, valid: true);
         EnqueueSync();
         FlushCommandQueue();
 
@@ -335,7 +335,7 @@ public static unsafe class GICv3Its
     /// </summary>
     public static void MapDevice(uint deviceId, uint maxEvents)
     {
-        if (!_initialized)
+        if (!s_initialized)
         {
             return;
         }
@@ -345,12 +345,12 @@ public static unsafe class GICv3Its
         // memory beyond the table, and the device's MSIs silently vanish.
         // Reject loudly instead; MsiX.Enable turns this into a clean
         // polled-mode downgrade for the device.
-        if (deviceId > _maxDeviceId)
+        if (deviceId > s_maxDeviceId)
         {
             Serial.WriteString("[GICv3-ITS] ERROR: DeviceID 0x");
             Serial.WriteHex(deviceId);
             Serial.WriteString(" exceeds flat device table max 0x");
-            Serial.WriteHex(_maxDeviceId);
+            Serial.WriteHex(s_maxDeviceId);
             Serial.WriteString(" (grow DeviceTablePages or add BASER.Indirect support)\n");
             throw new System.InvalidOperationException("GICv3-ITS: DeviceID exceeds the flat device table range");
         }
@@ -362,7 +362,7 @@ public static unsafe class GICv3Its
             sizeField = 0;
         }
 
-        ulong ittBytes = (ulong)nrEvents * (ulong)_ittEntrySize;
+        ulong ittBytes = (ulong)nrEvents * (ulong)s_ittEntrySize;
         // ITT must be 256-byte aligned. PageAllocator returns 4 KiB pages
         // which already satisfies that; allocate at least 1 page.
         ulong pages = (ittBytes + ItsPageMask) / ItsPageSize;
@@ -394,7 +394,7 @@ public static unsafe class GICv3Its
     /// </summary>
     public static void MapEvent(uint deviceId, uint eventId, uint lpi)
     {
-        if (!_initialized)
+        if (!s_initialized)
         {
             return;
         }
@@ -433,8 +433,8 @@ public static unsafe class GICv3Its
                     | BASER_PAGE_SIZE_4K
                     | (ulong)((pages - 1) & BASER_PAGES_MASK)
                     | BASER_VALID;
-        Native.MMIO.Write64(_itsBase + (uint)off, baser);
-        ulong rb = Native.MMIO.Read64(_itsBase + (uint)off);
+        Native.MMIO.Write64(s_itsBase + (uint)off, baser);
+        ulong rb = Native.MMIO.Read64(s_itsBase + (uint)off);
 
         // Page_Size is not guaranteed writable: a 16K/64K-only ITS holds a
         // larger granule in the read-back, and Size counts pages of THAT
@@ -471,8 +471,8 @@ public static unsafe class GICv3Its
                   | BASER_INNERSHAREABLE
                   | (rbGranule << BASER_PAGE_SIZE_SHIFT)
                   | BASER_VALID; // Size = 0: one granule
-            Native.MMIO.Write64(_itsBase + (uint)off, baser);
-            rb = Native.MMIO.Read64(_itsBase + (uint)off);
+            Native.MMIO.Write64(s_itsBase + (uint)off, baser);
+            rb = Native.MMIO.Read64(s_itsBase + (uint)off);
         }
 
         // Shareability forced to 0 means the ITS will not snoop CPU caches
@@ -491,7 +491,7 @@ public static unsafe class GICv3Its
         {
             // A flat table indexes by DeviceID value: this is the highest
             // ID MAPD can accept without the ITS walking past the table.
-            _maxDeviceId = sizeBytes / (ulong)entrySize - 1;
+            s_maxDeviceId = sizeBytes / (ulong)entrySize - 1;
         }
 
         return true;
@@ -501,23 +501,23 @@ public static unsafe class GICv3Its
 
     private static void EnqueueRaw(ulong cmd0, ulong cmd1, ulong cmd2, ulong cmd3)
     {
-        // Caller holds _cmdLock.
-        ulong* q = (ulong*)(_cmdQueueVirt + _cmdWriteOff);
+        // Caller holds s_cmdLock.
+        ulong* q = (ulong*)(s_cmdQueueVirt + s_cmdWriteOff);
         q[0] = cmd0;
         q[1] = cmd1;
         q[2] = cmd2;
         q[3] = cmd3;
 
-        _cmdWriteOff += ItsCommandSize;
-        if (_cmdWriteOff >= _cmdQueueSize)
+        s_cmdWriteOff += ItsCommandSize;
+        if (s_cmdWriteOff >= s_cmdQueueSize)
         {
-            _cmdWriteOff = 0;
+            s_cmdWriteOff = 0;
         }
     }
 
     private static void EnqueueMapc(ushort collection, ulong target, bool valid)
     {
-        _cmdLock.Acquire();
+        s_cmdLock.Acquire();
         // cmd[0]: opcode in low byte
         // cmd[2]: collection (15:0) | target_addr [47:16] (PTA mode) or proc_num<<16 (non-PTA)
         //         valid in bit 63
@@ -525,44 +525,44 @@ public static unsafe class GICv3Its
                  | (target & CMD_TARGET_ADDR_MASK)
                  | (valid ? CMD_VALID : 0);
         EnqueueRaw(CMD_MAPC, 0, c2, 0);
-        _cmdLock.Release();
+        s_cmdLock.Release();
     }
 
     private static void EnqueueMapd(uint deviceId, ulong ittPhys, int sizeField, bool valid)
     {
-        _cmdLock.Acquire();
+        s_cmdLock.Acquire();
         ulong c0 = CMD_MAPD | ((ulong)deviceId << CMD_DEVICE_ID_SHIFT);
         ulong c1 = (ulong)sizeField & MAPD_SIZE_MASK;
         ulong c2 = (ittPhys & MAPD_ITT_ADDR_MASK) | (valid ? CMD_VALID : 0);
         EnqueueRaw(c0, c1, c2, 0);
-        _cmdLock.Release();
+        s_cmdLock.Release();
     }
 
     private static void EnqueueMapti(uint deviceId, uint eventId, uint lpi, ushort collection)
     {
-        _cmdLock.Acquire();
+        s_cmdLock.Acquire();
         ulong c0 = CMD_MAPTI | ((ulong)deviceId << CMD_DEVICE_ID_SHIFT);
         ulong c1 = (ulong)eventId | ((ulong)lpi << MAPTI_LPI_SHIFT);
         ulong c2 = (ulong)collection;
         EnqueueRaw(c0, c1, c2, 0);
-        _cmdLock.Release();
+        s_cmdLock.Release();
     }
 
     private static void EnqueueInv(uint deviceId, uint eventId)
     {
-        _cmdLock.Acquire();
+        s_cmdLock.Acquire();
         ulong c0 = CMD_INV | ((ulong)deviceId << CMD_DEVICE_ID_SHIFT);
         ulong c1 = (ulong)eventId;
         EnqueueRaw(c0, c1, 0, 0);
-        _cmdLock.Release();
+        s_cmdLock.Release();
     }
 
     private static void EnqueueSync()
     {
-        _cmdLock.Acquire();
-        ulong c2 = _bootRedistTarget & CMD_TARGET_ADDR_MASK;
+        s_cmdLock.Acquire();
+        ulong c2 = s_bootRedistTarget & CMD_TARGET_ADDR_MASK;
         EnqueueRaw(CMD_SYNC, 0, c2, 0);
-        _cmdLock.Release();
+        s_cmdLock.Release();
     }
 
     /// <summary>
@@ -571,17 +571,17 @@ public static unsafe class GICv3Its
     /// </summary>
     private static void FlushCommandQueue()
     {
-        _cmdLock.Acquire();
+        s_cmdLock.Acquire();
         // DSB so the command bytes are globally visible BEFORE the ITS sees
         // the advanced CWRITER pointer; otherwise the ITS may fetch stale
         // queue contents and ignore our command.
         DeviceMapperNative.DsbIsb();
-        Native.MMIO.Write64(_itsBase + GITS_CWRITER, _cmdWriteOff);
+        Native.MMIO.Write64(s_itsBase + GITS_CWRITER, s_cmdWriteOff);
 
         for (int i = 0; i < CommandFlushSpinLimit; i++)
         {
-            ulong reader = Native.MMIO.Read64(_itsBase + GITS_CREADR);
-            if ((reader & CREADR_OFFSET_MASK) == _cmdWriteOff)
+            ulong reader = Native.MMIO.Read64(s_itsBase + GITS_CREADR);
+            if ((reader & CREADR_OFFSET_MASK) == s_cmdWriteOff)
             {
                 // Spec: GITS_CREADR.Stalled (bit 0) == 1 means the ITS
                 // rejected the last command and won't advance further.
@@ -590,14 +590,14 @@ public static unsafe class GICv3Its
                 // see their interrupts.
                 if ((reader & CREADR_STALLED) != 0)
                 {
-                    _cmdLock.Release();
+                    s_cmdLock.Release();
                     throw new System.InvalidOperationException("[GICv3-ITS] command queue STALLED");
                 }
-                _cmdLock.Release();
+                s_cmdLock.Release();
                 return;
             }
         }
-        _cmdLock.Release();
+        s_cmdLock.Release();
         throw new System.InvalidOperationException("[GICv3-ITS] command queue flush timeout");
     }
 

--- a/src/Cosmos.Kernel.Core.ARM64/Cpu/Gic/GICv3Lpi.cs
+++ b/src/Cosmos.Kernel.Core.ARM64/Cpu/Gic/GICv3Lpi.cs
@@ -85,14 +85,14 @@ public static unsafe class GICv3Lpi
     /// <summary>Maximum poll iterations while waiting for GICR_CTLR.RWP to clear or GICR_SYNCR to read 0.</summary>
     private const int RegisterSyncSpinLimit = 1_000_000;
 
-    private static ulong _propTablePhys;
-    private static ulong _propTableVirt;
-    private static ulong _pendTablePhys;
-    private static ulong _pendTableVirt;
-    private static ulong _rdBase;
-    private static bool _initialized;
+    private static ulong s_propTablePhys;
+    private static ulong s_propTableVirt;
+    private static ulong s_pendTablePhys;
+    private static ulong s_pendTableVirt;
+    private static ulong s_rdBase;
+    private static bool s_initialized;
 
-    public static bool IsInitialized => _initialized;
+    public static bool IsInitialized => s_initialized;
 
     /// <summary>
     /// Initialize LPI delivery on the boot CPU's redistributor. <paramref name="rdBase"/>
@@ -104,12 +104,12 @@ public static unsafe class GICv3Lpi
     /// </summary>
     public static void Initialize(ulong rdBase)
     {
-        if (_initialized)
+        if (s_initialized)
         {
             return;
         }
 
-        _rdBase = rdBase;
+        s_rdBase = rdBase;
 
         // If firmware ran with LPIs enabled, GICR_PROPBASER/PENDBASER still
         // point at tables we don't own: silently keeping them while every
@@ -120,7 +120,7 @@ public static unsafe class GICv3Lpi
         // InitializeMsi downgrades the whole MSI path to polled.
         // GICR_CTLR is a 32-bit register; using Write/Read64 here would
         // misalign the access and silently no-op on QEMU.
-        uint ctlr = Native.MMIO.Read32(_rdBase + GICR_CTLR);
+        uint ctlr = Native.MMIO.Read32(s_rdBase + GICR_CTLR);
         if ((ctlr & GICR_CTLR_ENABLE_LPIS) != 0)
         {
             if ((ctlr & GICR_CTLR_CES) == 0)
@@ -130,27 +130,27 @@ public static unsafe class GICv3Lpi
             }
 
             Serial.WriteString("[GICv3-LPI] firmware left LPIs enabled; CES=1, disabling to reprogram\n");
-            Native.MMIO.Write32(_rdBase + GICR_CTLR, ctlr & ~GICR_CTLR_ENABLE_LPIS);
+            Native.MMIO.Write32(s_rdBase + GICR_CTLR, ctlr & ~GICR_CTLR_ENABLE_LPIS);
             for (int i = 0; i < RegisterSyncSpinLimit; i++)
             {
-                if ((Native.MMIO.Read32(_rdBase + GICR_CTLR) & GICR_CTLR_RWP) == 0)
+                if ((Native.MMIO.Read32(s_rdBase + GICR_CTLR) & GICR_CTLR_RWP) == 0)
                 {
                     break;
                 }
             }
 
-            ctlr = Native.MMIO.Read32(_rdBase + GICR_CTLR);
+            ctlr = Native.MMIO.Read32(s_rdBase + GICR_CTLR);
         }
 
         // Property table — 1 byte per INTID, 4KB-aligned. Allocate 4 pages
         // (16 KiB == 2^14) → covers IDbits=13.
-        _propTableVirt = (ulong)PageAllocator.AllocPages(PageType.Unmanaged, PropTablePages, zero: true);
-        if (_propTableVirt == 0)
+        s_propTableVirt = (ulong)PageAllocator.AllocPages(PageType.Unmanaged, PropTablePages, zero: true);
+        if (s_propTableVirt == 0)
         {
             Serial.WriteString("[GICv3-LPI] ERROR: prop table alloc failed\n");
             return;
         }
-        _propTablePhys = PageAllocator.VirtualToPhysical(_propTableVirt);
+        s_propTablePhys = PageAllocator.VirtualToPhysical(s_propTableVirt);
 
         // Pending table — bits, 64 KiB-aligned. Over-allocate so we can
         // pick a 64KB-aligned starting page from the contiguous run.
@@ -165,29 +165,29 @@ public static unsafe class GICv3Lpi
         // Round up to next 64KB-aligned phys; preserve same offset on virt.
         ulong pendAlignedPhys = (pendBlockPhys + PendTableAlignmentMask) & ~PendTableAlignmentMask;
         ulong delta = pendAlignedPhys - pendBlockPhys;
-        _pendTablePhys = pendAlignedPhys;
-        _pendTableVirt = pendBlockVirt + delta;
+        s_pendTablePhys = pendAlignedPhys;
+        s_pendTableVirt = pendBlockVirt + delta;
 
         ulong propbaser = ((ulong)LpiIdBits & PROPBASER_IDBITS_MASK)
                         | PROPBASER_INNER_WB
                         | PROPBASER_INNER_SHAREABLE
-                        | (_propTablePhys & GICv3.BASER_PHYS_ADDR_MASK);
-        Native.MMIO.Write64(_rdBase + GICR_PROPBASER, propbaser);
+                        | (s_propTablePhys & GICv3.BASER_PHYS_ADDR_MASK);
+        Native.MMIO.Write64(s_rdBase + GICR_PROPBASER, propbaser);
 
         ulong pendbaser = PENDBASER_INNER_WB
                         | PENDBASER_INNER_SHAREABLE
                         | PENDBASER_PTZ
-                        | (_pendTablePhys & PENDBASER_ADDR_MASK);
-        Native.MMIO.Write64(_rdBase + GICR_PENDBASER, pendbaser);
+                        | (s_pendTablePhys & PENDBASER_ADDR_MASK);
+        Native.MMIO.Write64(s_rdBase + GICR_PENDBASER, pendbaser);
 
         // Enable LPIs (32-bit write).
         ctlr |= GICR_CTLR_ENABLE_LPIS;
-        Native.MMIO.Write32(_rdBase + GICR_CTLR, ctlr);
+        Native.MMIO.Write32(s_rdBase + GICR_CTLR, ctlr);
 
         // Wait for RWP to clear.
         for (int i = 0; i < RegisterSyncSpinLimit; i++)
         {
-            if ((Native.MMIO.Read32(_rdBase + GICR_CTLR) & GICR_CTLR_RWP) == 0)
+            if ((Native.MMIO.Read32(s_rdBase + GICR_CTLR) & GICR_CTLR_RWP) == 0)
             {
                 break;
             }
@@ -195,7 +195,7 @@ public static unsafe class GICv3Lpi
 
         Serial.WriteString("[GICv3-LPI] enabled, INTID range 8192..16383\n");
 
-        _initialized = true;
+        s_initialized = true;
     }
 
     /// <summary>
@@ -206,7 +206,7 @@ public static unsafe class GICv3Lpi
     /// </summary>
     public static void EnableLpi(uint lpi)
     {
-        if (!_initialized || lpi < GIC.LPI_START)
+        if (!s_initialized || lpi < GIC.LPI_START)
         {
             return;
         }
@@ -215,7 +215,7 @@ public static unsafe class GICv3Lpi
         {
             return;
         }
-        byte* cfg = (byte*)_propTableVirt;
+        byte* cfg = (byte*)s_propTableVirt;
         cfg[off] = (byte)(GicArch.DefaultPriority | LPI_CFG_ENABLE);
 
         // The redistributor reads the config table over the bus; the byte
@@ -224,10 +224,10 @@ public static unsafe class GICv3Lpi
         // ITS INV command emitted from MapEvent is what actually refreshes
         // the cached LPI configuration.
         DeviceMapperNative.DsbIsb();
-        Native.MMIO.Write64(_rdBase + GICR_INVLPIR, lpi);
+        Native.MMIO.Write64(s_rdBase + GICR_INVLPIR, lpi);
         for (int i = 0; i < RegisterSyncSpinLimit; i++)
         {
-            if (Native.MMIO.Read32(_rdBase + GICR_SYNCR) == 0)
+            if (Native.MMIO.Read32(s_rdBase + GICR_SYNCR) == 0)
             {
                 break;
             }
@@ -237,7 +237,7 @@ public static unsafe class GICv3Lpi
     /// <summary>Disable an LPI in the config table.</summary>
     public static void DisableLpi(uint lpi)
     {
-        if (!_initialized || lpi < GIC.LPI_START)
+        if (!s_initialized || lpi < GIC.LPI_START)
         {
             return;
         }
@@ -246,13 +246,13 @@ public static unsafe class GICv3Lpi
         {
             return;
         }
-        byte* cfg = (byte*)_propTableVirt;
+        byte* cfg = (byte*)s_propTableVirt;
         cfg[off] = (byte)(GicArch.DefaultPriority & ~LPI_CFG_ENABLE);
         DeviceMapperNative.DsbIsb();
-        Native.MMIO.Write64(_rdBase + GICR_INVLPIR, lpi);
+        Native.MMIO.Write64(s_rdBase + GICR_INVLPIR, lpi);
         for (int i = 0; i < RegisterSyncSpinLimit; i++)
         {
-            if (Native.MMIO.Read32(_rdBase + GICR_SYNCR) == 0)
+            if (Native.MMIO.Read32(s_rdBase + GICR_SYNCR) == 0)
             {
                 break;
             }

--- a/src/Cosmos.Kernel.Core.X64/Cpu/ApicManager.cs
+++ b/src/Cosmos.Kernel.Core.X64/Cpu/ApicManager.cs
@@ -9,12 +9,12 @@ namespace Cosmos.Kernel.Core.X64.Cpu;
 /// </summary>
 public static class ApicManager
 {
-    private static bool _initialized;
+    private static bool s_initialized;
 
     /// <summary>
     /// Gets whether the APIC system is initialized.
     /// </summary>
-    public static bool IsInitialized => _initialized;
+    public static bool IsInitialized => s_initialized;
 
     /// <summary>
     /// Initializes the APIC system using MADT information.
@@ -57,7 +57,7 @@ public static class ApicManager
             Serial.Write("[ApicManager] WARNING: No I/O APIC found in MADT!\n");
         }
 
-        _initialized = true;
+        s_initialized = true;
         Serial.Write("[ApicManager] APIC system initialized\n");
     }
 
@@ -70,7 +70,7 @@ public static class ApicManager
     /// <param name="startMasked">If true, the IRQ starts masked and must be explicitly unmasked.</param>
     public static unsafe void RouteIrq(byte irq, byte vector, bool startMasked = false)
     {
-        if (!_initialized)
+        if (!s_initialized)
         {
             Serial.Write("[ApicManager] ERROR: APIC not initialized!\n");
             return;

--- a/src/Cosmos.Kernel.Core.X64/Cpu/Idt.cs
+++ b/src/Cosmos.Kernel.Core.X64/Cpu/Idt.cs
@@ -14,7 +14,7 @@ public static unsafe class Idt
 {
     public static ulong GetCurrentCodeSelector() => IdtNative.GetCurrentCodeSelector();
 
-    private static IdtEntry[]? IdtEntries;
+    private static IdtEntry[]? s_idtEntries;
 
     /// <summary>
     /// Registers all IRQ stubs in the IDT.
@@ -26,13 +26,13 @@ public static unsafe class Idt
         Serial.Write("[IDT] Initializing with CS=0x", cs.ToString("X"), "\n");
 
         // Allocate IDT entries array if not already done
-        if (IdtEntries == null)
+        if (s_idtEntries == null)
         {
-            Serial.WriteString("[IDT] Allocating IdtEntries array...\n");
-            IdtEntries = new IdtEntry[256];
+            Serial.WriteString("[IDT] Allocating s_idtEntries array...\n");
+            s_idtEntries = new IdtEntry[256];
         }
-        Serial.WriteString("[IDT] IdtEntries length: ");
-        Serial.WriteNumber((ulong)IdtEntries.Length);
+        Serial.WriteString("[IDT] s_idtEntries length: ");
+        Serial.WriteNumber((ulong)s_idtEntries.Length);
         Serial.WriteString("\n");
 
         // Initialize all 256 IDT entries
@@ -44,13 +44,13 @@ public static unsafe class Idt
                 Serial.WriteNumber((ulong)i);
                 Serial.WriteString("\n");
             }
-            IdtEntries[i].Selector = (ushort)cs;
-            IdtEntries[i].RawFlags = 0x8E00;  // P=1, DPL=0, Type=Interrupt Gate
-            IdtEntries[i].Offset = (ulong)GetStub(i);
+            s_idtEntries[i].Selector = (ushort)cs;
+            s_idtEntries[i].RawFlags = 0x8E00;  // P=1, DPL=0, Type=Interrupt Gate
+            s_idtEntries[i].Offset = (ulong)GetStub(i);
         }
 
         // Load the IDT into the CPU
-        fixed (void* ptr = &IdtEntries[0])
+        fixed (void* ptr = &s_idtEntries[0])
         {
             IdtPointer idtPtr = new IdtPointer
             {

--- a/src/Cosmos.Kernel.Core.X64/Cpu/IoApic.cs
+++ b/src/Cosmos.Kernel.Core.X64/Cpu/IoApic.cs
@@ -28,15 +28,15 @@ public static class IoApic
     private const ulong ACTIVE_LOW = 1UL << 13;       // Active low (vs high)
     private const ulong LOGICAL_DEST = 1UL << 11;     // Logical (vs Physical) destination mode
 
-    private static ulong _baseAddress;
-    private static uint _gsiBase;
-    private static byte _maxRedirectionEntry;
-    private static bool _initialized;
+    private static ulong s_baseAddress;
+    private static uint s_gsiBase;
+    private static byte s_maxRedirectionEntry;
+    private static bool s_initialized;
 
     /// <summary>
     /// Gets whether the I/O APIC is initialized.
     /// </summary>
-    public static bool IsInitialized => _initialized;
+    public static bool IsInitialized => s_initialized;
 
     /// <summary>
     /// Initializes the I/O APIC with information from MADT.
@@ -44,8 +44,8 @@ public static class IoApic
     /// <param name="info">I/O APIC info from MADT.</param>
     public static void Initialize(IoApicInfo info)
     {
-        _baseAddress = info.Address;
-        _gsiBase = info.GsiBase;
+        s_baseAddress = info.Address;
+        s_gsiBase = info.GsiBase;
 
         Serial.Write("[IOAPIC] Initializing at 0x", info.Address.ToString("X"), "\n");
         Serial.Write("[IOAPIC] GSI base: ", info.GsiBase, "\n");
@@ -54,19 +54,19 @@ public static class IoApic
         uint id = Read(IOAPIC_ID);
         uint version = Read(IOAPIC_VER);
 
-        _maxRedirectionEntry = (byte)((version >> 16) & 0xFF);
+        s_maxRedirectionEntry = (byte)((version >> 16) & 0xFF);
 
         Serial.Write("[IOAPIC] ID: ", (id >> 24) & 0xF, "\n");
         Serial.Write("[IOAPIC] Version: ", version & 0xFF, "\n");
-        Serial.Write("[IOAPIC] Max redirection entries: ", _maxRedirectionEntry + 1, "\n");
+        Serial.Write("[IOAPIC] Max redirection entries: ", s_maxRedirectionEntry + 1, "\n");
 
         // Mask all interrupts initially
-        for (int i = 0; i <= _maxRedirectionEntry; i++)
+        for (int i = 0; i <= s_maxRedirectionEntry; i++)
         {
             SetRedirectionEntry((byte)i, 0, true);
         }
 
-        _initialized = true;
+        s_initialized = true;
         Serial.Write("[IOAPIC] Initialization complete\n");
     }
 
@@ -80,7 +80,7 @@ public static class IoApic
     /// <param name="startMasked">If true, the IRQ starts masked and must be explicitly unmasked.</param>
     public static void RouteIrq(byte irq, byte vector, byte targetApicId, IrqOverride? @override = null, bool startMasked = false)
     {
-        if (!_initialized)
+        if (!s_initialized)
         {
             return;
         }
@@ -96,8 +96,8 @@ public static class IoApic
             levelTriggered = @override.Value.IsLevelTriggered;
         }
 
-        uint redirIndex = gsi - _gsiBase;
-        if (redirIndex > _maxRedirectionEntry)
+        uint redirIndex = gsi - s_gsiBase;
+        if (redirIndex > s_maxRedirectionEntry)
         {
             return;
         }
@@ -168,13 +168,13 @@ public static class IoApic
     /// </summary>
     public static ulong GetRedirectionEntry(byte irq)
     {
-        if (!_initialized)
+        if (!s_initialized)
         {
             return 0;
         }
 
-        uint redirIndex = irq - _gsiBase;
-        if (redirIndex > _maxRedirectionEntry)
+        uint redirIndex = irq - s_gsiBase;
+        if (redirIndex > s_maxRedirectionEntry)
         {
             return 0;
         }
@@ -187,13 +187,13 @@ public static class IoApic
     /// </summary>
     public static void MaskIrq(byte irq)
     {
-        if (!_initialized)
+        if (!s_initialized)
         {
             return;
         }
 
-        uint redirIndex = irq - _gsiBase;
-        if (redirIndex > _maxRedirectionEntry)
+        uint redirIndex = irq - s_gsiBase;
+        if (redirIndex > s_maxRedirectionEntry)
         {
             return;
         }
@@ -208,13 +208,13 @@ public static class IoApic
     /// </summary>
     public static void UnmaskIrq(byte irq)
     {
-        if (!_initialized)
+        if (!s_initialized)
         {
             return;
         }
 
-        uint redirIndex = irq - _gsiBase;
-        if (redirIndex > _maxRedirectionEntry)
+        uint redirIndex = irq - s_gsiBase;
+        if (redirIndex > s_maxRedirectionEntry)
         {
             return;
         }
@@ -229,8 +229,8 @@ public static class IoApic
     /// </summary>
     private static uint Read(byte reg)
     {
-        Native.MMIO.Write32(_baseAddress + IOREGSEL, reg);
-        return Native.MMIO.Read32(_baseAddress + IOWIN);
+        Native.MMIO.Write32(s_baseAddress + IOREGSEL, reg);
+        return Native.MMIO.Read32(s_baseAddress + IOWIN);
     }
 
     /// <summary>
@@ -238,7 +238,7 @@ public static class IoApic
     /// </summary>
     private static void Write(byte reg, uint value)
     {
-        Native.MMIO.Write32(_baseAddress + IOREGSEL, reg);
-        Native.MMIO.Write32(_baseAddress + IOWIN, value);
+        Native.MMIO.Write32(s_baseAddress + IOREGSEL, reg);
+        Native.MMIO.Write32(s_baseAddress + IOWIN, value);
     }
 }

--- a/src/Cosmos.Kernel.Core.X64/Cpu/LocalApic.cs
+++ b/src/Cosmos.Kernel.Core.X64/Cpu/LocalApic.cs
@@ -82,22 +82,22 @@ public static class LocalApic
     /// <summary>Period, in ticks, of the recurring timer-tick log message.</summary>
     private const uint TimerLogPeriodTicks = 100;
 
-    private static ulong _baseAddress;
-    private static bool _initialized;
-    private static uint _ticksPerMs;
-    private static bool _timerCalibrated;
-    private static uint _timerIntervalMs;
-    private static ulong _timerIntervalNs;
+    private static ulong s_baseAddress;
+    private static bool s_initialized;
+    private static uint s_ticksPerMs;
+    private static bool s_timerCalibrated;
+    private static uint s_timerIntervalMs;
+    private static ulong s_timerIntervalNs;
 
     /// <summary>
     /// Gets the base address of the Local APIC.
     /// </summary>
-    public static ulong BaseAddress => _baseAddress;
+    public static ulong BaseAddress => s_baseAddress;
 
     /// <summary>
     /// Gets whether the Local APIC is initialized.
     /// </summary>
-    public static bool IsInitialized => _initialized;
+    public static bool IsInitialized => s_initialized;
 
     /// <summary>
     /// Initializes the Local APIC with the given base address from MADT.
@@ -105,7 +105,7 @@ public static class LocalApic
     /// <param name="baseAddress">The physical address of the Local APIC registers.</param>
     public static void Initialize(ulong baseAddress)
     {
-        _baseAddress = baseAddress;
+        s_baseAddress = baseAddress;
 
         Serial.Write("[LocalAPIC] Initializing at 0x", baseAddress.ToString("X"), "\n");
 
@@ -137,7 +137,7 @@ public static class LocalApic
         Write(LAPIC_TIMER_LVT, LVT_MASKED);  // Masked
         Write(LAPIC_ERROR_LVT, LVT_MASKED);  // Masked
 
-        _initialized = true;
+        s_initialized = true;
 
         // Register the x64 MSI binder for HAL-level PCI MSI-X code. Intel
         // SDM Vol 3 §10.11: address [31:20]=0xFEE, [19:12]=destination APIC
@@ -154,7 +154,7 @@ public static class LocalApic
     /// </summary>
     public static void SendEOI()
     {
-        if (_initialized)
+        if (s_initialized)
         {
             Write(LAPIC_EOI, 0);
         }
@@ -169,7 +169,7 @@ public static class LocalApic
     /// </summary>
     public static void SendSelfIpi(byte vector)
     {
-        if (_initialized)
+        if (s_initialized)
         {
             Write(LAPIC_ICR_LOW, vector | ICR_DEST_SHORTHAND_SELF);
         }
@@ -210,7 +210,7 @@ public static class LocalApic
     /// </summary>
     private static uint Read(uint offset)
     {
-        return Native.MMIO.Read32(_baseAddress + offset);
+        return Native.MMIO.Read32(s_baseAddress + offset);
     }
 
     /// <summary>
@@ -218,23 +218,23 @@ public static class LocalApic
     /// </summary>
     private static void Write(uint offset, uint value)
     {
-        Native.MMIO.Write32(_baseAddress + offset, value);
+        Native.MMIO.Write32(s_baseAddress + offset, value);
     }
 
     /// <summary>
     /// Gets whether the LAPIC timer has been calibrated.
     /// </summary>
-    public static bool IsTimerCalibrated => _timerCalibrated;
+    public static bool IsTimerCalibrated => s_timerCalibrated;
 
     /// <summary>
     /// Gets the calibrated ticks per millisecond.
     /// </summary>
-    public static uint TicksPerMs => _ticksPerMs;
+    public static uint TicksPerMs => s_ticksPerMs;
 
     /// <summary>
     /// Gets the current timer interval in nanoseconds.
     /// </summary>
-    public static ulong TimerIntervalNs => _timerIntervalNs;
+    public static ulong TimerIntervalNs => s_timerIntervalNs;
 
     /// <summary>
     /// Calibrates the LAPIC timer using the PIT as a reference.
@@ -242,7 +242,7 @@ public static class LocalApic
     /// </summary>
     public static void CalibrateTimer()
     {
-        if (!_initialized)
+        if (!s_initialized)
         {
             Serial.Write("[LocalAPIC] ERROR: Cannot calibrate timer - APIC not initialized\n");
             return;
@@ -294,10 +294,10 @@ public static class LocalApic
 
         // Calculate ticks per ms (we waited ~10ms)
         // Account for divide by 16
-        _ticksPerMs = lapicTicksElapsed / CalibrationDurationMs;
+        s_ticksPerMs = lapicTicksElapsed / CalibrationDurationMs;
 
-        _timerCalibrated = true;
-        Serial.Write("[LocalAPIC] Timer calibrated: ", _ticksPerMs, " ticks/ms\n");
+        s_timerCalibrated = true;
+        Serial.Write("[LocalAPIC] Timer calibrated: ", s_ticksPerMs, " ticks/ms\n");
     }
 
     /// <summary>
@@ -306,7 +306,7 @@ public static class LocalApic
     /// <param name="ms">Number of milliseconds to wait.</param>
     public static void Wait(uint ms)
     {
-        if (!_timerCalibrated)
+        if (!s_timerCalibrated)
         {
             Serial.Write("[LocalAPIC] ERROR: Timer not calibrated\n");
             return;
@@ -321,7 +321,7 @@ public static class LocalApic
         Write(LAPIC_TIMER_DIVIDE, TIMER_DIVIDE_BY_16);
 
         // Calculate ticks needed
-        uint ticks = _ticksPerMs * ms;
+        uint ticks = s_ticksPerMs * ms;
 
         // Set up one-shot timer (masked - we poll instead of interrupt)
         Write(LAPIC_TIMER_LVT, LVT_MASKED);
@@ -336,10 +336,10 @@ public static class LocalApic
         // Re-arm the periodic scheduler tick this wait hijacked: the LVT was
         // masked and switched to one-shot above, and without this the
         // scheduler tick stays dead after the first Wait call.
-        if (_timerIntervalMs != 0)
+        if (s_timerIntervalMs != 0)
         {
             Write(LAPIC_TIMER_LVT, TIMER_PERIODIC | TIMER_VECTOR);
-            Write(LAPIC_TIMER_INIT, _ticksPerMs * _timerIntervalMs);
+            Write(LAPIC_TIMER_INIT, s_ticksPerMs * s_timerIntervalMs);
         }
     }
 
@@ -350,18 +350,18 @@ public static class LocalApic
     /// <param name="intervalMs">Interval in milliseconds between interrupts.</param>
     public static void StartPeriodicTimer(uint intervalMs)
     {
-        if (!_timerCalibrated)
+        if (!s_timerCalibrated)
         {
             Serial.Write("[LocalAPIC] ERROR: Timer not calibrated\n");
             return;
         }
 
-        uint ticks = _ticksPerMs * intervalMs;
-        _timerIntervalMs = intervalMs;
-        _timerIntervalNs = (ulong)intervalMs * SchedulerManager.NanosecondsPerMillisecond;  // Convert ms to ns
+        uint ticks = s_ticksPerMs * intervalMs;
+        s_timerIntervalMs = intervalMs;
+        s_timerIntervalNs = (ulong)intervalMs * SchedulerManager.NanosecondsPerMillisecond;  // Convert ms to ns
 
         Serial.Write("[LocalAPIC] Starting periodic timer:\n");
-        Serial.Write("[LocalAPIC]   TicksPerMs: ", _ticksPerMs, "\n");
+        Serial.Write("[LocalAPIC]   TicksPerMs: ", s_ticksPerMs, "\n");
         Serial.Write("[LocalAPIC]   Interval: ", intervalMs, "ms\n");
         Serial.Write("[LocalAPIC]   Ticks: ", ticks, "\n");
         Serial.Write("[LocalAPIC]   Vector: 0x", TIMER_VECTOR.ToString("X"), "\n");
@@ -399,10 +399,10 @@ public static class LocalApic
     /// <summary>
     /// LAPIC timer interrupt handler - triggers scheduler for preemptive multitasking.
     /// </summary>
-    private static uint _timerTickCount;
+    private static uint s_timerTickCount;
     private static unsafe void HandleTimerInterrupt(ref IRQContext context)
     {
-        _timerTickCount++;
+        s_timerTickCount++;
 
         // Get current CPU ID from APIC
         uint cpuId = (uint)GetId();
@@ -414,22 +414,22 @@ public static class LocalApic
         // Sanity check RSP - should be in kernel space (0xFFFF800000000000+)
         if ((currentRsp & AddressSpace.KernelSpaceCanonicalMask) != AddressSpace.KernelSpaceCanonicalMask)
         {
-            Serial.Write("[LAPIC] ERROR: Invalid RSP at tick ", _timerTickCount, ": ");
+            Serial.Write("[LAPIC] ERROR: Invalid RSP at tick ", s_timerTickCount, ": ");
             Serial.WriteHex((ulong)currentRsp);
             Serial.Write("\n");
             return;  // Don't call scheduler with bad RSP
         }
 
         // Log first few and then periodically
-        if (_timerTickCount <= TimerLogInitialTicks || _timerTickCount % TimerLogPeriodTicks == 0)
+        if (s_timerTickCount <= TimerLogInitialTicks || s_timerTickCount % TimerLogPeriodTicks == 0)
         {
-            Serial.Write("[LAPIC] Timer tick ", _timerTickCount, " RSP=");
+            Serial.Write("[LAPIC] Timer tick ", s_timerTickCount, " RSP=");
             Serial.WriteHex((ulong)currentRsp);
             Serial.Write("\n");
         }
 
         // Call scheduler with elapsed time
-        SchedulerManager.OnTimerInterrupt(cpuId, currentRsp, _timerIntervalNs);
+        SchedulerManager.OnTimerInterrupt(cpuId, currentRsp, s_timerIntervalNs);
 
         // EOI is sent by InterruptManager.Dispatch after handler returns
     }

--- a/src/Cosmos.Kernel.Core/Bridge/Interop/libSystemNative.cs
+++ b/src/Cosmos.Kernel.Core/Bridge/Interop/libSystemNative.cs
@@ -9,9 +9,9 @@ internal static class libSystemNative
     [StructLayout(LayoutKind.Sequential)]
     internal struct ProcessCpuInformation
     {
-        internal ulong lastRecordedCurrentTime;
-        internal ulong lastRecordedKernelTime;
-        internal ulong lastRecordedUserTime;
+        internal ulong _lastRecordedCurrentTime;
+        internal ulong _lastRecordedKernelTime;
+        internal ulong _lastRecordedUserTime;
     }
 
     [UnmanagedCallersOnly(EntryPoint = "SystemNative_GetCpuUtilization")]
@@ -25,15 +25,15 @@ internal static class libSystemNative
         ulong currentTime = GetMonotonicNs();
         ulong busyTime = SchedulerManager.GetBusyCpuTimeNs();
 
-        ulong lastTime = previousCpuInfo->lastRecordedCurrentTime;
-        ulong lastBusy = previousCpuInfo->lastRecordedUserTime;
+        ulong lastTime = previousCpuInfo->_lastRecordedCurrentTime;
+        ulong lastBusy = previousCpuInfo->_lastRecordedUserTime;
 
         // First call: seed snapshot only.
         if (lastTime == 0)
         {
-            previousCpuInfo->lastRecordedCurrentTime = currentTime;
-            previousCpuInfo->lastRecordedUserTime = busyTime;
-            previousCpuInfo->lastRecordedKernelTime = 0;
+            previousCpuInfo->_lastRecordedCurrentTime = currentTime;
+            previousCpuInfo->_lastRecordedUserTime = busyTime;
+            previousCpuInfo->_lastRecordedKernelTime = 0;
             return 0.0;
         }
 
@@ -59,9 +59,9 @@ internal static class libSystemNative
             }
         }
 
-        previousCpuInfo->lastRecordedCurrentTime = currentTime;
-        previousCpuInfo->lastRecordedUserTime = busyTime;
-        previousCpuInfo->lastRecordedKernelTime = 0;
+        previousCpuInfo->_lastRecordedCurrentTime = currentTime;
+        previousCpuInfo->_lastRecordedUserTime = busyTime;
+        previousCpuInfo->_lastRecordedKernelTime = 0;
         return utilization;
     }
 

--- a/src/Cosmos.Kernel.Core/IO/EarlyGop.cs
+++ b/src/Cosmos.Kernel.Core/IO/EarlyGop.cs
@@ -11,9 +11,9 @@ namespace Cosmos.Kernel.Core.IO;
 /// </summary>
 public static unsafe class EarlyGop
 {
-    private static int _col;
-    private static int _row;
-    private static bool _initialized;
+    private static int s_col;
+    private static int s_row;
+    private static bool s_initialized;
 
     /// <summary>Set to false to stop mirroring serial output to the screen.</summary>
     public static bool Enabled = true;
@@ -25,10 +25,10 @@ public static unsafe class EarlyGop
     // The inscribed rectangle of a circle with d=320 is ~226px,
     // so we inset by ~48px on each side to stay inside the visible area.
     // For rectangular screens these are effectively 0 (auto-computed in Initialize).
-    private static int _marginX;
-    private static int _marginY;
-    private static int _usableCols;
-    private static int _usableRows;
+    private static int s_marginX;
+    private static int s_marginY;
+    private static int s_usableCols;
+    private static int s_usableRows;
 
     // Hardcoded 8x8 bitmap font for printable ASCII 0x20 (' ') through 0x7E ('~').
     // Each character occupies 8 bytes (one per pixel row), bit 7 = leftmost pixel.
@@ -233,9 +233,9 @@ public static unsafe class EarlyGop
     /// </summary>
     public static void Initialize()
     {
-        _col = 0;
-        _row = 0;
-        _initialized = false;
+        s_col = 0;
+        s_row = 0;
+        s_initialized = false;
 
         if (Limine.Framebuffer.Response == null ||
             Limine.Framebuffer.Response->FramebufferCount == 0)
@@ -259,29 +259,29 @@ public static unsafe class EarlyGop
         {
             // Use ~70% of each axis → 15% margin on each side (in pixels).
             int marginPx = (int)(fb->Width * 15 / 100);
-            _marginX = (marginPx + CharW - 1) / CharW; // in character cells
-            _marginY = (marginPx + CharH - 1) / CharH;
+            s_marginX = (marginPx + CharW - 1) / CharW; // in character cells
+            s_marginY = (marginPx + CharH - 1) / CharH;
         }
         else
         {
-            _marginX = 0;
-            _marginY = 0;
+            s_marginX = 0;
+            s_marginY = 0;
         }
 
-        _usableCols = totalCols - 2 * _marginX;
-        _usableRows = totalRows - 2 * _marginY;
+        s_usableCols = totalCols - 2 * s_marginX;
+        s_usableRows = totalRows - 2 * s_marginY;
 
-        if (_usableCols < 1)
+        if (s_usableCols < 1)
         {
-            _usableCols = 1;
+            s_usableCols = 1;
         }
 
-        if (_usableRows < 1)
+        if (s_usableRows < 1)
         {
-            _usableRows = 1;
+            s_usableRows = 1;
         }
 
-        _initialized = true;
+        s_initialized = true;
     }
 
     /// <summary>
@@ -295,12 +295,12 @@ public static unsafe class EarlyGop
             return;
         }
 
-        if (!_initialized)
+        if (!s_initialized)
         {
             Initialize();
         }
 
-        if (!_initialized)
+        if (!s_initialized)
         {
             return;
         }
@@ -310,16 +310,16 @@ public static unsafe class EarlyGop
         switch (c)
         {
             case '\n':
-                _col = 0;
-                _row++;
-                if (_row >= _usableRows)
+                s_col = 0;
+                s_row++;
+                if (s_row >= s_usableRows)
                 {
                     ClearUsableRegion(fb);
-                    _row = 0;
+                    s_row = 0;
                 }
                 break;
             case '\r':
-                _col = 0;
+                s_col = 0;
                 break;
             default:
                 if (c < 0x20 || c > 0x7E)
@@ -327,16 +327,16 @@ public static unsafe class EarlyGop
                     c = '?';
                 }
 
-                DrawGlyph(fb, c, _col + _marginX, _row + _marginY);
-                _col++;
-                if (_col >= _usableCols)
+                DrawGlyph(fb, c, s_col + s_marginX, s_row + s_marginY);
+                s_col++;
+                if (s_col >= s_usableCols)
                 {
-                    _col = 0;
-                    _row++;
-                    if (_row >= _usableRows)
+                    s_col = 0;
+                    s_row++;
+                    if (s_row >= s_usableRows)
                     {
                         ClearUsableRegion(fb);
-                        _row = 0;
+                        s_row = 0;
                     }
                 }
                 break;
@@ -375,8 +375,8 @@ public static unsafe class EarlyGop
         ulong pitch = fb->Pitch;
         byte* addr = (byte*)fb->Address;
 
-        ulong topPx = (ulong)(_marginY * CharH);
-        ulong usableHeightPx = (ulong)(_usableRows * CharH);
+        ulong topPx = (ulong)(s_marginY * CharH);
+        ulong usableHeightPx = (ulong)(s_usableRows * CharH);
 
         ulong* clear = (ulong*)(addr + pitch * topPx);
         ulong count = pitch * usableHeightPx / 8;

--- a/src/Cosmos.Kernel.Core/Memory/PageAllocator.cs
+++ b/src/Cosmos.Kernel.Core/Memory/PageAllocator.cs
@@ -54,17 +54,17 @@ public static unsafe class PageAllocator
     /// stored at the end of RAM
     /// </remarks>
     // We need a pointer as the RAT can move around in future with dynamic RAM etc.
-    private static byte* mRAT;
+    private static byte* s_mRAT;
 
     /// <summary>
     /// Virtual address of the RAT base (one byte per page).
     /// </summary>
-    public static ulong RatAddress => (ulong)mRAT;
+    public static ulong RatAddress => (ulong)s_mRAT;
 
     /// <summary>
     /// Pointer to end of the heap
     /// </summary>
-    private static byte* HeapEnd;
+    private static byte* s_heapEnd;
 
     /// <summary>
     /// Size of heap.
@@ -419,31 +419,31 @@ public static unsafe class PageAllocator
         Serial.WriteString(" KB\n");
 
         // IMPORTANT: Following Cosmos OS structure, place RAT at the END of usable memory
-        // Heap: [RamStart ... HeapEnd] [RAT]
-        mRAT = usableStart + usableSize - xRatTotalSize;
+        // Heap: [RamStart ... s_heapEnd] [RAT]
+        s_mRAT = usableStart + usableSize - xRatTotalSize;
         RamStart = usableStart;
         RamSize = usableSize - xRatTotalSize;
-        HeapEnd = mRAT;  // Heap ends where RAT begins
+        s_heapEnd = s_mRAT;  // Heap ends where RAT begins
 
         Serial.WriteString("[PageAllocator] Memory layout (Cosmos-style):\n");
         Serial.WriteString("  RamStart (heap): 0x");
         Serial.WriteHex((ulong)RamStart);
-        Serial.WriteString("\n  HeapEnd: 0x");
-        Serial.WriteHex((ulong)HeapEnd);
+        Serial.WriteString("\n  s_heapEnd: 0x");
+        Serial.WriteHex((ulong)s_heapEnd);
         Serial.WriteString("\n  RAT location: 0x");
-        Serial.WriteHex((ulong)mRAT);
+        Serial.WriteHex((ulong)s_mRAT);
         Serial.WriteString("\n  RAT end: 0x");
-        Serial.WriteHex((ulong)(mRAT + xRatTotalSize));
+        Serial.WriteHex((ulong)(s_mRAT + xRatTotalSize));
         Serial.WriteString("\n  Heap size: ");
         Serial.WriteNumber(RamSize / BytesPerKilobyte / BytesPerKilobyte);
         Serial.WriteString(" MB\n");
 
         // Sanity checks
-        if (mRAT < RamStart)
+        if (s_mRAT < RamStart)
         {
             throw new Exception("RAT is before heap start - invalid memory layout!");
         }
-        if ((ulong)mRAT % PageSize != 0)
+        if ((ulong)s_mRAT % PageSize != 0)
         {
             throw new Exception("RAT is not page-aligned!");
         }
@@ -455,14 +455,14 @@ public static unsafe class PageAllocator
 
         // Test first write before loop
         Serial.WriteString("[PageAllocator] Testing first RAT write at 0x");
-        Serial.WriteHex((ulong)mRAT);
+        Serial.WriteHex((ulong)s_mRAT);
         Serial.WriteString("...\n");
-        mRAT[0] = (byte)PageType.Empty;
+        s_mRAT[0] = (byte)PageType.Empty;
         Serial.WriteString("[PageAllocator] First write successful, initializing all entries...\n");
 
         for (ulong i = 0; i < TotalPageCount; i++)
         {
-            mRAT[i] = (byte)PageType.Empty;
+            s_mRAT[i] = (byte)PageType.Empty;
 
             // Progress indicator every 10000 pages to confirm loop is progressing
             if (i > 0 && i % RatInitProgressInterval == 0)
@@ -488,7 +488,7 @@ public static unsafe class PageAllocator
 
         for (ulong i = ratStartPage; i < TotalPageCount; i++)
         {
-            mRAT[i] = (byte)PageType.PageAllocator;
+            s_mRAT[i] = (byte)PageType.PageAllocator;
         }
 
         // Free page count is total minus RAT pages
@@ -505,14 +505,14 @@ public static unsafe class PageAllocator
 
         // Test RAT is writable
         Serial.WriteString("[PageAllocator] Testing RAT write access...\n");
-        byte testValue = mRAT[0];
-        mRAT[0] = RatWriteTestValue;
-        if (mRAT[0] != RatWriteTestValue)
+        byte testValue = s_mRAT[0];
+        s_mRAT[0] = RatWriteTestValue;
+        if (s_mRAT[0] != RatWriteTestValue)
         {
             Serial.WriteString("[PageAllocator] ERROR: RAT is not writable!\n");
             throw new Exception("RAT memory is not writable!");
         }
-        mRAT[0] = testValue; // Restore
+        s_mRAT[0] = testValue; // Restore
         Serial.WriteString("[PageAllocator] RAT write test passed\n");
 
         // Initialize small heap
@@ -545,7 +545,7 @@ public static unsafe class PageAllocator
         uint xCount = 0;
         if (aPageCount == 1)
         {
-            for (byte* ptr = mRAT; ptr < mRAT + TotalPageCount; ptr++)
+            for (byte* ptr = s_mRAT; ptr < s_mRAT + TotalPageCount; ptr++)
             {
                 if ((PageType)(*ptr) == PageType.Empty)
                 {
@@ -556,9 +556,9 @@ public static unsafe class PageAllocator
         }
         else
         {
-            // This loop will FAIL if mRAT is ever 0. This should be impossible though
+            // This loop will FAIL if s_mRAT is ever 0. This should be impossible though
             // so we don't bother to account for such a case. xPos would also have issues.
-            for (byte* ptr = mRAT + TotalPageCount - 1; ptr >= mRAT; ptr--)
+            for (byte* ptr = s_mRAT + TotalPageCount - 1; ptr >= s_mRAT; ptr--)
             {
                 if (*ptr == (byte)PageType.Empty)
                 {
@@ -578,7 +578,7 @@ public static unsafe class PageAllocator
         // If we found enough space, mark it as used.
         if (startPage != null)
         {
-            long offset = startPage - mRAT;
+            long offset = startPage - s_mRAT;
             byte* pageAddress = RamStart + (ulong)offset * PageSize;
 
             if ((ulong)offset >= TotalPageCount)
@@ -586,11 +586,11 @@ public static unsafe class PageAllocator
                 return null;
             }
 
-            mRAT[offset] = (byte)aType;
+            s_mRAT[offset] = (byte)aType;
 
             for (ulong i = 1; i < aPageCount; i++)
             {
-                mRAT[(ulong)offset + i] = (byte)PageType.Extension;
+                s_mRAT[(ulong)offset + i] = (byte)PageType.Extension;
             }
 
             if (zero)
@@ -620,12 +620,12 @@ public static unsafe class PageAllocator
     public static uint GetFirstPageAllocatorIndex(void* aPtr)
     {
         ulong xPos = (ulong)((byte*)aPtr - RamStart) / PageSize;
-        // See note about when mRAT = 0 in Alloc.
-        for (byte* p = mRAT + xPos; p >= mRAT; p--)
+        // See note about when s_mRAT = 0 in Alloc.
+        for (byte* p = s_mRAT + xPos; p >= s_mRAT; p--)
         {
             if (*p != (byte)PageType.Extension)
             {
-                return (uint)(p - mRAT);
+                return (uint)(p - s_mRAT);
             }
         }
 
@@ -647,12 +647,12 @@ public static unsafe class PageAllocator
     /// <exception cref="Exception">Thrown if page type is not found.</exception>
     public static PageType GetPageType(void* aPtr)
     {
-        if (aPtr < RamStart || aPtr > HeapEnd)
+        if (aPtr < RamStart || aPtr > s_heapEnd)
         {
             return PageType.Empty;
         }
 
-        return (PageType)mRAT[GetFirstPageAllocatorIndex(aPtr)];
+        return (PageType)s_mRAT[GetFirstPageAllocatorIndex(aPtr)];
     }
 
     /// <summary>
@@ -661,10 +661,10 @@ public static unsafe class PageAllocator
     /// <param name="aPageIdx">A index to the page to be freed.</param>
     public static void Free(uint aPageIdx)
     {
-        byte* p = mRAT + aPageIdx;
+        byte* p = s_mRAT + aPageIdx;
         *p = (byte)PageType.Empty;
         FreePageCount++;
-        for (; p < mRAT + TotalPageCount;)
+        for (; p < s_mRAT + TotalPageCount;)
         {
             if (*++p != (byte)PageType.Extension)
             {
@@ -702,14 +702,14 @@ public static unsafe class PageAllocator
         empty = gcHeap = heapSmall = heapMedium = heapLarge = unmanaged =
             pageDirectory = pageAllocator = smt = extension = unknown = 0;
 
-        if (mRAT == null || TotalPageCount == 0)
+        if (s_mRAT == null || TotalPageCount == 0)
         {
             return;
         }
 
         for (ulong i = 0; i < TotalPageCount; i++)
         {
-            byte b = mRAT[i];
+            byte b = s_mRAT[i];
             switch ((PageType)b)
             {
                 case PageType.Empty: empty++; break;

--- a/src/Cosmos.Kernel.Core/Runtime/Cpu.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Cpu.cs
@@ -7,12 +7,12 @@ public static class Cpu
     /// <summary>
     /// replace this with some thing better
     /// </summary>
-    private static long TickCount64 = 0;
+    private static long s_tickCount64 = 0;
 
     [RuntimeExport("RhpGetTickCount64")]
     public static unsafe long RhpGetTickCount64()
     {
-        return TickCount64++;
+        return s_tickCount64++;
     }
 
 }

--- a/src/Cosmos.Kernel.Core/Runtime/Thread.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Thread.cs
@@ -10,7 +10,7 @@ namespace Cosmos.Kernel.Core.Runtime;
 public class Thread
 {
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
-    private static object[][] threadData;
+    private static object[][] s_threadData;
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
     [RuntimeExport("RhGetThreadStaticStorage")]
     internal static ref object[][] RhGetThreadStaticStorage()
@@ -22,7 +22,7 @@ public class Thread
         }
         else
         {
-            return ref threadData;
+            return ref s_threadData;
         }
     }
 

--- a/src/Cosmos.Kernel.Core/Scheduler/PerCpuState.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/PerCpuState.cs
@@ -19,7 +19,7 @@ public class PerCpuState : SchedulerExtensible
     // InterruptEvent.Signal); consumed by ReschedulePendingFromIrq on
     // hardware-IRQ exit so the woken thread runs immediately instead of
     // sitting in the run queue until the next timer tick.
-    internal bool NeedReschedule;
+    internal bool _needReschedule;
 
     // ===== Synchronization =====
     public SpinLock Lock;

--- a/src/Cosmos.Kernel.Core/Scheduler/SchedulerManager.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/SchedulerManager.cs
@@ -16,23 +16,23 @@ namespace Cosmos.Kernel.Core.Scheduler;
 public static class SchedulerManager
 {
 
-    private static IScheduler? _currentScheduler;
-    private static PerCpuState[]? _cpuStates;
-    private static uint _cpuCount;
-    private static SpinLock _globalLock;
-    private static bool _enabled;
-    private static uint _nextThreadId;
+    private static IScheduler? s_currentScheduler;
+    private static PerCpuState[]? s_cpuStates;
+    private static uint s_cpuCount;
+    private static SpinLock s_globalLock;
+    private static bool s_enabled;
+    private static uint s_nextThreadId;
 
     // Global thread registry: tracks ALL live threads across all states
     // (Running, Ready, Blocked, Sleeping). Used by GC to scan all thread stacks.
     // Allocated once at init to avoid heap allocations during GC.
-    private static Thread?[]? _allThreads;
-    private static int _allThreadCount;
+    private static Thread?[]? s_allThreads;
+    private static int s_allThreadCount;
 
     // Cumulative TotalRuntime of exited non-idle threads. Live-thread runtime
-    // disappears from _allThreads on UnregisterThread, so we move it here to
+    // disappears from s_allThreads on UnregisterThread, so we move it here to
     // keep GetBusyCpuTimeNs monotonic across thread lifecycle.
-    private static ulong _exitedNonIdleRuntimeNs;
+    private static ulong s_exitedNonIdleRuntimeNs;
 
     /// <summary>
     /// Default time slice in nanoseconds (10ms).
@@ -67,7 +67,7 @@ public static class SchedulerManager
     /// is exactly one execution context, so callers fall back to
     /// spin/polled paths instead of blocking.
     /// </summary>
-    public static bool IsReady => IsEnabled && _cpuStates != null;
+    public static bool IsReady => IsEnabled && s_cpuStates != null;
 
     private static void ThrowIfDisabled()
     {
@@ -83,17 +83,17 @@ public static class SchedulerManager
     {
         ThrowIfDisabled();
 
-        _cpuCount = cpuCount;
-        _cpuStates = new PerCpuState[cpuCount];
+        s_cpuCount = cpuCount;
+        s_cpuStates = new PerCpuState[cpuCount];
 
         for (uint i = 0; i < cpuCount; i++)
         {
-            _cpuStates[i] = new PerCpuState { CpuId = i };
+            s_cpuStates[i] = new PerCpuState { CpuId = i };
         }
 
         // Pre-allocate thread registry
-        _allThreads = new Thread?[Thread.MaxThreadCount];
-        _allThreadCount = 0;
+        s_allThreads = new Thread?[Thread.MaxThreadCount];
+        s_allThreadCount = 0;
 
         Cosmos.Kernel.Core.Runtime.DebugLiveSnapshot.Initialize();
         Cosmos.Kernel.Core.Runtime.DebugLiveGCSnapshot.Initialize();
@@ -104,36 +104,36 @@ public static class SchedulerManager
     {
         ThrowIfCpuStateNotInitialized();
 
-        _globalLock.Acquire();
+        s_globalLock.Acquire();
         try
         {
-            if (_currentScheduler != null)
+            if (s_currentScheduler != null)
             {
-                for (uint i = 0; i < _cpuCount; i++)
+                for (uint i = 0; i < s_cpuCount; i++)
                 {
-                    _currentScheduler.ShutdownCpu(_cpuStates[i]);
+                    s_currentScheduler.ShutdownCpu(s_cpuStates[i]);
                 }
             }
 
-            _currentScheduler = scheduler;
+            s_currentScheduler = scheduler;
 
-            for (uint i = 0; i < _cpuCount; i++)
+            for (uint i = 0; i < s_cpuCount; i++)
             {
-                scheduler.InitializeCpu(_cpuStates[i]);
+                scheduler.InitializeCpu(s_cpuStates[i]);
             }
         }
         finally
         {
-            _globalLock.Release();
+            s_globalLock.Release();
         }
     }
 
     // ========== Accessors ==========
 
-    public static IScheduler? Current => _currentScheduler;
-    public static uint CpuCount => _cpuCount;
-    public static PerCpuState? GetCpuState(uint cpuId) => _cpuStates?[cpuId];
-    public static PerCpuState[]? GetAllCpuStates() => _cpuStates;
+    public static IScheduler? Current => s_currentScheduler;
+    public static uint CpuCount => s_cpuCount;
+    public static PerCpuState? GetCpuState(uint cpuId) => s_cpuStates?[cpuId];
+    public static PerCpuState[]? GetAllCpuStates() => s_cpuStates;
 
     /// <summary>
     /// Sets up the idle thread for a CPU. Should only be called during initialization.
@@ -142,7 +142,7 @@ public static class SchedulerManager
     {
         ThrowIfCpuStateNotInitialized();
 
-        var state = _cpuStates[cpuId];
+        var state = s_cpuStates[cpuId];
         state.IdleThread = idleThread;
         state.CurrentThread = idleThread;
         RegisterThread(idleThread);
@@ -153,14 +153,14 @@ public static class SchedulerManager
     /// </summary>
     public static bool Enabled
     {
-        get => _enabled;
-        set => _enabled = value;
+        get => s_enabled;
+        set => s_enabled = value;
     }
 
     /// <summary>
     /// Allocates a new unique thread ID.
     /// </summary>
-    public static uint AllocateThreadId() => _nextThreadId++;
+    public static uint AllocateThreadId() => s_nextThreadId++;
 
     // ========== Thread Entry Dispatch ==========
     [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "StartThread")]
@@ -264,12 +264,12 @@ public static class SchedulerManager
     /// <summary>
     /// Returns the thread registry array. Safe to call from GC (no allocations).
     /// </summary>
-    public static Thread?[]? Threads => _allThreads;
+    public static Thread?[]? Threads => s_allThreads;
 
     /// <summary>
     /// Returns the number of registered threads. Safe to call from GC.
     /// </summary>
-    public static int ThreadCount => _allThreadCount;
+    public static int ThreadCount => s_allThreadCount;
 
     /// <summary>
     /// Returns the CPU ID currently executing this code path. Single-CPU today.
@@ -287,13 +287,13 @@ public static class SchedulerManager
     /// </summary>
     public static ulong GetBusyCpuTimeNs()
     {
-        Thread?[]? threads = _allThreads;
+        Thread?[]? threads = s_allThreads;
         if (threads == null)
         {
             return 0;
         }
 
-        ulong sum = _exitedNonIdleRuntimeNs;
+        ulong sum = s_exitedNonIdleRuntimeNs;
         for (int i = 0; i < threads.Length; i++)
         {
             Thread? t = threads[i];
@@ -327,27 +327,27 @@ public static class SchedulerManager
     /// </summary>
     public static void RegisterThread(Thread thread)
     {
-        if (_allThreads == null)
+        if (s_allThreads == null)
         {
             return;
         }
 
         // Idempotent: idle-thread setup goes through both CreateThread and
         // SetupIdleThread, both of which call here. Avoid duplicate slots.
-        for (int i = 0; i < _allThreads.Length; i++)
+        for (int i = 0; i < s_allThreads.Length; i++)
         {
-            if (_allThreads[i] == thread)
+            if (s_allThreads[i] == thread)
             {
                 return;
             }
         }
 
-        for (int i = 0; i < _allThreads.Length; i++)
+        for (int i = 0; i < s_allThreads.Length; i++)
         {
-            if (_allThreads[i] == null)
+            if (s_allThreads[i] == null)
             {
-                _allThreads[i] = thread;
-                _allThreadCount++;
+                s_allThreads[i] = thread;
+                s_allThreadCount++;
                 return;
             }
         }
@@ -362,41 +362,41 @@ public static class SchedulerManager
     /// </summary>
     public static void UnregisterThread(Thread thread)
     {
-        if (_allThreads == null)
+        if (s_allThreads == null)
         {
             return;
         }
 
-        for (int i = 0; i < _allThreads.Length; i++)
+        for (int i = 0; i < s_allThreads.Length; i++)
         {
-            if (_allThreads[i] == thread)
+            if (s_allThreads[i] == thread)
             {
                 if ((thread.Flags & ThreadFlags.IdleThread) == 0)
                 {
-                    _exitedNonIdleRuntimeNs += thread.TotalRuntime;
+                    s_exitedNonIdleRuntimeNs += thread.TotalRuntime;
                 }
-                _allThreads[i] = null;
-                _allThreadCount--;
+                s_allThreads[i] = null;
+                s_allThreadCount--;
                 return;
             }
         }
     }
 
-    [MemberNotNull(nameof(_cpuStates))]
+    [MemberNotNull(nameof(s_cpuStates))]
     private static void ThrowIfCpuStateNotInitialized()
     {
-        if (_cpuStates is null)
+        if (s_cpuStates is null)
         {
             throw new Exception($"{nameof(SchedulerManager)} not initialized");
         }
     }
 
-    [MemberNotNull(nameof(_currentScheduler))]
+    [MemberNotNull(nameof(s_currentScheduler))]
     private static void ThrowIfSchedulerNotSet()
     {
-        if (_currentScheduler is null)
+        if (s_currentScheduler is null)
         {
-            throw new Exception($"{nameof(SchedulerManager)}{nameof(_currentScheduler)} not initialized");
+            throw new Exception($"{nameof(SchedulerManager)}{nameof(s_currentScheduler)} not initialized");
         }
     }
 
@@ -413,8 +413,8 @@ public static class SchedulerManager
         RegisterThread(thread);
         using (CPU.InternalCpu.DisableInterruptsScope())
         {
-            var state = _cpuStates[cpuId];
-            _currentScheduler.OnThreadCreate(state, thread);
+            var state = s_cpuStates[cpuId];
+            s_currentScheduler.OnThreadCreate(state, thread);
         }
         Serial.WriteString("[SCHED] CreateThread: done\n");
     }
@@ -427,7 +427,7 @@ public static class SchedulerManager
 
         using (CPU.InternalCpu.DisableInterruptsScope())
         {
-            var state = _cpuStates[cpuId];
+            var state = s_cpuStates[cpuId];
 
             // Only set to Ready if not a new thread (Created).
             // New threads stay Created until they actually start running.
@@ -437,12 +437,12 @@ public static class SchedulerManager
                 thread.State = ThreadState.Ready;
             }
 
-            _currentScheduler.OnThreadReady(state, thread);
+            s_currentScheduler.OnThreadReady(state, thread);
 
             // Ask the next hardware-IRQ exit to reschedule: when this wake
             // comes from an ISR (InterruptEvent.Signal), the woken thread
             // would otherwise sit in the run queue until the next timer tick.
-            state.NeedReschedule = true;
+            state._needReschedule = true;
 
             Serial.WriteString("[SCHED] Thread ");
             Serial.WriteNumber(thread.Id);
@@ -459,16 +459,16 @@ public static class SchedulerManager
 
         using (CPU.InternalCpu.DisableInterruptsScope())
         {
-            PerCpuState state = _cpuStates[cpuId];
+            PerCpuState state = s_cpuStates[cpuId];
 
             thread.State = ThreadState.Blocked;
-            _currentScheduler.OnThreadBlocked(state, thread);
+            s_currentScheduler.OnThreadBlocked(state, thread);
 
             // Ask the next IRQ exit to switch away (same as ReadyThread): a
             // blocked current thread otherwise keeps re-entering its halt
             // loop until the quantum tick preempts it — or forever when the
             // periodic tick is not running.
-            state.NeedReschedule = true;
+            state._needReschedule = true;
 
             Serial.WriteString("[SCHED] BlockThread id=");
             Serial.WriteNumber(thread.Id);
@@ -505,7 +505,7 @@ public static class SchedulerManager
 
         using (CPU.InternalCpu.DisableInterruptsScope())
         {
-            PerCpuState state = _cpuStates[cpuId];
+            PerCpuState state = s_cpuStates[cpuId];
 
             // Return TLAB and track unused bytes before unregistering
             if (GarbageCollector.IsEnabled)
@@ -519,7 +519,7 @@ public static class SchedulerManager
             }
 
             thread.State = ThreadState.Dead;
-            _currentScheduler.OnThreadExit(state, thread);
+            s_currentScheduler.OnThreadExit(state, thread);
             UnregisterThread(thread);
             Serial.WriteString("[SCHED] ExitThread: OnThreadExit done\n");
         }
@@ -532,9 +532,9 @@ public static class SchedulerManager
 
         using (CPU.InternalCpu.DisableInterruptsScope())
         {
-            PerCpuState state = _cpuStates[cpuId];
+            PerCpuState state = s_cpuStates[cpuId];
 
-            _currentScheduler.OnThreadYield(state, thread);
+            s_currentScheduler.OnThreadYield(state, thread);
         }
     }
 
@@ -572,7 +572,7 @@ public static class SchedulerManager
 
         using (InternalCpu.DisableInterruptsScope())
         {
-            PerCpuState cpuState = _cpuStates[cpuId];
+            PerCpuState cpuState = s_cpuStates[cpuId];
 
             ulong timestamp = GetTimestamp();
             // WakeupTime is compared against GetTimestamp() — Stopwatch ticks —
@@ -582,7 +582,7 @@ public static class SchedulerManager
             ulong ticksPerMs = (ulong)Stopwatch.Frequency / 1000;
             thread.WakeupTime = timestamp + timeoutMs * ticksPerMs;
 
-            _currentScheduler.OnThreadBlocked(cpuState, thread);
+            s_currentScheduler.OnThreadBlocked(cpuState, thread);
             thread.State = ThreadState.Sleeping;
         }
     }
@@ -607,8 +607,8 @@ public static class SchedulerManager
         ThrowIfCpuStateNotInitialized();
         ThrowIfSchedulerNotSet();
 
-        var state = _cpuStates[cpuId];
-        return _currentScheduler.OnTick(state, state.CurrentThread, elapsedNs);
+        var state = s_cpuStates[cpuId];
+        return s_currentScheduler.OnTick(state, state.CurrentThread, elapsedNs);
     }
 
     public static void Schedule(uint cpuId)
@@ -616,11 +616,11 @@ public static class SchedulerManager
         ThrowIfCpuStateNotInitialized();
         ThrowIfSchedulerNotSet();
 
-        var state = _cpuStates[cpuId];
+        var state = s_cpuStates[cpuId];
         state.Lock.Acquire();
 
         var prev = state.CurrentThread;
-        var next = _currentScheduler.PickNext(state) ?? state.IdleThread;
+        var next = s_currentScheduler.PickNext(state) ?? state.IdleThread;
 
         if (next == null)
         {
@@ -648,11 +648,11 @@ public static class SchedulerManager
         ThrowIfCpuStateNotInitialized();
         ThrowIfSchedulerNotSet();
 
-        var state = _cpuStates[cpuId];
+        var state = s_cpuStates[cpuId];
         state.Lock.Acquire();
         try
         {
-            _currentScheduler.SetPriority(state, thread, priority);
+            s_currentScheduler.SetPriority(state, thread, priority);
         }
         finally
         {
@@ -664,7 +664,7 @@ public static class SchedulerManager
     {
         ThrowIfSchedulerNotSet();
 
-        return _currentScheduler.GetPriority(thread);
+        return s_currentScheduler.GetPriority(thread);
     }
 
     // ========== Load Balancing ==========
@@ -673,7 +673,7 @@ public static class SchedulerManager
     {
         ThrowIfSchedulerNotSet();
 
-        return _currentScheduler.SelectCpu(thread, currentCpu, _cpuCount);
+        return s_currentScheduler.SelectCpu(thread, currentCpu, s_cpuCount);
     }
 
     public static void Balance(uint cpuId)
@@ -681,14 +681,14 @@ public static class SchedulerManager
         ThrowIfCpuStateNotInitialized();
         ThrowIfSchedulerNotSet();
 
-        var state = _cpuStates[cpuId];
-        _currentScheduler.Balance(state, _cpuStates);
+        var state = s_cpuStates[cpuId];
+        s_currentScheduler.Balance(state, s_cpuStates);
     }
 
     // ========== Timer Interrupt Handling ==========
 
     // Debug counter to avoid flooding serial output
-    private static uint _tickCount;
+    private static uint s_tickCount;
 
     /// <summary>
     /// Called from timer interrupt handler to process scheduling.
@@ -699,12 +699,12 @@ public static class SchedulerManager
     /// <param name="elapsedNs">Nanoseconds since last tick.</param>
     public static void OnTimerInterrupt(uint cpuId, nuint currentRsp, ulong elapsedNs)
     {
-        _tickCount++;
+        s_tickCount++;
 
         // Refresh the debug-live snapshot every 10 ticks (~100ms at 100Hz)
         // so the host-side QMP poller sees fresh thread state without
         // pausing the kernel.
-        if ((_tickCount % SnapshotRefreshTickInterval) == 0)
+        if ((s_tickCount % SnapshotRefreshTickInterval) == 0)
         {
             Cosmos.Kernel.Core.Runtime.DebugLiveSnapshot.Update();
             Cosmos.Kernel.Core.Runtime.DebugLiveGCSnapshot.Update();
@@ -712,26 +712,26 @@ public static class SchedulerManager
         }
 
         // Log first 10 ticks and then every 50 ticks
-        if (_tickCount <= InitialTickLogCount || _tickCount % TickLogInterval == 0)
+        if (s_tickCount <= InitialTickLogCount || s_tickCount % TickLogInterval == 0)
         {
             Serial.WriteString("[SCHED] Tick ");
-            Serial.WriteNumber(_tickCount);
+            Serial.WriteNumber(s_tickCount);
             Serial.WriteString(" enabled=");
-            Serial.WriteString(_enabled ? "1" : "0");
+            Serial.WriteString(s_enabled ? "1" : "0");
             Serial.WriteString("\n");
         }
 
-        if (!_enabled || _currentScheduler == null || _cpuStates == null)
+        if (!s_enabled || s_currentScheduler == null || s_cpuStates == null)
         {
             return;
         }
 
-        if (cpuId >= _cpuCount)
+        if (cpuId >= s_cpuCount)
         {
             return;
         }
 
-        var state = _cpuStates[cpuId];
+        var state = s_cpuStates[cpuId];
         if (state.CurrentThread == null)
         {
             return;
@@ -741,7 +741,7 @@ public static class SchedulerManager
         CheckSleepingThreads(elapsedNs);
 
         // Update timing and check if preemption needed
-        bool needsReschedule = _currentScheduler.OnTick(state, state.CurrentThread, elapsedNs);
+        bool needsReschedule = s_currentScheduler.OnTick(state, state.CurrentThread, elapsedNs);
 
         if (needsReschedule)
         {
@@ -756,16 +756,16 @@ public static class SchedulerManager
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void CheckSleepingThreads(ulong elapsedNs)
     {
-        if (_allThreads == null)
+        if (s_allThreads == null)
         {
             return;
         }
 
         ulong currentTime = GetTimestamp();
 
-        for (int i = 0; i < _allThreads.Length; i++)
+        for (int i = 0; i < s_allThreads.Length; i++)
         {
-            Thread? thread = _allThreads[i];
+            Thread? thread = s_allThreads[i];
             if (thread == null || thread.State != ThreadState.Sleeping)
             {
                 continue;
@@ -799,18 +799,18 @@ public static class SchedulerManager
     /// <param name="currentRsp">Current RSP (pointer to saved context on stack).</param>
     public static void ReschedulePendingFromIrq(uint cpuId, nuint currentRsp)
     {
-        if (!_enabled || _currentScheduler == null || _cpuStates == null || cpuId >= _cpuCount)
+        if (!s_enabled || s_currentScheduler == null || s_cpuStates == null || cpuId >= s_cpuCount)
         {
             return;
         }
 
-        PerCpuState state = _cpuStates[cpuId];
-        if (!state.NeedReschedule)
+        PerCpuState state = s_cpuStates[cpuId];
+        if (!state._needReschedule)
         {
             return;
         }
 
-        state.NeedReschedule = false;
+        state._needReschedule = false;
 
         if (ContextSwitchNative.GetContextSwitchSp() != 0)
         {
@@ -831,11 +831,11 @@ public static class SchedulerManager
         ThrowIfCpuStateNotInitialized();
         ThrowIfSchedulerNotSet();
 
-        var state = _cpuStates[cpuId];
+        var state = s_cpuStates[cpuId];
 
         // No lock needed - interrupts are already disabled in interrupt context
         var prev = state.CurrentThread;
-        var next = _currentScheduler.PickNext(state) ?? state.IdleThread;
+        var next = s_currentScheduler.PickNext(state) ?? state.IdleThread;
 
         if (next == null)
         {
@@ -868,7 +868,7 @@ public static class SchedulerManager
                 // Put previous thread back in run queue if still runnable
                 if (prev.State == ThreadState.Ready)
                 {
-                    _currentScheduler.OnThreadYield(state, prev);
+                    s_currentScheduler.OnThreadYield(state, prev);
                 }
             }
 

--- a/src/Cosmos.Kernel.Core/Scheduler/Stride/StrideScheduler.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/Stride/StrideScheduler.cs
@@ -201,11 +201,11 @@ public class StrideScheduler : IScheduler
     }
 
     // Debug counter for OnTick logging
-    private static uint _onTickLogCount;
+    private static uint s_onTickLogCount;
 
     public bool OnTick(PerCpuState cpuState, Thread current, ulong elapsedNs)
     {
-        _onTickLogCount++;
+        s_onTickLogCount++;
 
         if (current == null)
         {
@@ -244,7 +244,7 @@ public class StrideScheduler : IScheduler
         UpdateGlobalPass(cpuData);
 
         // Log every 100 ticks
-        if (_onTickLogCount % 100 == 0)
+        if (s_onTickLogCount % 100 == 0)
         {
             Cosmos.Kernel.Core.IO.Serial.WriteString("[STRIDE] OnTick: current=");
             Cosmos.Kernel.Core.IO.Serial.WriteNumber(current.Id);

--- a/src/Cosmos.Kernel.HAL.ARM64/Devices/Timer/GenericTimer.cs
+++ b/src/Cosmos.Kernel.HAL.ARM64/Devices/Timer/GenericTimer.cs
@@ -168,7 +168,7 @@ public class GenericTimer : TimerDevice
     /// <summary>
     /// Timer tick counter for debugging.
     /// </summary>
-    private static uint _timerTickCount;
+    private static uint s_timerTickCount;
 
     /// <summary>
     /// Handles the timer interrupt.
@@ -180,7 +180,7 @@ public class GenericTimer : TimerDevice
             return;
         }
 
-        _timerTickCount++;
+        s_timerTickCount++;
 
         // Re-arm the timer for the next period
         if (Instance._ticksPerPeriod > uint.MaxValue)
@@ -204,10 +204,10 @@ public class GenericTimer : TimerDevice
         nuint currentSp = contextPtr - ARM64InterruptController.NeonSaveAreaBytes;  // SP points to start of NEON save area
 
         // Log first few ticks and then periodically
-        if (_timerTickCount <= 5 || _timerTickCount % 100 == 0)
+        if (s_timerTickCount <= 5 || s_timerTickCount % 100 == 0)
         {
             Serial.Write("[GenericTimer] Tick ");
-            Serial.WriteNumber(_timerTickCount);
+            Serial.WriteNumber(s_timerTickCount);
             Serial.Write(" SP=0x");
             Serial.WriteHex((ulong)currentSp);
             Serial.Write("\n");

--- a/src/Cosmos.Kernel.HAL.Interfaces/Devices/Network/MACAddress.cs
+++ b/src/Cosmos.Kernel.HAL.Interfaces/Devices/Network/MACAddress.cs
@@ -2,18 +2,18 @@ namespace Cosmos.Kernel.HAL.Devices.Network;
 
 public class MACAddress : IComparable
 {
-    private static MACAddress? _broadcast;
-    private static MACAddress? _none;
+    private static MACAddress? s_broadcast;
+    private static MACAddress? s_none;
 
     public static MACAddress Broadcast
     {
         get
         {
-            if (_broadcast == null)
+            if (s_broadcast == null)
             {
-                _broadcast = new MACAddress([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
+                s_broadcast = new MACAddress([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
             }
-            return _broadcast;
+            return s_broadcast;
         }
     }
 
@@ -21,11 +21,11 @@ public class MACAddress : IComparable
     {
         get
         {
-            if (_none == null)
+            if (s_none == null)
             {
-                _none = new MACAddress([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+                s_none = new MACAddress([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
             }
-            return _none;
+            return s_none;
         }
     }
 

--- a/src/Cosmos.Kernel.HAL.X64/Devices/Input/PS2Keyboard.cs
+++ b/src/Cosmos.Kernel.HAL.X64/Devices/Input/PS2Keyboard.cs
@@ -23,10 +23,10 @@ public class PS2Keyboard : KeyboardDevice
     }
 
     // Static reference to the first keyboard instance (for IRQ handler)
-    private static PS2Keyboard? _instance;
+    private static PS2Keyboard? s_instance;
 
     // Flag to prevent multiple IRQ registrations
-    private static bool _irqRegistered;
+    private static bool s_irqRegistered;
 
     /// <summary>
     /// Registers IRQ handler for keyboard interrupts.
@@ -106,9 +106,9 @@ public class PS2Keyboard : KeyboardDevice
         Serial.WriteString("[PS2Keyboard] Initialized (scanning will be enabled later)\n");
 
         // Store first keyboard instance for IRQ handler
-        if (_instance == null)
+        if (s_instance == null)
         {
-            _instance = this;
+            s_instance = this;
         }
 
         UpdateLeds();
@@ -136,9 +136,9 @@ public class PS2Keyboard : KeyboardDevice
         }
 
         // Use the instance's OnKeyPressed callback (set by KeyboardManager.RegisterKeyboard)
-        if (_instance?.OnKeyPressed != null)
+        if (s_instance?.OnKeyPressed != null)
         {
-            _instance.OnKeyPressed.Invoke(scanCode, released);
+            s_instance.OnKeyPressed.Invoke(scanCode, released);
         }
 
         // EOI is sent by InterruptManager.Dispatch after this handler returns
@@ -180,10 +180,10 @@ public class PS2Keyboard : KeyboardDevice
     public override void Enable()
     {
         // Register IRQ handler on first Enable() call (after callback is set)
-        if (!_irqRegistered)
+        if (!s_irqRegistered)
         {
             RegisterIRQHandler();
-            _irqRegistered = true;
+            s_irqRegistered = true;
             return;
         }
 

--- a/src/Cosmos.Kernel.HAL.X64/Devices/Input/PS2Mouse.cs
+++ b/src/Cosmos.Kernel.HAL.X64/Devices/Input/PS2Mouse.cs
@@ -23,15 +23,15 @@ public class PS2Mouse : MouseDevice
     }
 
     // Static reference to the first mouse instance (for IRQ handler)
-    private static PS2Mouse? _instance;
+    private static PS2Mouse? s_instance;
 
     // Flag to prevent multiple IRQ registrations
-    private static bool _irqRegistered;
+    private static bool s_irqRegistered;
 
     // Mouse packet buffer (3 bytes for standard PS/2 mouse, 4 bytes for scroll wheel)
-    private static byte[] _packet = new byte[4];
-    private static int _packetIndex = 0;
-    private static bool _hasScrollWheel = false;
+    private static byte[] s_packet = new byte[4];
+    private static int s_packetIndex = 0;
+    private static bool s_hasScrollWheel = false;
 
     /// <summary>
     /// Registers IRQ handler for mouse interrupts.
@@ -109,9 +109,9 @@ public class PS2Mouse : MouseDevice
         SendCommand(Command.SetDefaults);
 
         // Try to enable scroll wheel (IntelliMouse protocol)
-        _hasScrollWheel = TryEnableScrollWheel();
+        s_hasScrollWheel = TryEnableScrollWheel();
 
-        if (_hasScrollWheel)
+        if (s_hasScrollWheel)
         {
             Serial.WriteString("[PS2Mouse] Scroll wheel enabled\n");
         }
@@ -119,9 +119,9 @@ public class PS2Mouse : MouseDevice
         Serial.WriteString("[PS2Mouse] Initialized (data reporting will be enabled later)\n");
 
         // Store first mouse instance for IRQ handler
-        if (_instance == null)
+        if (s_instance == null)
         {
-            _instance = this;
+            s_instance = this;
         }
     }
 
@@ -151,39 +151,39 @@ public class PS2Mouse : MouseDevice
         byte data = Native.IO.Read8(0x60);
 
         // Add to packet buffer
-        _packet[_packetIndex] = data;
-        _packetIndex++;
+        s_packet[s_packetIndex] = data;
+        s_packetIndex++;
 
         // Check if we have a complete packet
-        int packetSize = _hasScrollWheel ? 4 : 3;
-        if (_packetIndex >= packetSize)
+        int packetSize = s_hasScrollWheel ? 4 : 3;
+        if (s_packetIndex >= packetSize)
         {
-            _packetIndex = 0;
+            s_packetIndex = 0;
 
             // Validate packet (bit 3 of first byte should always be 1)
-            if ((_packet[0] & 0x08) != 0x08)
+            if ((s_packet[0] & 0x08) != 0x08)
             {
                 // Invalid packet, skip it
                 return;
             }
 
             // Parse packet
-            bool leftButton = (_packet[0] & 0x01) != 0;
-            bool rightButton = (_packet[0] & 0x02) != 0;
-            bool middleButton = (_packet[0] & 0x04) != 0;
+            bool leftButton = (s_packet[0] & 0x01) != 0;
+            bool rightButton = (s_packet[0] & 0x02) != 0;
+            bool middleButton = (s_packet[0] & 0x04) != 0;
 
             // X/Y (9-bit signed values) and Z movement
-            int deltaX = _packet[1];
-            int deltaY = _packet[2];
-            int deltaZ = _hasScrollWheel ? _packet[3] & 0x0F : 0;
+            int deltaX = s_packet[1];
+            int deltaY = s_packet[2];
+            int deltaZ = s_hasScrollWheel ? s_packet[3] & 0x0F : 0;
 
             // Sign-extend X, Y and Z if negative
-            if ((_packet[0] & 0x10) != 0)
+            if ((s_packet[0] & 0x10) != 0)
             {
                 deltaX |= unchecked((int)0xFFFFFF00);
             }
 
-            if ((_packet[0] & 0x20) != 0)
+            if ((s_packet[0] & 0x20) != 0)
             {
                 deltaY |= unchecked((int)0xFFFFFF00);
             }
@@ -197,17 +197,17 @@ public class PS2Mouse : MouseDevice
             deltaY = -deltaY;
 
             // Update instance state
-            if (_instance != null)
+            if (s_instance != null)
             {
-                _instance.X += deltaX;
-                _instance.Y += deltaY;
-                _instance.ScrollDelta = deltaZ;
-                _instance.LeftButton = leftButton;
-                _instance.RightButton = rightButton;
-                _instance.MiddleButton = middleButton;
+                s_instance.X += deltaX;
+                s_instance.Y += deltaY;
+                s_instance.ScrollDelta = deltaZ;
+                s_instance.LeftButton = leftButton;
+                s_instance.RightButton = rightButton;
+                s_instance.MiddleButton = middleButton;
 
                 // Invoke callback
-                _instance.OnMouseEvent?.Invoke(deltaX, deltaY, deltaZ, leftButton, rightButton, middleButton);
+                s_instance.OnMouseEvent?.Invoke(deltaX, deltaY, deltaZ, leftButton, rightButton, middleButton);
             }
         }
 
@@ -238,10 +238,10 @@ public class PS2Mouse : MouseDevice
     public override void Enable()
     {
         // Register IRQ handler on first Enable() call (after callback is set)
-        if (!_irqRegistered)
+        if (!s_irqRegistered)
         {
             RegisterIRQHandler();
-            _irqRegistered = true;
+            s_irqRegistered = true;
             return;
         }
 

--- a/src/Cosmos.Kernel.HAL.X64/Devices/Timer/PIT.cs
+++ b/src/Cosmos.Kernel.HAL.X64/Devices/Timer/PIT.cs
@@ -25,8 +25,8 @@ public class PIT : TimerDevice
 
     public bool T0RateGen = false;
 
-    private ushort t0Countdown = 65535;
-    private ushort t2Countdown = 65535;
+    private ushort _t0Countdown = 65535;
+    private ushort _t2Countdown = 65535;
 
     /// <summary>
     /// Channel 0 data port.
@@ -75,10 +75,10 @@ public class PIT : TimerDevice
 
     public ushort T0Countdown
     {
-        get => t0Countdown;
+        get => _t0Countdown;
         set
         {
-            t0Countdown = value;
+            _t0Countdown = value;
 
             Native.IO.Write8(Command, (byte)(T0RateGen ? 0x34 : 0x30));
             Native.IO.Write8(Data0, (byte)(value & 0xFF));
@@ -89,11 +89,11 @@ public class PIT : TimerDevice
     /// <summary>
     /// Gets the timer frequency in Hz.
     /// </summary>
-    public override uint Frequency => PITFrequency / t0Countdown;
+    public override uint Frequency => PITFrequency / _t0Countdown;
 
     public uint T0Frequency
     {
-        get => PITFrequency / t0Countdown;
+        get => PITFrequency / _t0Countdown;
         set
         {
             if (value < 19 || value > 1193180)
@@ -117,7 +117,7 @@ public class PIT : TimerDevice
 
     public uint T0DelayNS
     {
-        get => PITDelayNS * t0Countdown;
+        get => PITDelayNS * _t0Countdown;
         set
         {
             if (value > 54918330)
@@ -132,10 +132,10 @@ public class PIT : TimerDevice
 
     public ushort T2Countdown
     {
-        get => t2Countdown;
+        get => _t2Countdown;
         set
         {
-            t2Countdown = value;
+            _t2Countdown = value;
 
             Native.IO.Write8(Command, 0xB6);
             Native.IO.Write8(Data2, (byte)(value & 0xFF));
@@ -145,7 +145,7 @@ public class PIT : TimerDevice
 
     public uint T2Frequency
     {
-        get => PITFrequency / t2Countdown;
+        get => PITFrequency / _t2Countdown;
         set
         {
             if (value < 19 || value > 1193180)
@@ -160,7 +160,7 @@ public class PIT : TimerDevice
 
     public uint T2DelayNS
     {
-        get => PITDelayNS * t2Countdown;
+        get => PITDelayNS * _t2Countdown;
         set
         {
             if (value > 54918330)
@@ -180,7 +180,7 @@ public class PIT : TimerDevice
     public override void RegisterTimer(SoftwareTimer timer)
     {
         base.RegisterTimer(timer);
-        T0Countdown = t0Countdown;
+        T0Countdown = _t0Countdown;
     }
 
     private static void HandleIRQ(ref IRQContext aContext)
@@ -195,7 +195,7 @@ public class PIT : TimerDevice
         // In one-shot mode, must reload after each interrupt
         if (!Instance.T0RateGen)
         {
-            Instance.T0Countdown = Instance.t0Countdown;
+            Instance.T0Countdown = Instance._t0Countdown;
         }
 
         Instance.HandleTick(t0Delay);

--- a/src/Cosmos.Kernel.HAL/Pci/PciDevice.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/PciDevice.cs
@@ -350,13 +350,13 @@ public class PciDevice : Device
 #endif
     }
 
-    private static bool _firstAccessLogged = false;
+    private static bool s_firstAccessLogged = false;
 
     private static ushort ReadConfig16(ushort bus, ushort slot, ushort func, byte offset)
     {
 #if ARCH_ARM64
         ulong addr = GetEcamAddress(bus, slot, func, offset);
-        if (!_firstAccessLogged)
+        if (!s_firstAccessLogged)
         {
             Serial.WriteString("[PciDevice] First ECAM Read: Bus ");
             Serial.WriteNumber(bus);
@@ -369,7 +369,7 @@ public class PciDevice : Device
             Serial.WriteString(" -> Addr 0x");
             Serial.WriteHex(addr);
             Serial.WriteString("\n");
-            _firstAccessLogged = true;
+            s_firstAccessLogged = true;
         }
         return Native.MMIO.Read16(addr);
 #else

--- a/src/Cosmos.Kernel.HAL/PlatformHAL.cs
+++ b/src/Cosmos.Kernel.HAL/PlatformHAL.cs
@@ -20,23 +20,23 @@ public static class PlatformHAL
     /// </summary>
     public const ushort LegacyPostPort = 0x80;
 
-    private static IPortIO? _portIO;
-    private static ICpuOps? _cpuOps;
-    private static IPowerOps? _powerOps;
-    private static PlatformArchitecture _architecture;
-    private static string? _platformName;
-    private static IPlatformInitializer? _initializer;
+    private static IPortIO? s_portIO;
+    private static ICpuOps? s_cpuOps;
+    private static IPowerOps? s_powerOps;
+    private static PlatformArchitecture s_architecture;
+    private static string? s_platformName;
+    private static IPlatformInitializer? s_initializer;
 
-    public static IPortIO PortIO => _portIO!;
-    public static ICpuOps? CpuOps => _cpuOps;
-    public static IPowerOps? PowerOps => _powerOps;
-    public static PlatformArchitecture Architecture => _architecture;
-    public static string PlatformName => _platformName ?? "Unknown";
+    public static IPortIO PortIO => s_portIO!;
+    public static ICpuOps? CpuOps => s_cpuOps;
+    public static IPowerOps? PowerOps => s_powerOps;
+    public static PlatformArchitecture Architecture => s_architecture;
+    public static string PlatformName => s_platformName ?? "Unknown";
 
     /// <summary>
     /// Gets the registered platform initializer, if any.
     /// </summary>
-    public static IPlatformInitializer? Initializer => _initializer;
+    public static IPlatformInitializer? Initializer => s_initializer;
 
     /// <summary>
     /// Registers a platform initializer for later use by Kernel.Initialize().
@@ -45,7 +45,7 @@ public static class PlatformHAL
     /// <param name="initializer">Platform-specific initializer to register.</param>
     public static void SetInitializer(IPlatformInitializer initializer)
     {
-        _initializer = initializer;
+        s_initializer = initializer;
     }
 
     /// <summary>
@@ -54,11 +54,11 @@ public static class PlatformHAL
     /// <param name="initializer">Platform-specific initializer (X64 or ARM64).</param>
     public static void Initialize(IPlatformInitializer initializer)
     {
-        _initializer = initializer;
-        _platformName = initializer.PlatformName;
-        _architecture = initializer.Architecture;
-        _portIO = initializer.CreatePortIO();
-        _cpuOps = initializer.CreateCpuOps();
-        _powerOps = initializer.CreatePowerOps();
+        s_initializer = initializer;
+        s_platformName = initializer.PlatformName;
+        s_architecture = initializer.Architecture;
+        s_portIO = initializer.CreatePortIO();
+        s_cpuOps = initializer.CreateCpuOps();
+        s_powerOps = initializer.CreatePowerOps();
     }
 }

--- a/src/Cosmos.Kernel.System/Global.cs
+++ b/src/Cosmos.Kernel.System/Global.cs
@@ -11,15 +11,15 @@ public static class Global
     /// <summary>
     /// The registered kernel instance that will be started.
     /// </summary>
-    private static Kernel? _kernel;
+    private static Kernel? s_kernel;
 
     /// <summary>
     /// Gets or sets the current kernel instance.
     /// </summary>
     public static Kernel? CurrentKernel
     {
-        get => _kernel;
-        set => _kernel = value;
+        get => s_kernel;
+        set => s_kernel = value;
     }
 
     /// <summary>
@@ -30,7 +30,7 @@ public static class Global
     public static void RegisterKernel(Kernel kernel)
     {
         Serial.WriteString("[Global] Registering kernel\n");
-        _kernel = kernel;
+        s_kernel = kernel;
     }
 
     /// <summary>
@@ -71,7 +71,7 @@ public static class Global
     {
         Serial.WriteString("[Global] StartKernel called\n");
 
-        if (_kernel == null)
+        if (s_kernel == null)
         {
             Serial.WriteString("[Global] ERROR: No kernel registered!\n");
             Serial.WriteString("[Global] Check CosmosKernelClass property in your .csproj\n");
@@ -85,7 +85,7 @@ public static class Global
         }
 
         Serial.WriteString("[Global] Starting kernel...\n");
-        _kernel.Start();
+        s_kernel.Start();
 
         // If kernel.Start() returns, halt the system
         Serial.WriteString("[Global] Kernel.Start() returned, halting...\n");

--- a/src/Cosmos.Kernel.System/Graphics/Canvas.cs
+++ b/src/Cosmos.Kernel.System/Graphics/Canvas.cs
@@ -57,17 +57,17 @@ public unsafe class Canvas
     /// <summary>
     /// Bytes per pixel (4 in 32bit, 3 in 24bit).
     /// </summary>
-    internal int BytesPerPixel;
+    internal int _bytesPerPixel;
 
     /// <summary>
-    /// Stride.
+    /// _stride.
     /// </summary>
-    internal int Stride;
+    internal int _stride;
 
     /// <summary>
-    /// Pitch.
+    /// _pitch.
     /// </summary>
-    internal int Pitch;
+    internal int _pitch;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Canvas"/> class.
@@ -84,9 +84,9 @@ public unsafe class Canvas
     protected Canvas(Mode mode)
     {
         _mode = mode;
-        BytesPerPixel = (int)mode.ColorDepth / 8;
-        Stride = (int)mode.ColorDepth / 8;
-        Pitch = (int)mode.Width * BytesPerPixel;
+        _bytesPerPixel = (int)mode.ColorDepth / 8;
+        _stride = (int)mode.ColorDepth / 8;
+        _pitch = (int)mode.Width * _bytesPerPixel;
     }
 
     /// <summary>
@@ -114,9 +114,9 @@ public unsafe class Canvas
     public Canvas(int width, int height, ColorDepth colorDepth = ColorDepth.ColorDepth32)
     {
         _mode = new Mode((uint)width, (uint)height, colorDepth);
-        BytesPerPixel = (int)colorDepth / 8;
-        Stride = (int)colorDepth / 8;
-        Pitch = width * BytesPerPixel;
+        _bytesPerPixel = (int)colorDepth / 8;
+        _stride = (int)colorDepth / 8;
+        _pitch = width * _bytesPerPixel;
         Buffer = new int[width * height];
     }
 
@@ -291,7 +291,7 @@ public unsafe class Canvas
 
     internal int GetPointOffset(int x, int y)
     {
-        return (x * Stride) + (y * Pitch);
+        return (x * _stride) + (y * _pitch);
     }
 
     /// <summary>

--- a/src/Cosmos.Kernel.System/Graphics/Fonts/PCScreenFont.cs
+++ b/src/Cosmos.Kernel.System/Graphics/Fonts/PCScreenFont.cs
@@ -11,7 +11,7 @@ namespace Cosmos.Kernel.System.Graphics.Fonts;
 /// </summary>
 public class PCScreenFont : Font
 {
-    readonly List<UnicodeMapping> unicodeMappings; // Maps the fonts to the corresponding unicode characters
+    readonly List<UnicodeMapping> _unicodeMappings; // Maps the fonts to the corresponding unicode characters
 
     #region DefaultFontData
     // Credit to fcambus https://github.com/fcambus/spleen under BSD-2 License
@@ -47,12 +47,12 @@ public class PCScreenFont : Font
         public const string DefaultFontName = $"{DefaultFontKey}.psf";
     }
 
-    static PCScreenFont? _Default = null;
+    static PCScreenFont? s_default = null;
     public static PCScreenFont DefaultFont
     {
         get
         {
-            if (_Default == null)
+            if (s_default == null)
             {
                 try
                 {
@@ -65,8 +65,8 @@ public class PCScreenFont : Font
                         Serial.WriteString("Loading default PSF font from resources...\n");
                         Serial.WriteString($"Font Key: {embeddedResourceName}");
                         Serial.WriteString($"Font size: {resourceSpan.Length.ToString()} bytes\n");
-                        _Default = LoadFont(resourceSpan.ToArray());
-                        return _Default;
+                        s_default = LoadFont(resourceSpan.ToArray());
+                        return s_default;
                     }
                 }
                 catch (Exception ex)
@@ -75,7 +75,7 @@ public class PCScreenFont : Font
                 }
 
                 Serial.WriteString("Loading built-in fallback font\n");
-                _Default = LoadFont(Convert.FromBase64String("NgQDEAAAAAAAZjxmZmY8ZgAAAAAAABgYGBgYAAAYGBgYGAAAAABsbAAAAAAAAAAAAAAAAAAAAHyCmqKiopqCfAAAAAAAAAB8grqqsqqqgnwAAAAAAHwAAAAAAAAAAAAAAAAAAAAcJgwGJhwAAAAAAAAAAAAAAAAAAAAYPDwYAAAAAAAAAAwYMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgYMAAAGDgYGBg8AAAAAAAAAAAAAGCQIBKWbBgwcNSUHgQEADAYAHzGxsb+xsbGxgAAAAAYMAB8xsbG/sbGxsYAAAAAOGwAfMbGxv7GxsbGAAAAADJMAHzGxsb+xsbGxgAAAAAwGAB+wMDA+MDAwH4AAAAAOGwAfsDAwPjAwMB+AAAAAGxsAH7AwMD4wMDAfgAAAAAwGAB+GBgYGBgYGH4AAAAAAAB+1tbWdhYWFhYWAAAAAAA8ZmAwPGZmZmY8DAZmPAAMGAB+GBgYGBgYGH4AAAAAOGwAfhgYGBgYGBh+AAAAAGZmAH4YGBgYGBgYfgAAAAAAAHxmZmb2ZmZmZnwAAAAAMBgAfMbGxsbGxsZ8AAAAABgwAHzGxsbGxsbGfAAAAAA4bAB8xsbGxsbGxnwAAAAAMkwAfMbGxsbGxsZ8AAAAAAAAAAAAxmw4OGzGAAAAAAAAAnzGzs7W1ubmxnyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGBgYGBgYGAAYGAAAAAAAZmZmZgAAAAAAAAAAAAAAAABsbP5sbGxs/mxsAAAAAAAQftDQ0HwWFhYW/BAAAAAAAAZmbAwYGDA2ZmAAAAAAAAA4bGxsOHDazMx6AAAAAAAYGBgYAAAAAAAAAAAAAAAADhgwMGBgYGBgYDAwGA4AAHAYDAwGBgYGBgYMDBhwAAAAAABmPBj/" +
+                s_default = LoadFont(Convert.FromBase64String("NgQDEAAAAAAAZjxmZmY8ZgAAAAAAABgYGBgYAAAYGBgYGAAAAABsbAAAAAAAAAAAAAAAAAAAAHyCmqKiopqCfAAAAAAAAAB8grqqsqqqgnwAAAAAAHwAAAAAAAAAAAAAAAAAAAAcJgwGJhwAAAAAAAAAAAAAAAAAAAAYPDwYAAAAAAAAAAwYMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgYMAAAGDgYGBg8AAAAAAAAAAAAAGCQIBKWbBgwcNSUHgQEADAYAHzGxsb+xsbGxgAAAAAYMAB8xsbG/sbGxsYAAAAAOGwAfMbGxv7GxsbGAAAAADJMAHzGxsb+xsbGxgAAAAAwGAB+wMDA+MDAwH4AAAAAOGwAfsDAwPjAwMB+AAAAAGxsAH7AwMD4wMDAfgAAAAAwGAB+GBgYGBgYGH4AAAAAAAB+1tbWdhYWFhYWAAAAAAA8ZmAwPGZmZmY8DAZmPAAMGAB+GBgYGBgYGH4AAAAAOGwAfhgYGBgYGBh+AAAAAGZmAH4YGBgYGBgYfgAAAAAAAHxmZmb2ZmZmZnwAAAAAMBgAfMbGxsbGxsZ8AAAAABgwAHzGxsbGxsbGfAAAAAA4bAB8xsbGxsbGxnwAAAAAMkwAfMbGxsbGxsZ8AAAAAAAAAAAAxmw4OGzGAAAAAAAAAnzGzs7W1ubmxnyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGBgYGBgYGAAYGAAAAAAAZmZmZgAAAAAAAAAAAAAAAABsbP5sbGxs/mxsAAAAAAAQftDQ0HwWFhYW/BAAAAAAAAZmbAwYGDA2ZmAAAAAAAAA4bGxsOHDazMx6AAAAAAAYGBgYAAAAAAAAAAAAAAAADhgwMGBgYGBgYDAwGA4AAHAYDAwGBgYGBgYMDBhwAAAAAABmPBj/" +
                 "GDxmAAAAAAAAAAAAABgYfhgYAAAAAAAAAAAAAAAAAAAAABgYMAAAAAAAAAAAAAB+AAAAAAAAAAAAAAAAAAAAAAAAGBgAAAAAAAMDBgYMDBgYMDBgYMDAAAAAfMbGzt725sbGfAAAAAAAABg4eFgYGBgYGH4AAAAAAAB8xgYGDBgwYMb+AAAAAAAAfMYGBjwGBgbGfAAAAAAAAMDAzMzMzP4MDAwAAAAAAAD+xsDA/AYGBsZ8AAAAAAAAfMbAwPzGxsbGfAAAAAAAAP7GBgYMGDAwMDAAAAAAAAB8xsbGfMbGxsZ8AAAAAAAAfMbGxsZ+BgbGfAAAAAAAAAAAABgYAAAAGBgAAAAAAAAAAAAYGAAAABgYMAAAAAAABgwYMGBgMBgMBgAAAAAAAAAAAH4AAH4AAAAAAAAAAABgMBgMBgYMGDBgAAAAAAAAfMYGDBgwMAAwMAAAAAAAAAB8wtra2trewHwAAAAAAAB8xsbG/sbGxsbGAAAAAAAA/MbGxvzGxsbG/AAAAAAAAH7AwMDAwMDAwH4AAAAAAAD8xsbGxsbGxsb8AAAAAAAAfsDAwPjAwMDAfgAAAAAAAH7AwMD4wMDAwMAAAAAAAAB+wMDA3sbGxsZ+AAAAAAAAxsbGxv7GxsbGxgAAAAAAAH4YGBgYGBgYGH4AAAAAAAB+GBgYGBgYGBjwAAAAAAAAxsbGzPjMxsbGxgAAAAAAAMDAwMDAwMDAwH4AAAAAAADG7v7WxsbGxsbGAAAAAAAAxsbm5tbWzs7GxgAAAAAAAHzGxsbGxsbGxnwAAAAAAAD8xsbG/MDAwMDAAAAAAAAAfMbGxsbGxtbWfBgMAAAAAPzGxsb8xsbGxsYAAAAAAAB+wMDAfAYGBgb8AAAAAAAA/xgYGBgYGBgYGAAAAAAAAMbGxsbGxsbGxn4AAAAAAADGxsbGxsbGbDgQAAAAAAAAxsbGxsbG1v7u" +
                 "xgAAAAAAAMbGxmw4bMbGxsYAAAAAAADGxsbGfgYGBgb8AAAAAAAA/gYGDBgwYMDA/gAAAAAAPjAwMDAwMDAwMDAwMD4AAMDAYGAwMBgYDAwGBgMDAAB8DAwMDAwMDAwMDAwMfAAAEDhsxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD+AAAwGAwAAAAAAAAAAAAAAAAAAAAAAHwGfsbGxn4AAAAAAADAwMD8xsbGxsb8AAAAAAAAAAAAfsDAwMDAfgAAAAAAAAYGBn7GxsbGxn4AAAAAAAAAAAB+xsb+wMB+AAAAAAAAHjAwMHwwMDAwMAAAAAAAAAAAAH7GxsbGxnwGBvwAAADAwMD8xsbGxsbGAAAAAAAAGBgAOBgYGBgYHAAAAAAAABgYABgYGBgYGBgYGHAAAADAwMDM2PDw2MzGAAAAAAAAMDAwMDAwMDAwHAAAAAAAAAAAAOzW1tbWxsYAAAAAAAAAAAD8xsbGxsbGAAAAAAAAAAAAfMbGxsbGfAAAAAAAAAAAAPzGxsbGxvzAwMAAAAAAAAB+xsbGxsZ+BgYGAAAAAAAAfsbAwMDAwAAAAAAAAAAAAH7AwHwGBvwAAAAAAAAwMDB8MDAwMDAeAAAAAAAAAAAAxsbGxsbGfgAAAAAAAAAAAMbGxsZsOBAAAAAAAAAAAADGxtbW1tZuAAAAAAAAAAAAxmw4OGzGxgAAAAAAAAAAAMbGxsbGxn4GBvwAAAAAAAD+BgwYMGD+AAAAAAAOGBgYGBhwcBgYGBgYDgAAABgYGBgYGBgYGBgYGAAAAHAYGBgYGA4OGBgYGBhwAAAyfkwAAAAAAAAAAAAAAAAwGADGxsbGxsbGxn4AAAAAAAB+wMDAwMDAwMB+GBgwAAAAbGwAxsbGxsbGfgAAAAAADBgwAH7Gxv7AwH4AAAAAABA4bAB8Bn7GxsZ+AAAAAAAAbGwAfAZ+xsbGfgAA" +
                 "AAAAYDAYAHwGfsbGxn4AAAAAADhsOAB8Bn7GxsZ+AAAAAAAAAAAAfsDAwMDAfhgYMAAAEDhsAH7Gxv7AwH4AAAAAAABsbAB+xsb+wMB+AAAAAABgMBgAfsbG/sDAfgAAAAAAAGZmADgYGBgYGBwAAAAAABg8ZgA4GBgYGBgcAAAAAAAwGAwAOBgYGBgYHAAAAABsbAB8xsbG/sbGxsYAAAAAOGw4fMbGxv7GxsbGAAAAABgwAH7AwMD4wMDAfgAAAAAAAAAAAG4WFn7Q0G4AAAAAAAB+2NjY/tjY2NjeAAAAAAAQOGwAfMbGxsbGfAAAAAAAAGxsAHzGxsbGxnwAAAAAAGAwGAB8xsbGxsZ8AAAAAAAQOGwAxsbGxsbGfgAAAAAAYDAYAMbGxsbGxn4AAAAAAABsbADGxsbGxsZ+Bgb8AGxsAHzGxsbGxsbGfAAAAABsbADGxsbGxsbGxn4AAAAAAAAAAAh+yMjIyMh+CAAAAAAAOGxgYGD4YGDA/gAAAAAAAMPDZjwYPBg8GBgAAAAAGDAAxsbGxsbGxsZ+AAAAADhsAMbGxsbGxsbGfgAAAAAADBgwAHwGfsbGxn4AAAAAAAwYMAA4GBgYGBgcAAAAAAAMGDAAfMbGxsbGfAAAAAAADBgwAMbGxsbGxn4AAAAAADJ+TAD8xsbGxsbGAAAAADJMAMbm5tbWzs7GxgAAAAAAOAw8TDwAfAAAAAAAAAAAADhsbDgAAHwAAAAAAAAAAAAAGBgAGBgwYMDGfAAAAAAYMADGxsbGfgYGBvwAAAAAAAAAAAAA/gYGBgAAAAAAAABAwEBCRuwYMGzSggwQHgAAQMBAQkbsGDBw1JQeBAQAAAAYGAAYGBgYGBgYAAAAAAAAAAAAADNmzGYzAAAAAAAAAAAAAADMZjNmzAAAAAAAEUQRRBFEEUQRRBFEEUQRRFWqVapVqlWqVapVqlWqVardd9" +
@@ -92,7 +92,7 @@ public class PCScreenFont : Font
                 "////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////w=="));
             }
 
-            return _Default;
+            return s_default;
         }
     }
     #endregion
@@ -111,10 +111,10 @@ public class PCScreenFont : Font
     /// <param name="width">The width of a single character in pixels</param>
     /// <param name="height">The height of a single character in pixels</param>
     /// <param name="data">The PCF data.</param>
-    /// <param name="unicodeMappings">The mappings of Unicode characters to font indexes.</param>
-    public PCScreenFont(byte width, byte height, byte[] data, List<UnicodeMapping> unicodeMappings) : base(width, height, data)
+    /// <param name="_unicodeMappings">The mappings of Unicode characters to font indexes.</param>
+    public PCScreenFont(byte width, byte height, byte[] data, List<UnicodeMapping> _unicodeMappings) : base(width, height, data)
     {
-        this.unicodeMappings = unicodeMappings;
+        this._unicodeMappings = _unicodeMappings;
     }
 
     /// <summary>
@@ -312,9 +312,9 @@ public class PCScreenFont : Font
     private int FindASCIIOffset(byte i)
     {
         int offset;
-        for (offset = 0; offset < unicodeMappings.Count; offset++)
+        for (offset = 0; offset < _unicodeMappings.Count; offset++)
         {
-            UnicodeMapping mapping = unicodeMappings[offset];
+            UnicodeMapping mapping = _unicodeMappings[offset];
             if (mapping.ASCIICharacters.Contains(i))
             {
                 break;

--- a/src/Cosmos.Kernel.System/Graphics/GopCanvas.cs
+++ b/src/Cosmos.Kernel.System/Graphics/GopCanvas.cs
@@ -15,7 +15,7 @@ namespace Cosmos.Kernel.System.Graphics;
 /// </summary>
 internal class GopCanvas : Canvas
 {
-    static readonly Mode defaultMode = new(1024, 768, ColorDepth.ColorDepth32);
+    static readonly Mode s_defaultMode = new(1024, 768, ColorDepth.ColorDepth32);
     private Mode _mode;
     private readonly int _refreshRate = 60;
 
@@ -24,11 +24,11 @@ internal class GopCanvas : Canvas
     /// <summary>
     /// Initializes a new instance of the <see cref="GopCanvas"/> class.
     /// </summary>
-    internal GopCanvas() : this(defaultMode)
+    internal GopCanvas() : this(s_defaultMode)
     {
     }
 
-    private readonly GopDriver? driver;
+    private readonly GopDriver? _driver;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GopCanvas"/> class.
@@ -43,7 +43,7 @@ internal class GopCanvas : Canvas
         if (Limine.Framebuffer.Response != null && Limine.Framebuffer.Response->FramebufferCount > 0)
         {
             LimineFramebuffer* fb = Limine.Framebuffer.Response->Framebuffers[0];
-            driver = new GopDriver((uint*)fb->Address, (uint)fb->Width, (uint)fb->Height, (uint)fb->Pitch);
+            _driver = new GopDriver((uint*)fb->Address, (uint)fb->Width, (uint)fb->Height, (uint)fb->Pitch);
 
             // Update mode to match actual framebuffer resolution
             this._mode = new Mode((uint)fb->Width, (uint)fb->Height, mode.ColorDepth);
@@ -56,12 +56,12 @@ internal class GopCanvas : Canvas
         }
     }
 
-    [MemberNotNull(nameof(driver))]
+    [MemberNotNull(nameof(_driver))]
     private void ThrowIfDriverNotInitialized()
     {
-        if (driver is null)
+        if (_driver is null)
         {
-            throw new Exception($"{nameof(driver)} not initialized");
+            throw new Exception($"{nameof(_driver)} not initialized");
         }
     }
 
@@ -116,7 +116,7 @@ internal class GopCanvas : Canvas
 
     public override void Disable()
     {
-        //driver.DisableDisplay();
+        //_driver.DisableDisplay();
     }
 
     public override string Name() => "GopCanvas";
@@ -134,9 +134,9 @@ internal class GopCanvas : Canvas
             // framebuffer size is also deliberately NOT checked against
             // AvailableModes — that legacy VBE list doesn't contain every mode
             // firmware can hand us (e.g. 1280x800).
-            if (driver != null)
+            if (_driver != null)
             {
-                _mode = new Mode(driver.Width, driver.Height, value.ColorDepth);
+                _mode = new Mode(_driver.Width, _driver.Height, value.ColorDepth);
             }
             else
             {
@@ -199,7 +199,7 @@ internal class GopCanvas : Canvas
         new Mode(1920, 1200, ColorDepth.ColorDepth32),
     };
 
-    public override Mode DefaultGraphicsMode => defaultMode;
+    public override Mode DefaultGraphicsMode => s_defaultMode;
 
     /// <summary>
     /// Sets the used display mode, disabling text mode if it is active.
@@ -212,7 +212,7 @@ internal class GopCanvas : Canvas
         ushort yres = (ushort)Mode.Height;
         ushort bpp = (ushort)Mode.ColorDepth;
 
-        //driver.VBESet(xres, yres, bpp);
+        //_driver.VBESet(xres, yres, bpp);
     }
     #endregion
 
@@ -238,7 +238,7 @@ internal class GopCanvas : Canvas
                 throw new NotImplementedException();
             case ColorDepth.ColorDepth32:
                 ThrowIfDriverNotInitialized();
-                driver.ClearScreen((uint)aColor);
+                _driver.ClearScreen((uint)aColor);
                 break;
             default:
                 throw new NotImplementedException();
@@ -265,7 +265,7 @@ internal class GopCanvas : Canvas
                 throw new NotImplementedException();
             case ColorDepth.ColorDepth32:
                 ThrowIfDriverNotInitialized();
-                driver.ClearScreen((uint)aColor.ToArgb());
+                _driver.ClearScreen((uint)aColor.ToArgb());
                 break;
             default:
                 throw new NotImplementedException();
@@ -306,14 +306,14 @@ internal class GopCanvas : Canvas
                     aColor = AlphaBlend(aColor, GetPointColor(aX, aY), aColor.A);
                 }
 
-                driver.DrawPixel((uint)aColor.ToArgb(), aX, aY);
+                _driver.DrawPixel((uint)aColor.ToArgb(), aX, aY);
 
                 break;
             case ColorDepth.ColorDepth24:
 
                 //offset = (uint)GetPointOffset(aX, aY);
 
-                driver.DrawPixel((uint)aColor.ToArgb(), aX, aY);
+                _driver.DrawPixel((uint)aColor.ToArgb(), aX, aY);
 
                 break;
             default:
@@ -331,13 +331,13 @@ internal class GopCanvas : Canvas
             case ColorDepth.ColorDepth32:
                 //offset = (uint)GetPointOffset(aX, aY);
 
-                driver.DrawPixel(aColor, aX, aY);
+                _driver.DrawPixel(aColor, aX, aY);
 
                 break;
             case ColorDepth.ColorDepth24:
                 //offset = (uint)GetPointOffset(aX, aY);
 
-                driver.DrawPixel(aColor, aX, aY);
+                _driver.DrawPixel(aColor, aX, aY);
 
                 break;
             default:
@@ -363,21 +363,21 @@ internal class GopCanvas : Canvas
             pixels[i] = (uint)aColors[i].ToArgb();
         }
 
-        driver.CopyBuffer(pixels.AsMemory(), aX, aY, aWidth, aHeight);
+        _driver.CopyBuffer(pixels.AsMemory(), aX, aY, aWidth, aHeight);
     }
 
     public override void DrawArray(int[] aColors, int aX, int aY, int aWidth, int aHeight)
     {
         ThrowIfDriverNotInitialized();
 
-        driver.CopyBuffer(aColors.AsMemory(), aX, aY, aWidth, aHeight);
+        _driver.CopyBuffer(aColors.AsMemory(), aX, aY, aWidth, aHeight);
     }
 
     public override void DrawArray(int[] aColors, int aX, int aY, int aWidth, int aHeight, int startIndex)
     {
         ThrowIfDriverNotInitialized();
 
-        driver.CopyBuffer(aColors.AsMemory(startIndex), aX, aY, aWidth, aHeight);
+        _driver.CopyBuffer(aColors.AsMemory(startIndex), aX, aY, aWidth, aHeight);
     }
 
     public override void DrawFilledRectangle(Color aColor, int aX, int aY, int aWidth, int aHeight, bool preventOffBoundPixels = true)
@@ -406,7 +406,7 @@ internal class GopCanvas : Canvas
         var color = aColor.ToArgb();
         for (int i = aY; i < aY + aHeight; i++)
         {
-            driver.ClearVRAM((int)((i * driver.Pitch) + (aX * 4)), aWidth, color);
+            _driver.ClearVRAM((int)((i * _driver.Pitch) + (aX * 4)), aWidth, color);
         }
     }
 
@@ -481,7 +481,7 @@ internal class GopCanvas : Canvas
             // If no cropping needed, use CopyBuffer directly
             if (sourceX == 0 && sourceY == 0 && maxWidth == width && maxHeight == height)
             {
-                driver.CopyBuffer(data.AsMemory(), startX, startY, width, height);
+                _driver.CopyBuffer(data.AsMemory(), startX, startY, width, height);
             }
             else
             {
@@ -489,13 +489,13 @@ internal class GopCanvas : Canvas
                 for (int i = 0; i < maxHeight; i++)
                 {
                     int sourceIndex = (sourceY + i) * width + sourceX;
-                    driver.CopyBuffer(data.AsMemory(sourceIndex, maxWidth), startX, startY + i, maxWidth, 1);
+                    _driver.CopyBuffer(data.AsMemory(sourceIndex, maxWidth), startX, startY + i, maxWidth, 1);
                 }
             }
         }
         else
         {
-            driver.CopyBuffer(data.AsMemory(), x, y, width, height);
+            _driver.CopyBuffer(data.AsMemory(), x, y, width, height);
         }
     }
 
@@ -529,7 +529,7 @@ internal class GopCanvas : Canvas
             // If no cropping needed, use CopyBuffer directly
             if (sourceX == 0 && sourceY == 0 && maxWidth == xWidth && maxHeight == xHeight)
             {
-                driver.CopyBuffer(xBitmap.AsMemory(), startX, startY, xWidth, xHeight);
+                _driver.CopyBuffer(xBitmap.AsMemory(), startX, startY, xWidth, xHeight);
             }
             else
             {
@@ -537,13 +537,13 @@ internal class GopCanvas : Canvas
                 for (int i = 0; i < maxHeight; i++)
                 {
                     int sourceIndex = (sourceY + i) * xWidth + sourceX;
-                    driver.CopyBuffer(xBitmap.AsMemory(sourceIndex, maxWidth), startX, startY + i, maxWidth, 1);
+                    _driver.CopyBuffer(xBitmap.AsMemory(sourceIndex, maxWidth), startX, startY + i, maxWidth, 1);
                 }
             }
         }
         else
         {
-            driver.CopyBuffer(xBitmap.AsMemory(), aX, aY, xWidth, xHeight);
+            _driver.CopyBuffer(xBitmap.AsMemory(), aX, aY, xWidth, xHeight);
         }
     }
 
@@ -554,7 +554,7 @@ internal class GopCanvas : Canvas
         var srcBuffer = canvas.GetBuffer();
         if (srcBuffer != null)
         {
-            driver.CopyBuffer(srcBuffer.AsMemory(), x, y, canvas.Width, canvas.Height);
+            _driver.CopyBuffer(srcBuffer.AsMemory(), x, y, canvas.Width, canvas.Height);
         }
         else
         {
@@ -566,7 +566,7 @@ internal class GopCanvas : Canvas
 
     public override void Display()
     {
-        driver?.Swap();
+        _driver?.Swap();
     }
 
     #region Reading
@@ -575,14 +575,14 @@ internal class GopCanvas : Canvas
     {
         ThrowIfDriverNotInitialized();
 
-        return Color.FromArgb((int)driver.GetPixel(aX, aY));
+        return Color.FromArgb((int)_driver.GetPixel(aX, aY));
     }
 
     public override int GetRawPointColor(int aX, int aY)
     {
         ThrowIfDriverNotInitialized();
 
-        return (int)driver.GetPixel(aX, aY);
+        return (int)_driver.GetPixel(aX, aY);
     }
 
     public override Bitmap GetImage(int x, int y, int width, int height)
@@ -603,10 +603,10 @@ internal class GopCanvas : Canvas
 
         for (int posy = startY; posy < endY; posy++)
         {
-            int srcOffset = (int)(posy * driver.Pitch + startX * 4);
+            int srcOffset = (int)(posy * _driver.Pitch + startX * 4);
             int destOffset = (posy - startY + offsetY) * width + offsetX;
 
-            driver.GetVRAM(srcOffset, rawData, destOffset, endX - startX);
+            _driver.GetVRAM(srcOffset, rawData, destOffset, endX - startX);
         }
 
         bitmap.RawData = rawData;

--- a/src/Cosmos.Kernel.System/Graphics/KernelConsole.cs
+++ b/src/Cosmos.Kernel.System/Graphics/KernelConsole.cs
@@ -48,7 +48,7 @@ public class KernelConsole
     private bool _cursorDrawn = false;
 
     // Console color palette (standard 16 colors)
-    private static readonly uint[] _palette =
+    private static readonly uint[] s_palette =
     [
         0xFF000000, // Black
         0xFF000080, // DarkBlue
@@ -265,7 +265,7 @@ public class KernelConsole
     /// </summary>
     public void SetForegroundColor(ConsoleColor color)
     {
-        _foregroundColor = _palette[(int)color];
+        _foregroundColor = s_palette[(int)color];
     }
 
     /// <summary>
@@ -273,7 +273,7 @@ public class KernelConsole
     /// </summary>
     public void SetBackgroundColor(ConsoleColor color)
     {
-        _backgroundColor = _palette[(int)color];
+        _backgroundColor = s_palette[(int)color];
     }
 
     /// <summary>
@@ -281,7 +281,7 @@ public class KernelConsole
     /// </summary>
     public static uint ConsoleColorToUint(ConsoleColor color)
     {
-        return _palette[(int)color];
+        return s_palette[(int)color];
     }
 
     /// <summary>

--- a/src/Cosmos.Kernel.System/Keyboard/KeyboardManager.cs
+++ b/src/Cosmos.Kernel.System/Keyboard/KeyboardManager.cs
@@ -18,10 +18,10 @@ public static class KeyboardManager
     /// </summary>
     public static bool IsEnabled => CosmosFeatures.KeyboardEnabled;
 
-    private static List<IKeyboardDevice>? _keyboards;
-    private static Queue<KeyEvent>? _queuedKeys;
-    private static ScanMapBase? _scanMap;
-    private static bool _initialized;
+    private static List<IKeyboardDevice>? s_keyboards;
+    private static Queue<KeyEvent>? s_queuedKeys;
+    private static ScanMapBase? s_scanMap;
+    private static bool s_initialized;
 
     /// <summary>
     /// The num-lock state.
@@ -56,7 +56,7 @@ public static class KeyboardManager
     /// <summary>
     /// Whether a keyboard input is pending to be processed.
     /// </summary>
-    public static bool KeyAvailable => _queuedKeys != null && _queuedKeys.Count > 0;
+    public static bool KeyAvailable => s_queuedKeys != null && s_queuedKeys.Count > 0;
 
     private static void ThrowIfDisabled()
     {
@@ -74,16 +74,16 @@ public static class KeyboardManager
     {
         ThrowIfDisabled();
 
-        if (_initialized)
+        if (s_initialized)
         {
             return;
         }
 
-        _keyboards = new List<IKeyboardDevice>();
-        _queuedKeys = new Queue<KeyEvent>();
-        _scanMap = new USStandardLayout();
+        s_keyboards = new List<IKeyboardDevice>();
+        s_queuedKeys = new Queue<KeyEvent>();
+        s_scanMap = new USStandardLayout();
 
-        _initialized = true;
+        s_initialized = true;
     }
 
     /// <summary>
@@ -91,19 +91,19 @@ public static class KeyboardManager
     /// </summary>
     public static void RegisterKeyboard(IKeyboardDevice keyboard)
     {
-        if (_keyboards == null || keyboard == null)
+        if (s_keyboards == null || keyboard == null)
         {
             return;
         }
 
         keyboard.OnKeyPressed = HandleScanCode;
-        _keyboards.Add(keyboard);
+        s_keyboards.Add(keyboard);
 
         // Enable keyboard after callback is set (this registers IRQ handler)
         keyboard.Enable();
 
         Cosmos.Kernel.Core.IO.Serial.Write("[KeyboardManager] Registered keyboard, total: ");
-        Cosmos.Kernel.Core.IO.Serial.WriteNumber((uint)_keyboards.Count);
+        Cosmos.Kernel.Core.IO.Serial.WriteNumber((uint)s_keyboards.Count);
         Cosmos.Kernel.Core.IO.Serial.Write("\n");
     }
 
@@ -112,7 +112,7 @@ public static class KeyboardManager
     /// </summary>
     private static void Enqueue(KeyEvent keyEvent)
     {
-        _queuedKeys?.Enqueue(keyEvent);
+        s_queuedKeys?.Enqueue(keyEvent);
     }
 
     /// <summary>
@@ -120,37 +120,37 @@ public static class KeyboardManager
     /// </summary>
     public static void HandleScanCode(byte scanCode, bool released)
     {
-        if (_scanMap == null)
+        if (s_scanMap == null)
         {
             return;
         }
 
         byte key = scanCode;
 
-        if (_scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.CapsLock) && !released)
+        if (s_scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.CapsLock) && !released)
         {
             CapsLock = !CapsLock;
             UpdateLeds();
         }
-        else if (_scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.NumLock) && !released)
+        else if (s_scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.NumLock) && !released)
         {
             NumLock = !NumLock;
             UpdateLeds();
         }
-        else if (_scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.ScrollLock) && !released)
+        else if (s_scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.ScrollLock) && !released)
         {
             ScrollLock = !ScrollLock;
             UpdateLeds();
         }
-        else if (_scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.LCtrl) || _scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.RCtrl))
+        else if (s_scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.LCtrl) || s_scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.RCtrl))
         {
             ControlPressed = !released;
         }
-        else if (_scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.LShift) || _scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.RShift))
+        else if (s_scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.LShift) || s_scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.RShift))
         {
             ShiftPressed = !released;
         }
-        else if (_scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.LAlt) || _scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.RAlt))
+        else if (s_scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.LAlt) || s_scanMap.ScanCodeMatchesKey(key, ConsoleKeyEx.RAlt))
         {
             AltPressed = !released;
         }
@@ -171,12 +171,12 @@ public static class KeyboardManager
     /// </summary>
     private static void UpdateLeds()
     {
-        if (_keyboards == null)
+        if (s_keyboards == null)
         {
             return;
         }
 
-        foreach (IKeyboardDevice keyboard in _keyboards)
+        foreach (IKeyboardDevice keyboard in s_keyboards)
         {
             keyboard.UpdateLeds();
         }
@@ -189,12 +189,12 @@ public static class KeyboardManager
     /// <exception cref="InvalidOperationException"></exception>
     public static KeyEvent Peek()
     {
-        if (_queuedKeys == null)
+        if (s_queuedKeys == null)
         {
             throw new InvalidOperationException("KeyboardManager not initialized!");
         }
 
-        return _queuedKeys.Peek();
+        return s_queuedKeys.Peek();
     }
 
     /// <summary>
@@ -202,12 +202,12 @@ public static class KeyboardManager
     /// </summary>
     public static bool GetKey(byte scanCode, out KeyEvent? keyInfo)
     {
-        if (_scanMap == null)
+        if (s_scanMap == null)
         {
             keyInfo = null;
             return false;
         }
-        keyInfo = _scanMap.ConvertScanCode(scanCode, ControlPressed, ShiftPressed, AltPressed, NumLock, CapsLock, ScrollLock);
+        keyInfo = s_scanMap.ConvertScanCode(scanCode, ControlPressed, ShiftPressed, AltPressed, NumLock, CapsLock, ScrollLock);
         return keyInfo != null;
     }
 
@@ -218,9 +218,9 @@ public static class KeyboardManager
     {
         ThrowIfDisabled();
 
-        if (_queuedKeys != null && _queuedKeys.Count > 0)
+        if (s_queuedKeys != null && s_queuedKeys.Count > 0)
         {
-            key = _queuedKeys.Dequeue();
+            key = s_queuedKeys.Dequeue();
             return true;
         }
 
@@ -228,7 +228,7 @@ public static class KeyboardManager
         return false;
     }
 
-    private static bool _readKeyEntered = false;
+    private static bool s_readKeyEntered = false;
 
     /// <summary>
     /// Reads the next key from the pending key-press buffer, blocking until available.
@@ -237,13 +237,13 @@ public static class KeyboardManager
     {
         ThrowIfDisabled();
 
-        if (!_readKeyEntered)
+        if (!s_readKeyEntered)
         {
-            _readKeyEntered = true;
+            s_readKeyEntered = true;
             Cosmos.Kernel.Core.IO.Serial.Write("[KeyboardManager] ReadKey() entered\n");
         }
 
-        while (_queuedKeys == null || _queuedKeys.Count == 0)
+        while (s_queuedKeys == null || s_queuedKeys.Count == 0)
         {
             // Poll all keyboards for events (in case interrupts aren't working)
             PollKeyboards();
@@ -252,40 +252,40 @@ public static class KeyboardManager
             HAL.PlatformHAL.CpuOps?.Halt();
         }
 
-        return _queuedKeys.Dequeue();
+        return s_queuedKeys.Dequeue();
     }
 
-    private static uint _pollCallCount = 0;
+    private static uint s_pollCallCount = 0;
 
-    private static bool _pollEntered = false;
+    private static bool s_pollEntered = false;
 
     /// <summary>
     /// Polls all registered keyboards for events.
     /// </summary>
     private static void PollKeyboards()
     {
-        if (!_pollEntered)
+        if (!s_pollEntered)
         {
-            _pollEntered = true;
+            s_pollEntered = true;
             Cosmos.Kernel.Core.IO.Serial.Write("[KeyboardManager] PollKeyboards() first call\n");
         }
 
-        if (_keyboards == null)
+        if (s_keyboards == null)
         {
             return;
         }
 
-        _pollCallCount++;
-        if (_pollCallCount % 100 == 0)
+        s_pollCallCount++;
+        if (s_pollCallCount % 100 == 0)
         {
             Cosmos.Kernel.Core.IO.Serial.Write("[KeyboardManager] PollKeyboards #");
-            Cosmos.Kernel.Core.IO.Serial.WriteNumber(_pollCallCount);
+            Cosmos.Kernel.Core.IO.Serial.WriteNumber(s_pollCallCount);
             Cosmos.Kernel.Core.IO.Serial.Write(" keyboards=");
-            Cosmos.Kernel.Core.IO.Serial.WriteNumber((uint)_keyboards.Count);
+            Cosmos.Kernel.Core.IO.Serial.WriteNumber((uint)s_keyboards.Count);
             Cosmos.Kernel.Core.IO.Serial.Write("\n");
         }
 
-        foreach (var keyboard in _keyboards)
+        foreach (var keyboard in s_keyboards)
         {
             keyboard.Poll();
         }
@@ -294,7 +294,7 @@ public static class KeyboardManager
     /// <summary>
     /// Gets the currently used keyboard layout.
     /// </summary>
-    public static ScanMapBase? GetKeyLayout() => _scanMap;
+    public static ScanMapBase? GetKeyLayout() => s_scanMap;
 
     /// <summary>
     /// Sets the currently used keyboard layout.
@@ -303,7 +303,7 @@ public static class KeyboardManager
     {
         if (scanMap != null)
         {
-            _scanMap = scanMap;
+            s_scanMap = scanMap;
         }
     }
 

--- a/src/Cosmos.Kernel.System/Mouse/MouseManager.cs
+++ b/src/Cosmos.Kernel.System/Mouse/MouseManager.cs
@@ -16,8 +16,8 @@ public static class MouseManager
     /// </summary>
     public static bool IsEnabled => CosmosFeatures.MouseEnabled;
 
-    private static List<IMouseDevice>? _mice;
-    private static bool _initialized;
+    private static List<IMouseDevice>? s_mice;
+    private static bool s_initialized;
 
     /// <summary>
     /// Current X position (screen coordinates).
@@ -87,16 +87,16 @@ public static class MouseManager
     {
         ThrowIfDisabled();
 
-        if (_initialized)
+        if (s_initialized)
         {
             return;
         }
 
-        _mice = new List<IMouseDevice>();
+        s_mice = new List<IMouseDevice>();
         X = ScreenWidth / 2;
         Y = ScreenHeight / 2;
 
-        _initialized = true;
+        s_initialized = true;
     }
 
     /// <summary>
@@ -104,7 +104,7 @@ public static class MouseManager
     /// </summary>
     public static void RegisterMouse(IMouseDevice mouse)
     {
-        if (_mice == null || mouse == null)
+        if (s_mice == null || mouse == null)
         {
             return;
         }
@@ -115,13 +115,13 @@ public static class MouseManager
             mouseDevice.OnMouseEvent = HandleMouseEvent;
         }
 
-        _mice.Add(mouse);
+        s_mice.Add(mouse);
 
         // Enable mouse after callback is set
         mouse.Enable();
 
         Cosmos.Kernel.Core.IO.Serial.Write("[MouseManager] Registered mouse, total: ");
-        Cosmos.Kernel.Core.IO.Serial.WriteNumber((uint)_mice.Count);
+        Cosmos.Kernel.Core.IO.Serial.WriteNumber((uint)s_mice.Count);
         Cosmos.Kernel.Core.IO.Serial.Write("\n");
     }
 
@@ -171,12 +171,12 @@ public static class MouseManager
     /// </summary>
     public static void Poll()
     {
-        if (_mice == null)
+        if (s_mice == null)
         {
             return;
         }
 
-        foreach (var mouse in _mice)
+        foreach (var mouse in s_mice)
         {
             mouse.Poll();
         }

--- a/src/Cosmos.Kernel.System/Network/Config/IPConfig.cs
+++ b/src/Cosmos.Kernel.System/Network/Config/IPConfig.cs
@@ -9,14 +9,14 @@ namespace Cosmos.Kernel.System.Network.Config;
 /// </summary>
 public class IPConfig
 {
-    private static readonly List<IPConfig> ipConfigs = new();
+    private static readonly List<IPConfig> s_ipConfigs = new();
 
     /// <summary>
     /// Add the given IPv4 configuration.
     /// </summary>
     internal static void Add(IPConfig config)
     {
-        ipConfigs.Add(config);
+        s_ipConfigs.Add(config);
     }
 
     /// <summary>
@@ -24,7 +24,7 @@ public class IPConfig
     /// </summary>
     internal static void Remove(IPConfig config)
     {
-        ipConfigs.Remove(config);
+        s_ipConfigs.Remove(config);
     }
 
     /// <summary>
@@ -32,7 +32,7 @@ public class IPConfig
     /// </summary>
     internal static void RemoveAll()
     {
-        ipConfigs.Clear();
+        s_ipConfigs.Clear();
     }
 
     /// <summary>
@@ -43,7 +43,7 @@ public class IPConfig
     {
         Address? defaultGw = null;
 
-        foreach (IPConfig ipConfig in ipConfigs)
+        foreach (IPConfig ipConfig in s_ipConfigs)
         {
             if ((ipConfig.IPAddress.Id & ipConfig.SubnetMask.Id) ==
                 (destIP.Id & ipConfig.SubnetMask.Id))
@@ -90,10 +90,10 @@ public class IPConfig
     /// <param name="destIP">The address to check.</param>
     internal static bool IsLocalAddress(Address destIP)
     {
-        for (int c = 0; c < ipConfigs.Count; c++)
+        for (int c = 0; c < s_ipConfigs.Count; c++)
         {
-            if ((ipConfigs[c].IPAddress.Id & ipConfigs[c].SubnetMask.Id) ==
-                (destIP.Id & ipConfigs[c].SubnetMask.Id))
+            if ((s_ipConfigs[c].IPAddress.Id & s_ipConfigs[c].SubnetMask.Id) ==
+                (destIP.Id & s_ipConfigs[c].SubnetMask.Id))
             {
                 return true;
             }
@@ -123,9 +123,9 @@ public class IPConfig
     internal static Address? FindRoute(Address destIP)
     {
         // TODO is this correct implementation?
-        for (int c = 0; c < ipConfigs.Count; c++)
+        for (int c = 0; c < s_ipConfigs.Count; c++)
         {
-            return ipConfigs[c].DefaultGateway;
+            return s_ipConfigs[c].DefaultGateway;
         }
 
         return null;

--- a/src/Cosmos.Kernel.System/Network/IPv4/ICMPClient.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/ICMPClient.cs
@@ -8,17 +8,17 @@ namespace Cosmos.Kernel.System.Network.IPv4;
 /// </summary>
 public class ICMPClient : IDisposable
 {
-    private static readonly Dictionary<uint, ICMPClient> clients = new();
+    private static readonly Dictionary<uint, ICMPClient> s_clients = new();
 
     /// <summary>
-    /// The destination address.
+    /// The _destination address.
     /// </summary>
-    internal Address? destination;
+    internal Address? _destination;
 
     /// <summary>
     /// The RX buffer queue.
     /// </summary>
-    internal Queue<ICMPPacket> rxBuffer;
+    internal Queue<ICMPPacket> _rxBuffer;
 
     /// <summary>
     /// Gets a client by its IP address hash.
@@ -27,7 +27,7 @@ public class ICMPClient : IDisposable
     /// <returns>If a client is connected to the given address, the <see cref="ICMPClient"/>; otherwise, <see langword="null"/>.</returns>
     internal static ICMPClient? GetClient(uint iphash)
     {
-        if (clients.TryGetValue(iphash, out var client))
+        if (s_clients.TryGetValue(iphash, out var client))
         {
             return client;
         }
@@ -39,17 +39,17 @@ public class ICMPClient : IDisposable
     /// </summary>
     public ICMPClient()
     {
-        rxBuffer = new Queue<ICMPPacket>(8);
+        _rxBuffer = new Queue<ICMPPacket>(8);
     }
 
     /// <summary>
     /// Connects to the given client.
     /// </summary>
-    /// <param name="dest">The destination address.</param>
+    /// <param name="dest">The _destination address.</param>
     public void Connect(Address dest)
     {
-        destination = dest;
-        clients[dest.Id] = this;
+        _destination = dest;
+        s_clients[dest.Id] = this;
     }
 
     /// <summary>
@@ -57,26 +57,26 @@ public class ICMPClient : IDisposable
     /// </summary>
     public void Close()
     {
-        if (destination != null && clients.ContainsKey(destination.Id))
+        if (_destination != null && s_clients.ContainsKey(_destination.Id))
         {
-            clients.Remove(destination.Id);
+            s_clients.Remove(_destination.Id);
         }
     }
 
     /// <summary>
-    /// Sends an ICMP echo request to the connected destination.
+    /// Sends an ICMP echo request to the connected _destination.
     /// </summary>
     /// <param name="id">The echo identifier.</param>
     /// <param name="sequence">The echo sequence number.</param>
     public void SendEcho(ushort id = 0x0001, ushort sequence = 0x0001)
     {
-        if (destination == null)
+        if (_destination == null)
         {
-            throw new InvalidOperationException("Must establish a destination by calling Connect() before using SendEcho()");
+            throw new InvalidOperationException("Must establish a _destination by calling Connect() before using SendEcho()");
         }
 
-        Address source = IPConfig.FindNetwork(destination) ?? throw new InvalidOperationException("No network route to destination");
-        var request = new ICMPEchoRequest(source, destination, id, sequence);
+        Address source = IPConfig.FindNetwork(_destination) ?? throw new InvalidOperationException("No network route to _destination");
+        var request = new ICMPEchoRequest(source, _destination, id, sequence);
         OutgoingBuffer.AddPacket(request);
         NetworkStack.Update();
     }
@@ -90,18 +90,18 @@ public class ICMPClient : IDisposable
     public int Receive(ref EndPoint source, int timeout = 5000)
     {
         int waited = 0;
-        while (rxBuffer.Count < 1 && waited < timeout)
+        while (_rxBuffer.Count < 1 && waited < timeout)
         {
             TimerManager.Wait(10);
             waited += 10;
         }
 
-        if (rxBuffer.Count < 1)
+        if (_rxBuffer.Count < 1)
         {
             return -1;
         }
 
-        var packet = new ICMPEchoReply(rxBuffer.Dequeue().RawData);
+        var packet = new ICMPEchoReply(_rxBuffer.Dequeue().RawData);
         source.Address = packet.SourceIP;
 
         return waited;
@@ -113,7 +113,7 @@ public class ICMPClient : IDisposable
     /// <param name="packet">The packet to receive.</param>
     internal void ReceiveData(ICMPPacket packet)
     {
-        rxBuffer.Enqueue(packet);
+        _rxBuffer.Enqueue(packet);
     }
 
     public void Dispose()

--- a/src/Cosmos.Kernel.System/Network/IPv4/IPPacket.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/IPPacket.cs
@@ -12,7 +12,7 @@ namespace Cosmos.Kernel.System.Network.IPv4;
 public class IPPacket : EthernetPacket
 {
     protected byte ipHeaderLength;
-    private static ushort sNextFragmentID;
+    private static ushort s_sNextFragmentID;
 
     /// <summary>
     /// Handles a single IPv4 packet.
@@ -66,7 +66,7 @@ public class IPPacket : EthernetPacket
     /// <summary>
     /// Gets the next IP fragment ID.
     /// </summary>
-    public static ushort NextIPFragmentID => sNextFragmentID++;
+    public static ushort NextIPFragmentID => s_sNextFragmentID++;
 
     /// <summary>
     /// Create new instance of the <see cref="IPPacket"/> class.

--- a/src/Cosmos.Kernel.System/Network/IPv4/OutgoingBuffer.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/OutgoingBuffer.cs
@@ -50,17 +50,17 @@ public static class OutgoingBuffer
     }
 
     /// <summary>
-    /// The buffer queue. Initialized eagerly to avoid issues with interrupt context.
+    /// The buffer s_queue. Initialized eagerly to avoid issues with interrupt context.
     /// </summary>
-    private static List<BufferEntry> queue = new();
+    private static List<BufferEntry> s_queue = new();
 
     /// <summary>
-    /// Ensures the queue exists and is initialized.
+    /// Ensures the s_queue exists and is initialized.
     /// </summary>
     private static void EnsureQueueExists()
     {
         // Queue is now initialized at class load time, but keep this for safety
-        queue ??= new List<BufferEntry>();
+        s_queue ??= new List<BufferEntry>();
     }
 
     /// <summary>
@@ -85,7 +85,7 @@ public static class OutgoingBuffer
     {
         EnsureQueueExists();
         packet.SourceMAC = device.MacAddress;
-        queue.Add(new BufferEntry(device, packet));
+        s_queue.Add(new BufferEntry(device, packet));
     }
 
     /// <summary>
@@ -97,19 +97,19 @@ public static class OutgoingBuffer
         int iterations = 0;
         int maxIterations = 10000; // Spin-based timeout
 
-        while (queue.Count > 0)
+        while (s_queue.Count > 0)
         {
             iterations++;
             if (iterations >= maxIterations)
             {
                 Serial.WriteString("[OutgoingBuffer] ARP timeout\n");
-                queue.Clear();
+                s_queue.Clear();
                 break;
             }
 
-            for (int e = queue.Count - 1; e >= 0; e--)
+            for (int e = s_queue.Count - 1; e >= 0; e--)
             {
-                BufferEntry entry = queue[e];
+                BufferEntry entry = s_queue[e];
                 if (entry.Status == BufferEntry.EntryStatus.ADDED)
                 {
                     if (IPConfig.IsLocalAddress(entry.Packet.DestinationIP) == false)
@@ -117,7 +117,7 @@ public static class OutgoingBuffer
                         entry.NextHop = IPConfig.FindRoute(entry.Packet.DestinationIP);
                         if (entry.NextHop == null)
                         {
-                            queue.RemoveAt(e);
+                            s_queue.RemoveAt(e);
                             continue;
                         }
 
@@ -126,7 +126,7 @@ public static class OutgoingBuffer
                             entry.Packet.DestinationMAC = ARPCache.Resolve(entry.NextHop ?? throw new Exception($"{nameof(entry.NextHop)} can not be null"))
                                 ?? throw new Exception("DestinationMAC can not be null");
                             entry.NIC.Send(entry.Packet.RawData, entry.Packet.RawData.Length);
-                            queue.RemoveAt(e);
+                            s_queue.RemoveAt(e);
                         }
                         else
                         {
@@ -149,7 +149,7 @@ public static class OutgoingBuffer
                                                       ?? throw new Exception("DestinationMAC can not be null");
                         entry.NIC.Send(entry.Packet.RawData, entry.Packet.RawData.Length);
                         Serial.WriteString("[OutgoingBuffer] Sent via ARP cache\n");
-                        queue.RemoveAt(e);
+                        s_queue.RemoveAt(e);
                     }
                     else
                     {
@@ -177,7 +177,7 @@ public static class OutgoingBuffer
                         entry.Packet.DestinationMAC = ARPCache.Resolve(entry.Packet.DestinationIP)
                             ?? throw new Exception("DestinationMAC can not be null");
                         entry.NIC.Send(entry.Packet.RawData, entry.Packet.RawData.Length);
-                        queue.RemoveAt(e);
+                        s_queue.RemoveAt(e);
                     }
                 }
                 else if (entry.Status == BufferEntry.EntryStatus.ROUTE_ARP_SENT)
@@ -187,23 +187,23 @@ public static class OutgoingBuffer
                         entry.Packet.DestinationMAC = ARPCache.Resolve(entry.NextHop)
                                                       ?? throw new Exception("DestinationMAC can not be null");
                         entry.NIC.Send(entry.Packet.RawData, entry.Packet.RawData.Length);
-                        queue.RemoveAt(e);
+                        s_queue.RemoveAt(e);
                     }
                 }
                 else if (entry.Status == BufferEntry.EntryStatus.DHCP_REQUEST)
                 {
                     entry.NIC.Send(entry.Packet.RawData, entry.Packet.RawData.Length);
-                    queue.RemoveAt(e);
+                    s_queue.RemoveAt(e);
                 }
                 else if (entry.Status == BufferEntry.EntryStatus.JUST_SEND)
                 {
                     entry.NIC.Send(entry.Packet.RawData, entry.Packet.RawData.Length);
-                    queue.RemoveAt(e);
+                    s_queue.RemoveAt(e);
                 }
             }
 
             // Spin to allow interrupt processing (ARP replies)
-            if (queue.Count > 0)
+            if (s_queue.Count > 0)
             {
                 Thread.SpinWait(10000);
             }
@@ -217,9 +217,9 @@ public static class OutgoingBuffer
     internal static void UpdateARPCache(ARPReplyEthernet arpReply)
     {
         EnsureQueueExists();
-        for (int e = 0; e < queue.Count; e++)
+        for (int e = 0; e < s_queue.Count; e++)
         {
-            BufferEntry entry = queue[e];
+            BufferEntry entry = s_queue[e];
             if (entry.Status == BufferEntry.EntryStatus.ARP_SENT)
             {
                 if (entry.Packet.DestinationIP.CompareTo(arpReply.SenderIP) == 0)

--- a/src/Cosmos.Kernel.System/Network/IPv4/TCP/TCPPacket.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/TCP/TCPPacket.cs
@@ -192,12 +192,12 @@ public class TCPPacket : IPPacket
         Checksum = (ushort)((RawData[DataOffset + 16] << 8) | RawData[DataOffset + 17]);
         UrgentPointer = (ushort)((RawData[DataOffset + 18] << 8) | RawData[DataOffset + 19]);
 
-        SYN = (RawData[47] & (byte)Flags.SYN) != 0;
-        ACK = (RawData[47] & (byte)Flags.ACK) != 0;
-        FIN = (RawData[47] & (byte)Flags.FIN) != 0;
-        PSH = (RawData[47] & (byte)Flags.PSH) != 0;
-        RST = (RawData[47] & (byte)Flags.RST) != 0;
-        URG = (RawData[47] & (byte)Flags.URG) != 0;
+        _syn = (RawData[47] & (byte)Flags.SYN) != 0;
+        _ack = (RawData[47] & (byte)Flags.ACK) != 0;
+        _fin = (RawData[47] & (byte)Flags.FIN) != 0;
+        _psh = (RawData[47] & (byte)Flags.PSH) != 0;
+        _rst = (RawData[47] & (byte)Flags.RST) != 0;
+        _urg = (RawData[47] & (byte)Flags.URG) != 0;
 
         if (TCPHeaderLength > 20) //options
         {
@@ -297,27 +297,27 @@ public class TCPPacket : IPPacket
     /// <summary>
     /// Is SYN Flag set.
     /// </summary>
-    internal bool SYN;
+    internal bool _syn;
     /// <summary>
     /// Is ACK Flag set.
     /// </summary>
-    internal bool ACK;
+    internal bool _ack;
     /// <summary>
     /// Is FIN Flag set.
     /// </summary>
-    internal bool FIN;
+    internal bool _fin;
     /// <summary>
     /// Is PSH Flag set.
     /// </summary>
-    internal bool PSH;
+    internal bool _psh;
     /// <summary>
     /// Is RST Flag set.
     /// </summary>
-    internal bool RST;
+    internal bool _rst;
     /// <summary>
     /// Is URG Flag set.
     /// </summary>
-    internal bool URG;
+    internal bool _urg;
 
     /// <summary>
     /// Get destination port.
@@ -386,32 +386,32 @@ public class TCPPacket : IPPacket
     {
         string flags = "";
 
-        if (FIN)
+        if (_fin)
         {
             flags += "FIN|";
         }
 
-        if (SYN)
+        if (_syn)
         {
             flags += "SYN|";
         }
 
-        if (RST)
+        if (_rst)
         {
             flags += "RST|";
         }
 
-        if (PSH)
+        if (_psh)
         {
             flags += "PSH|";
         }
 
-        if (ACK)
+        if (_ack)
         {
             flags += "ACK|";
         }
 
-        if (URG)
+        if (_urg)
         {
             flags += "URG|";
         }

--- a/src/Cosmos.Kernel.System/Network/IPv4/TCP/Tcp.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/TCP/Tcp.cs
@@ -435,7 +435,7 @@ public class Tcp : IDisposable
             }
             else
             {
-                if (!packet.RST)
+                if (!packet._rst)
                 {
                     SendEmptyPacket(Flags.ACK);
                 }
@@ -452,22 +452,22 @@ public class Tcp : IDisposable
     /// </summary>
     public void ProcessListen(TCPPacket packet)
     {
-        if (packet.RST)
+        if (packet._rst)
         {
             Serial.WriteString("[TCP] RST received at LISTEN state, packet passed.\n");
         }
-        else if (packet.FIN)
+        else if (packet._fin)
         {
             Serial.WriteString("[TCP] Connection closed! (FIN received on LISTEN state)\n");
         }
-        else if (packet.ACK)
+        else if (packet._ack)
         {
             TCB.RcvNxt = packet.SequenceNumber;
             TCB.SndNxt = packet.AckNumber;
 
             Status = Status.ESTABLISHED;
         }
-        else if (packet.SYN)
+        else if (packet._syn)
         {
             LocalEndPoint.Address = IPConfig.FindNetwork(packet.SourceIP) ?? throw new Exception($"Address can not be null");
             RemoteEndPoint.Address = packet.SourceIP;
@@ -501,7 +501,7 @@ public class Tcp : IDisposable
     /// </summary>
     public void ProcessSynReceived(TCPPacket packet)
     {
-        if (packet.ACK)
+        if (packet._ack)
         {
             if (TCB.SndUna <= packet.AckNumber && packet.AckNumber <= TCB.SndNxt)
             {
@@ -523,12 +523,12 @@ public class Tcp : IDisposable
     /// </summary>
     public void ProcessSynSent(TCPPacket packet)
     {
-        if (packet.SYN)
+        if (packet._syn)
         {
             TCB.IRS = packet.SequenceNumber;
             TCB.RcvNxt = packet.SequenceNumber + 1;
 
-            if (packet.ACK)
+            if (packet._ack)
             {
                 TCB.SndUna = packet.AckNumber;
                 TCB.SndWnd = packet.WindowSize;
@@ -550,7 +550,7 @@ public class Tcp : IDisposable
                 Serial.WriteString("[TCP] Connection closed! (" + packet.GetFlags() + " received on SYN_SENT state)\n");
             }
         }
-        else if (packet.ACK)
+        else if (packet._ack)
         {
             //Check for bad ACK packet
             if ((int)packet.AckNumber - TCB.ISS < 0 || packet.AckNumber - TCB.SndNxt > 0)
@@ -566,12 +566,12 @@ public class Tcp : IDisposable
                 Status = Status.ESTABLISHED;
             }
         }
-        else if (packet.FIN)
+        else if (packet._fin)
         {
             Status = Status.CLOSED;
             Serial.WriteString("[TCP] Connection closed! (FIN received on SYN_SENT state).\n");
         }
-        else if (packet.RST)
+        else if (packet._rst)
         {
             Status = Status.CLOSED;
             Serial.WriteString("[TCP] Connection refused by remote computer.\n");
@@ -583,7 +583,7 @@ public class Tcp : IDisposable
     /// </summary>
     public void ProcessEstablished(TCPPacket packet)
     {
-        if (packet.ACK)
+        if (packet._ack)
         {
             if (TCB.SndUna < packet.AckNumber && packet.AckNumber <= TCB.SndNxt)
             {
@@ -613,7 +613,7 @@ public class Tcp : IDisposable
                 return;
             }
 
-            if (packet.PSH)
+            if (packet._psh)
             {
                 Serial.WriteString("[TCP] PSH received, data length: ");
                 Serial.WriteNumber((ulong)packet.TCP_DataLength);
@@ -628,7 +628,7 @@ public class Tcp : IDisposable
                 Serial.WriteString(" bytes\n");
 
                 // Handle FIN flag within PSH handling if both are set
-                if (packet.FIN)
+                if (packet._fin)
                 {
                     Serial.WriteString("[TCP] PSH+FIN received, closing\n");
                     TCB.RcvNxt++;
@@ -649,7 +649,7 @@ public class Tcp : IDisposable
                 }
                 return;
             }
-            else if (packet.FIN)
+            else if (packet._fin)
             {
                 Serial.WriteString("[TCP] FIN received, closing connection\n");
                 TCB.RcvNxt++;
@@ -668,13 +668,13 @@ public class Tcp : IDisposable
                 AppendToData(packet.TCP_Data);
             }
         }
-        if (packet.RST)
+        if (packet._rst)
         {
             Status = Status.CLOSED;
 
             Serial.WriteString("[TCP] Connection reset!\n");
         }
-        else if (packet.FIN)
+        else if (packet._fin)
         {
             TCB.RcvNxt++;
 
@@ -695,9 +695,9 @@ public class Tcp : IDisposable
     /// </summary>
     public void ProcessFinWait1(TCPPacket packet)
     {
-        if (packet.ACK)
+        if (packet._ack)
         {
-            if (packet.FIN)
+            if (packet._fin)
             {
                 TCB.RcvNxt++;
 
@@ -710,7 +710,7 @@ public class Tcp : IDisposable
                 Status = Status.FIN_WAIT2;
             }
         }
-        else if (packet.FIN)
+        else if (packet._fin)
         {
             TCB.RcvNxt++;
 
@@ -725,7 +725,7 @@ public class Tcp : IDisposable
     /// </summary>
     public void ProcessFinWait2(TCPPacket packet)
     {
-        if (packet.FIN)
+        if (packet._fin)
         {
             TCB.RcvNxt++;
 
@@ -733,7 +733,7 @@ public class Tcp : IDisposable
 
             WaitAndClose();
         }
-        else if (packet.RST)
+        else if (packet._rst)
         {
             Status = Status.CLOSED;
 
@@ -746,7 +746,7 @@ public class Tcp : IDisposable
     /// </summary>
     public void ProcessClosing(TCPPacket packet)
     {
-        if (packet.ACK)
+        if (packet._ack)
         {
             WaitAndClose();
         }
@@ -757,7 +757,7 @@ public class Tcp : IDisposable
     /// </summary>
     public void ProcessCloseWait(TCPPacket packet)
     {
-        if (packet.ACK)
+        if (packet._ack)
         {
             Status = Status.CLOSED;
         }
@@ -859,7 +859,7 @@ public class Tcp : IDisposable
 
         // Increment SndNxt BEFORE NetworkStack.Update() so that incoming packets
         // processed during Update() see the correct value
-        if (packet.SYN || packet.FIN)
+        if (packet._syn || packet._fin)
         {
             TCB.SndNxt++;
         }

--- a/src/Cosmos.Kernel.System/Network/IPv4/UDP/DHCP/DHCPClient.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/UDP/DHCP/DHCPClient.cs
@@ -21,7 +21,7 @@ public class DHCPClient : UdpClient
     /// <summary>
     /// Is DHCP asked check variable
     /// </summary>
-    private bool applied = false;
+    private bool _applied = false;
 
     /// <summary>
     /// Gets the IP address of the DHCP server.
@@ -69,7 +69,7 @@ public class DHCPClient : UdpClient
             }
             else if (packet.RawData[284] == 0x05 || packet.RawData[284] == 0x06) //ACK or NAK DHCP packet received
             {
-                if (!applied)
+                if (!_applied)
                 {
                     Apply(packet, true);
 
@@ -133,7 +133,7 @@ public class DHCPClient : UdpClient
             OutgoingBuffer.AddPacket(dhcpDiscover);
             NetworkStack.Update();
 
-            applied = false;
+            _applied = false;
         }
 
         return Receive();
@@ -167,7 +167,7 @@ public class DHCPClient : UdpClient
     /// <param name="message">Enable/Disable the displaying of messages about DHCP applying and conf.</param>
     private void Apply(DHCPPacket packet, bool message = false)
     {
-        if (applied == false)
+        if (_applied == false)
         {
             NetworkStack.RemoveAllConfigIP();
 
@@ -197,19 +197,19 @@ public class DHCPClient : UdpClient
                         DNSConfig.Add(packet.DNS);
                     }
 
-                    Serial.WriteString("[DHCP CONFIG] IP configuration applied.\n");
+                    Serial.WriteString("[DHCP CONFIG] IP configuration _applied.\n");
 
-                    applied = true;
+                    _applied = true;
 
                     return;
                 }
             }
 
-            Serial.WriteString("[DHCP CONFIG] No DHCP Config applied!\n");
+            Serial.WriteString("[DHCP CONFIG] No DHCP Config _applied!\n");
         }
         else
         {
-            Serial.WriteString("[DHCP CONFIG] DHCP already applied.\n");
+            Serial.WriteString("[DHCP CONFIG] DHCP already _applied.\n");
         }
     }
 }

--- a/src/Cosmos.Kernel.System/Network/IPv4/UDP/DHCP/DHCPPacket.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/UDP/DHCP/DHCPPacket.cs
@@ -37,7 +37,7 @@ public class DHCPOption
 public class DHCPPacket : UDPPacket
 {
     // Simple transaction ID generator
-    private static int idCounter = 1;
+    private static int s_idCounter = 1;
 
     /// <summary>
     /// Handles a single DHCP packet.
@@ -75,7 +75,7 @@ public class DHCPPacket : UDPPacket
         RawData[44] = 0x06; // Length mac
         RawData[45] = 0x00; // hops
 
-        int id = idCounter++;
+        int id = s_idCounter++;
         RawData[46] = (byte)((id >> 24) & 0xFF);
         RawData[47] = (byte)((id >> 16) & 0xFF);
         RawData[48] = (byte)((id >> 8) & 0xFF);

--- a/src/Cosmos.Kernel.System/Network/IPv4/UDP/DNS/DNSClient.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/UDP/DNS/DNSClient.cs
@@ -27,7 +27,7 @@ public class DnsClient : UdpClient
     /// <summary>
     /// Connects to a client.
     /// </summary>
-    /// <param name="address">The destination address.</param>
+    /// <param name="address">The _destination address.</param>
     public void Connect(Address address)
     {
         Connect(address, 53);
@@ -39,15 +39,15 @@ public class DnsClient : UdpClient
     /// <param name="url">The domain name string to query the DNS for.</param>
     public void SendAsk(string url)
     {
-        if (destination is null)
+        if (_destination is null)
         {
             throw new InvalidOperationException("No network route to DNS server. Run 'netconfig' or 'dhcp' first.");
         }
 
-        Address source = IPConfig.FindNetwork(destination)
+        Address source = IPConfig.FindNetwork(_destination)
             ?? throw new InvalidOperationException("No network route to DNS server. Run 'netconfig' or 'dhcp' first.");
         _queryUrl = url;
-        var askpacket = new DNSPacketAsk(source, destination!, url);
+        var askpacket = new DNSPacketAsk(source, _destination!, url);
 
         OutgoingBuffer.AddPacket(askpacket);
         NetworkStack.Update();

--- a/src/Cosmos.Kernel.System/Network/IPv4/UDP/DNS/DNSPacket.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/UDP/DNS/DNSPacket.cs
@@ -63,7 +63,7 @@ public class DNSAnswer
 public class DNSPacket : UDPPacket
 {
     // Simple transaction ID generator
-    private static byte transactionCounter = 1;
+    private static byte s_transactionCounter = 1;
 
     /// <summary>
     /// Handles DNS packets.
@@ -95,7 +95,7 @@ public class DNSPacket : UDPPacket
     public DNSPacket(Address source, Address dest, ushort urlnb, ushort len)
         : base(source, dest, 53, 53, (ushort)(len + 12))
     {
-        byte transactionID = transactionCounter++;
+        byte transactionID = s_transactionCounter++;
         RawData[this.DataOffset + 8] = (byte)((transactionID >> 8) & 0xFF);
         RawData[this.DataOffset + 9] = (byte)((transactionID >> 0) & 0xFF);
 

--- a/src/Cosmos.Kernel.System/Network/IPv4/UDP/UDPPacket.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/UDP/UDPPacket.cs
@@ -15,7 +15,7 @@ public delegate void UDPDataReceivedHandler(UDPPacket packet);
 /// </summary>
 public class UDPPacket : IPPacket
 {
-    private ushort udpCRC;
+    private ushort _udpCRC;
 
     /// <summary>
     /// Callback for receiving UDP data.
@@ -146,7 +146,7 @@ public class UDPPacket : IPPacket
         SourcePort = (ushort)((RawData[DataOffset] << 8) | RawData[DataOffset + 1]);
         DestinationPort = (ushort)((RawData[DataOffset + 2] << 8) | RawData[DataOffset + 3]);
         UDPLength = (ushort)((RawData[DataOffset + 4] << 8) | RawData[DataOffset + 5]);
-        udpCRC = (ushort)((RawData[DataOffset + 6] << 8) | RawData[DataOffset + 7]);
+        _udpCRC = (ushort)((RawData[DataOffset + 6] << 8) | RawData[DataOffset + 7]);
     }
 
     /// <summary>

--- a/src/Cosmos.Kernel.System/Network/IPv4/UDP/UdpClient.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/UDP/UdpClient.cs
@@ -10,7 +10,7 @@ public class UdpClient : IDisposable
 {
     public static ushort DynamicPortStart = 49152;
 
-    private static ushort nextPort = 49152;
+    private static ushort s_nextPort = 49152;
 
     /// <summary>
     /// Gets a dynamic port (simple incrementing approach for AOT compatibility).
@@ -21,12 +21,12 @@ public class UdpClient : IDisposable
     {
         for (int i = 0; i < tries; i++)
         {
-            ushort port = nextPort++;
-            if (nextPort >= 65535)
+            ushort port = s_nextPort++;
+            if (s_nextPort >= 65535)
             {
-                nextPort = DynamicPortStart;
+                s_nextPort = DynamicPortStart;
             }
-            if (!clients.ContainsKey(port))
+            if (!s_clients.ContainsKey(port))
             {
                 return port;
             }
@@ -35,14 +35,14 @@ public class UdpClient : IDisposable
         return 0;
     }
 
-    private static readonly Dictionary<uint, UdpClient> clients = new();
-    private readonly int localPort;
-    private int destinationPort;
+    private static readonly Dictionary<uint, UdpClient> s_clients = new();
+    private readonly int _localPort;
+    private int _destinationPort;
 
     /// <summary>
-    /// The destination address.
+    /// The _destination address.
     /// </summary>
-    internal Address? destination;
+    internal Address? _destination;
 
     /// <summary>
     /// The RX buffer queue.
@@ -52,11 +52,11 @@ public class UdpClient : IDisposable
     /// <summary>
     /// Gets a UDP client running on the given port.
     /// </summary>
-    /// <param name="destPort">The destination port.</param>
+    /// <param name="destPort">The _destination port.</param>
     /// <returns>If a client is running on the given port, the <see cref="UdpClient"/>; otherwise, <see langword="null"/>.</returns>
     internal static UdpClient? GetClient(ushort destPort)
     {
-        if (clients.TryGetValue(destPort, out var client))
+        if (s_clients.TryGetValue(destPort, out var client))
         {
             return client;
         }
@@ -73,15 +73,15 @@ public class UdpClient : IDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="UdpClient"/> class.
     /// </summary>
-    /// <param name="localPort">Local port.</param>
-    public UdpClient(int localPort)
+    /// <param name="_localPort">Local port.</param>
+    public UdpClient(int _localPort)
     {
         rxBuffer = new Queue<UDPPacket>(8);
 
-        this.localPort = localPort;
-        if (localPort > 0)
+        this._localPort = _localPort;
+        if (_localPort > 0)
         {
-            clients[(uint)localPort] = this;
+            s_clients[(uint)_localPort] = this;
         }
     }
 
@@ -93,19 +93,19 @@ public class UdpClient : IDisposable
     public UdpClient(Address dest, int destPort)
         : this(0)
     {
-        destination = dest;
-        destinationPort = destPort;
+        _destination = dest;
+        _destinationPort = destPort;
     }
 
     /// <summary>
     /// Connects to the given client.
     /// </summary>
-    /// <param name="dest">The destination address.</param>
-    /// <param name="destPort">The destination port.</param>
+    /// <param name="dest">The _destination address.</param>
+    /// <param name="destPort">The _destination port.</param>
     public void Connect(Address dest, int destPort)
     {
-        destination = dest;
-        destinationPort = destPort;
+        _destination = dest;
+        _destinationPort = destPort;
     }
 
     /// <summary>
@@ -113,9 +113,9 @@ public class UdpClient : IDisposable
     /// </summary>
     public void Close()
     {
-        if (clients.ContainsKey((uint)localPort))
+        if (s_clients.ContainsKey((uint)_localPort))
         {
-            clients.Remove((uint)localPort);
+            s_clients.Remove((uint)_localPort);
         }
     }
 
@@ -125,12 +125,12 @@ public class UdpClient : IDisposable
     /// <param name="data">The data to send.</param>
     public void Send(byte[] data)
     {
-        if (destination == null || destinationPort == 0)
+        if (_destination == null || _destinationPort == 0)
         {
             throw new InvalidOperationException("Must establish a default remote host by calling Connect() before using this Send() overload");
         }
 
-        Send(data, destination, destinationPort);
+        Send(data, _destination, _destinationPort);
         NetworkStack.Update();
     }
 
@@ -138,30 +138,30 @@ public class UdpClient : IDisposable
     /// Sends data to a remote host.
     /// </summary>
     /// <param name="data">The data to send.</param>
-    /// <param name="dest">The destination address.</param>
-    /// <param name="destPort">The destination port.</param>
+    /// <param name="dest">The _destination address.</param>
+    /// <param name="destPort">The _destination port.</param>
     public void Send(byte[] data, Address dest, int destPort)
     {
         Serial.WriteString("[UdpClient] Send to ");
         Serial.WriteString(dest.ToString());
         Serial.WriteString(":");
         Serial.WriteNumber((ulong)destPort);
-        Serial.WriteString(" localPort=");
-        Serial.WriteNumber((ulong)localPort);
+        Serial.WriteString(" _localPort=");
+        Serial.WriteNumber((ulong)_localPort);
         Serial.WriteString("\n");
 
         Address? source = IPConfig.FindNetwork(dest);
         if (source == null)
         {
             Serial.WriteString("[UdpClient] ERROR: IPConfig.FindNetwork returned null!\n");
-            throw new InvalidOperationException("No network route to destination");
+            throw new InvalidOperationException("No network route to _destination");
         }
 
         Serial.WriteString("[UdpClient] Source IP: ");
         Serial.WriteString(source.ToString());
         Serial.WriteString("\n");
 
-        var packet = new UDPPacket(source, dest, (ushort)localPort, (ushort)destPort, data);
+        var packet = new UDPPacket(source, dest, (ushort)_localPort, (ushort)destPort, data);
         Serial.WriteString("[UdpClient] UDPPacket created, adding to outgoing buffer\n");
         OutgoingBuffer.AddPacket(packet);
         Serial.WriteString("[UdpClient] Packet added to outgoing buffer\n");

--- a/src/Cosmos.Kernel.System/Network/NetworkManager.cs
+++ b/src/Cosmos.Kernel.System/Network/NetworkManager.cs
@@ -23,25 +23,25 @@ public static class NetworkManager
         }
     }
 
-    private static INetworkDevice? _primaryDevice;
-    private static INetworkDevice?[]? _devices;
-    private static int _deviceCount;
-    private static bool _initialized;
+    private static INetworkDevice? s_primaryDevice;
+    private static INetworkDevice?[]? s_devices;
+    private static int s_deviceCount;
+    private static bool s_initialized;
 
     /// <summary>
     /// Gets whether the network manager is initialized.
     /// </summary>
-    public static bool IsInitialized => _initialized;
+    public static bool IsInitialized => s_initialized;
 
     /// <summary>
     /// Gets the primary network device.
     /// </summary>
-    public static INetworkDevice? PrimaryDevice => _primaryDevice;
+    public static INetworkDevice? PrimaryDevice => s_primaryDevice;
 
     /// <summary>
     /// Gets the number of registered network devices.
     /// </summary>
-    public static int DeviceCount => _deviceCount;
+    public static int DeviceCount => s_deviceCount;
 
     /// <summary>
     /// Initializes the network manager.
@@ -50,14 +50,14 @@ public static class NetworkManager
     {
         ThrowIfDisabled();
 
-        if (_initialized)
+        if (s_initialized)
         {
             return;
         }
 
-        _devices = new INetworkDevice[8];
-        _deviceCount = 0;
-        _initialized = true;
+        s_devices = new INetworkDevice[8];
+        s_deviceCount = 0;
+        s_initialized = true;
     }
 
     /// <summary>
@@ -66,17 +66,17 @@ public static class NetworkManager
     /// <param name="device">The network device to register.</param>
     public static void RegisterDevice(INetworkDevice device)
     {
-        if (device == null || _devices == null || _deviceCount >= _devices.Length)
+        if (device == null || s_devices == null || s_deviceCount >= s_devices.Length)
         {
             return;
         }
 
-        _devices[_deviceCount++] = device;
+        s_devices[s_deviceCount++] = device;
 
         // First device becomes primary
-        if (_primaryDevice == null)
+        if (s_primaryDevice == null)
         {
-            _primaryDevice = device;
+            s_primaryDevice = device;
         }
     }
 
@@ -89,12 +89,12 @@ public static class NetworkManager
     {
         ThrowIfDisabled();
 
-        if (_devices == null || index < 0 || index >= _deviceCount)
+        if (s_devices == null || index < 0 || index >= s_deviceCount)
         {
             return null;
         }
 
-        return _devices[index];
+        return s_devices[index];
     }
 
     /// <summary>
@@ -106,11 +106,11 @@ public static class NetworkManager
     public static bool Send(byte[] data, int length)
     {
         ThrowIfDisabled();
-        return _primaryDevice?.Send(data, length) ?? false;
+        return s_primaryDevice?.Send(data, length) ?? false;
     }
 
     /// <summary>
     /// Gets whether the primary device link is up.
     /// </summary>
-    public static bool LinkUp => _primaryDevice?.LinkUp ?? false;
+    public static bool LinkUp => s_primaryDevice?.LinkUp ?? false;
 }

--- a/src/Cosmos.Kernel.System/Network/NetworkStack.cs
+++ b/src/Cosmos.Kernel.System/Network/NetworkStack.cs
@@ -106,7 +106,7 @@ public static class NetworkStack
     /// <summary>
     /// Flag to prevent recursive Update calls.
     /// </summary>
-    private static bool _updating = false;
+    private static bool s_updating = false;
 
     /// <summary>
     /// Updates the network stack (sends pending packets).
@@ -114,14 +114,14 @@ public static class NetworkStack
     public static void Update()
     {
         // Prevent recursive calls
-        if (_updating)
+        if (s_updating)
         {
             return;
         }
 
-        _updating = true;
+        s_updating = true;
         OutgoingBuffer.Send();
-        _updating = false;
+        s_updating = false;
     }
 
     /// <summary>

--- a/src/Cosmos.Kernel.System/Storage/StorageManager.cs
+++ b/src/Cosmos.Kernel.System/Storage/StorageManager.cs
@@ -29,26 +29,26 @@ public static class StorageManager
         }
     }
 
-    private static IBlockDevice? _primaryDevice;
-    private static IBlockDevice?[]? _devices;
-    private static int _deviceCount;
-    private static List<Partition>? _partitions;
-    private static bool _initialized;
+    private static IBlockDevice? s_primaryDevice;
+    private static IBlockDevice?[]? s_devices;
+    private static int s_deviceCount;
+    private static List<Partition>? s_partitions;
+    private static bool s_initialized;
 
     /// <summary>
     /// Gets whether the storage manager is initialized.
     /// </summary>
-    public static bool IsInitialized => _initialized;
+    public static bool IsInitialized => s_initialized;
 
     /// <summary>
     /// Gets the primary block device (first one registered).
     /// </summary>
-    public static IBlockDevice? PrimaryDevice => _primaryDevice;
+    public static IBlockDevice? PrimaryDevice => s_primaryDevice;
 
     /// <summary>
     /// Gets the number of registered block devices.
     /// </summary>
-    public static int DeviceCount => _deviceCount;
+    public static int DeviceCount => s_deviceCount;
 
     /// <summary>
     /// Partitions discovered across every registered device. Each entry is
@@ -56,7 +56,7 @@ public static class StorageManager
     /// starting LBA, so filesystem drivers consume them without knowing
     /// whether the host disk is GPT-, MBR-, or unpartitioned.
     /// </summary>
-    public static IReadOnlyList<Partition> Partitions => (IReadOnlyList<Partition>?)_partitions ?? Array.Empty<Partition>();
+    public static IReadOnlyList<Partition> Partitions => (IReadOnlyList<Partition>?)s_partitions ?? Array.Empty<Partition>();
 
     /// <summary>
     /// Initializes the storage manager.
@@ -65,15 +65,15 @@ public static class StorageManager
     {
         ThrowIfDisabled();
 
-        if (_initialized)
+        if (s_initialized)
         {
             return;
         }
 
-        _devices = new IBlockDevice[MaxDevices];
-        _deviceCount = 0;
-        _partitions = new List<Partition>();
-        _initialized = true;
+        s_devices = new IBlockDevice[MaxDevices];
+        s_deviceCount = 0;
+        s_partitions = new List<Partition>();
+        s_initialized = true;
     }
 
     /// <summary>
@@ -111,12 +111,12 @@ public static class StorageManager
 
     public static void RegisterDevice(IBlockDevice device)
     {
-        if (device == null || _devices == null || _deviceCount >= _devices.Length)
+        if (device == null || s_devices == null || s_deviceCount >= s_devices.Length)
         {
             return;
         }
 
-        // Serializes _devices/_partitions mutation for post-boot callers
+        // Serializes s_devices/s_partitions mutation for post-boot callers
         // (device hotplug paths, tests); reads are still unsynchronized —
         // enumerating Partitions while another thread rescans remains the
         // caller's problem. Re-registering a known device is a no-op:
@@ -126,20 +126,20 @@ public static class StorageManager
         s_mutationLock.Acquire();
         try
         {
-            for (int i = 0; i < _deviceCount; i++)
+            for (int i = 0; i < s_deviceCount; i++)
             {
-                if (ReferenceEquals(_devices[i], device))
+                if (ReferenceEquals(s_devices[i], device))
                 {
                     return;
                 }
             }
 
-            _devices[_deviceCount++] = device;
+            s_devices[s_deviceCount++] = device;
 
             // First device becomes primary
-            if (_primaryDevice == null)
+            if (s_primaryDevice == null)
             {
-                _primaryDevice = device;
+                s_primaryDevice = device;
             }
 
             ScanPartitions(device);
@@ -158,7 +158,7 @@ public static class StorageManager
     /// </summary>
     public static void RescanPartitions(IBlockDevice device)
     {
-        if (_partitions == null || device == null)
+        if (s_partitions == null || device == null)
         {
             return;
         }
@@ -166,11 +166,11 @@ public static class StorageManager
         s_mutationLock.Acquire();
         try
         {
-            for (int i = _partitions.Count - 1; i >= 0; i--)
+            for (int i = s_partitions.Count - 1; i >= 0; i--)
             {
-                if (ReferenceEquals(_partitions[i].Host, device))
+                if (ReferenceEquals(s_partitions[i].Host, device))
                 {
-                    _partitions.RemoveAt(i);
+                    s_partitions.RemoveAt(i);
                 }
             }
 
@@ -184,7 +184,7 @@ public static class StorageManager
 
     private static void ScanPartitions(IBlockDevice device)
     {
-        if (_partitions == null)
+        if (s_partitions == null)
         {
             return;
         }
@@ -200,7 +200,7 @@ public static class StorageManager
                 for (int i = 0; i < entries.Count; i++)
                 {
                     Gpt.PartitionEntry e = entries[i];
-                    _partitions.Add(new Partition(device, e.StartSector, e.SectorCount, (uint)i));
+                    s_partitions.Add(new Partition(device, e.StartSector, e.SectorCount, (uint)i));
                 }
                 return;
             }
@@ -215,7 +215,7 @@ public static class StorageManager
                 for (int i = 0; i < entries.Count; i++)
                 {
                     Mbr.PartitionEntry e = entries[i];
-                    _partitions.Add(new Partition(device, e.StartSector, e.SectorCount, slot));
+                    s_partitions.Add(new Partition(device, e.StartSector, e.SectorCount, slot));
                     slot++;
                 }
 
@@ -226,7 +226,7 @@ public static class StorageManager
                     for (int i = 0; i < logicals.Count; i++)
                     {
                         Mbr.PartitionEntry e = logicals[i];
-                        _partitions.Add(new Partition(device, e.StartSector, e.SectorCount, slot));
+                        s_partitions.Add(new Partition(device, e.StartSector, e.SectorCount, slot));
                         slot++;
                     }
                 }
@@ -254,11 +254,11 @@ public static class StorageManager
     {
         ThrowIfDisabled();
 
-        if (_devices == null || index < 0 || index >= _deviceCount)
+        if (s_devices == null || index < 0 || index >= s_deviceCount)
         {
             return null;
         }
 
-        return _devices[index];
+        return s_devices[index];
     }
 }

--- a/src/Cosmos.Kernel.System/Timer/TimerManager.cs
+++ b/src/Cosmos.Kernel.System/Timer/TimerManager.cs
@@ -12,25 +12,25 @@ public static class TimerManager
     /// <summary>Nanoseconds in one millisecond.</summary>
     private const ulong NanosecondsPerMillisecond = 1_000_000;
 
-    private static ITimerDevice? _timer;
-    private static bool _initialized;
+    private static ITimerDevice? s_timer;
+    private static bool s_initialized;
 
     /// <summary>
     /// Gets whether the timer manager is initialized.
     /// </summary>
-    public static bool IsInitialized => _initialized;
+    public static bool IsInitialized => s_initialized;
 
     /// <summary>
     /// Initializes the timer manager.
     /// </summary>
     public static void Initialize()
     {
-        if (_initialized)
+        if (s_initialized)
         {
             return;
         }
 
-        _initialized = true;
+        s_initialized = true;
     }
 
     /// <summary>
@@ -43,20 +43,20 @@ public static class TimerManager
             return;
         }
 
-        _timer = timer;
+        s_timer = timer;
     }
 
     /// <summary>
     /// Gets the current timer frequency in Hz.
     /// </summary>
-    public static uint Frequency => _timer?.Frequency ?? 0;
+    public static uint Frequency => s_timer?.Frequency ?? 0;
 
     /// <summary>
     /// Sets the timer frequency in Hz.
     /// </summary>
     public static void SetFrequency(uint frequency)
     {
-        _timer?.SetFrequency(frequency);
+        s_timer?.SetFrequency(frequency);
     }
 
     /// <summary>
@@ -65,7 +65,7 @@ public static class TimerManager
     /// <param name="ms">Milliseconds to wait.</param>
     public static void Wait(uint ms)
     {
-        _timer?.Wait(ms);
+        s_timer?.Wait(ms);
     }
 
     /// <summary>
@@ -105,23 +105,23 @@ public static class TimerManager
             return;
         }
 
-        _timer?.UnregisterTimer(timer);
+        s_timer?.UnregisterTimer(timer);
     }
 
     private static SoftwareTimer? ScheduleCore(Action callback, uint ms, bool recurring)
     {
-        if (_timer == null || callback == null)
+        if (s_timer == null || callback == null)
         {
             return null;
         }
 
         SoftwareTimer timer = new(callback, ms * NanosecondsPerMillisecond, recurring);
-        _timer.RegisterTimer(timer);
+        s_timer.RegisterTimer(timer);
         return timer;
     }
 
     /// <summary>
     /// Gets the registered timer device.
     /// </summary>
-    public static ITimerDevice? Timer => _timer;
+    public static ITimerDevice? Timer => s_timer;
 }

--- a/src/Cosmos.Patcher/Coverage/CoverageInstrumenter.cs
+++ b/src/Cosmos.Patcher/Coverage/CoverageInstrumenter.cs
@@ -30,7 +30,7 @@ public class CoverageInstrumenter
     /// <summary>
     /// Assembly name prefixes to skip entirely (test infrastructure, framework, etc.).
     /// </summary>
-    private static readonly string[] ExcludeAssemblies =
+    private static readonly string[] s_excludeAssemblies =
     [
         "Cosmos.TestRunner",
     ];
@@ -38,7 +38,7 @@ public class CoverageInstrumenter
     /// <summary>
     /// Fully-qualified type names to always skip (avoids infinite recursion).
     /// </summary>
-    private static readonly string[] ExcludeTypes =
+    private static readonly string[] s_excludeTypes =
     [
         "Cosmos.TestRunner.Framework.CoverageTracker",
     ];
@@ -439,7 +439,7 @@ public class CoverageInstrumenter
         }
 
         // Skip excluded assembly name prefixes
-        foreach (string exclude in ExcludeAssemblies)
+        foreach (string exclude in s_excludeAssemblies)
         {
             if (assemblyName.StartsWith(exclude, StringComparison.OrdinalIgnoreCase))
             {
@@ -464,7 +464,7 @@ public class CoverageInstrumenter
         }
 
         // Skip explicitly excluded types
-        foreach (string exclude in ExcludeTypes)
+        foreach (string exclude in s_excludeTypes)
         {
             if (type.FullName == exclude)
             {

--- a/src/Cosmos.Tools/Commands/InstallCommand.cs
+++ b/src/Cosmos.Tools/Commands/InstallCommand.cs
@@ -550,7 +550,7 @@ public class InstallCommand : AsyncCommand<InstallSettings>
     // Tool directories that should be on PATH. QEMU exes live under qemu\bin\
     // (so the bundle's qemu\share\qemu\ BIOS files are discoverable via -L,
     // which launchers add automatically).
-    private static readonly string[] ToolPathSubDirs =
+    private static readonly string[] s_toolPathSubDirs =
     [
         Path.Combine("llvm-tools", "bin"),
         "xorriso",
@@ -565,7 +565,7 @@ public class InstallCommand : AsyncCommand<InstallSettings>
             string currentPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User) ?? "";
             bool changed = false;
 
-            foreach (string sub in ToolPathSubDirs)
+            foreach (string sub in s_toolPathSubDirs)
             {
                 string dir = Path.Combine(toolsPath, sub);
                 if (!currentPath.Contains(dir, StringComparison.OrdinalIgnoreCase))
@@ -591,7 +591,7 @@ public class InstallCommand : AsyncCommand<InstallSettings>
         {
             string currentPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User) ?? "";
             bool changed = false;
-            foreach (string sub in ToolPathSubDirs)
+            foreach (string sub in s_toolPathSubDirs)
             {
                 string dir = Path.Combine(toolsPath, sub);
                 string upper = currentPath.ToUpperInvariant();

--- a/src/tests/Cosmos.Kernel.Tests.System/Network/IPv4/TCP/TcpTest.cs
+++ b/src/tests/Cosmos.Kernel.Tests.System/Network/IPv4/TCP/TcpTest.cs
@@ -8,12 +8,12 @@ namespace Cosmos.Kernel.Tests.System.Network.IPv4.TCP;
 
 public class TcpTest
 {
-    private Tcp target = null!;
+    private Tcp _target = null!;
 
     [SetUp]
     public void Setup()
     {
-        target = Tcp.CreateConnection(0, 0, new Address(1, 2, 3, 4), new Address(1, 2, 3, 4));
+        _target = Tcp.CreateConnection(0, 0, new Address(1, 2, 3, 4), new Address(1, 2, 3, 4));
     }
 
     [TestFixture]
@@ -22,29 +22,29 @@ public class TcpTest
         [Test]
         public void WhenBothData_AndOtherAreEmpty_DataIsEmpty()
         {
-            target.AppendToData([]);
+            _target.AppendToData([]);
 
-            Assert.That(target.Data.Length, Is.EqualTo(0));
+            Assert.That(_target.Data.Length, Is.EqualTo(0));
         }
 
         [Test]
         public void WhenDataIsNotEmpty_AndOtherIsEmpty_DataDoesNotChange()
         {
-            target.AppendToData([0, 1]);
+            _target.AppendToData([0, 1]);
 
-            target.AppendToData([]);
+            _target.AppendToData([]);
 
-            Assert.That(target.Data.ToArray(), Is.EquivalentTo([0, 1]));
+            Assert.That(_target.Data.ToArray(), Is.EquivalentTo([0, 1]));
         }
 
         [Test]
         public void WhenDataIsNotEmpty_AndOtherIsNotEmpty_OtherIsAppendedToData()
         {
-            target.AppendToData([0, 1]);
+            _target.AppendToData([0, 1]);
 
-            target.AppendToData([2, 3]);
+            _target.AppendToData([2, 3]);
 
-            Assert.That(target.Data.ToArray(), Is.EquivalentTo([0, 1, 2, 3]));
+            Assert.That(_target.Data.ToArray(), Is.EquivalentTo([0, 1, 2, 3]));
         }
     }
 
@@ -54,30 +54,30 @@ public class TcpTest
         [Test]
         public void WhenAdvancingByZero_NoChangesAreMade()
         {
-            target.AppendToData([0, 1]);
+            _target.AppendToData([0, 1]);
 
-            target.AdvanceDataOffset(0);
+            _target.AdvanceDataOffset(0);
 
-            Assert.That(target.Data.ToArray(), Is.EquivalentTo([0, 1]));
+            Assert.That(_target.Data.ToArray(), Is.EquivalentTo([0, 1]));
         }
 
         [Test]
         public void WhenAdvancingByOneAndLengthIsTwo_OnlyLastElementRemains()
         {
-            target.AppendToData([0, 1]);
+            _target.AppendToData([0, 1]);
 
-            target.AdvanceDataOffset(1);
+            _target.AdvanceDataOffset(1);
 
-            Assert.That(target.Data.ToArray(), Is.EquivalentTo([1]));
+            Assert.That(_target.Data.ToArray(), Is.EquivalentTo([1]));
         }
         [Test]
         public void WhenAdvancingByTwoAndLengthIsTwo_DataLengthIsZero()
         {
-            target.AppendToData([0, 1]);
+            _target.AppendToData([0, 1]);
 
-            target.AdvanceDataOffset(2);
+            _target.AdvanceDataOffset(2);
 
-            Assert.That(target.Data.Length, Is.Zero);
+            Assert.That(_target.Data.Length, Is.Zero);
         }
     }
 }


### PR DESCRIPTION
## Summary

The format CI has been red since the naming rules were raised to `error` severity: 151 fields across ~50 files were missing their `_` / `s_` prefixes. This PR makes `dotnet format --verify-no-changes --severity error` pass again.

### Renames
- Private/internal instance fields → `_camelCase` (e.g. `driver` → `_driver`)
- Private/internal static fields → `s_camelCase` (e.g. `nextPort` → `s_nextPort`, `_initialized` → `s_initialized`)
- `TCPPacket` flag fields `SYN/ACK/FIN/PSH/RST/URG` → `_syn/_ack/_fin/_psh/_rst/_urg` (the `Flags` enum members are untouched)

### Excluded from style analysis (`generated_code = true`)
Ported/vendored code stays diffable with its origin:
- `SharpZipLib/` and `Graphics/Images/Png/` (vendored ports)
- `Cosmos.Kernel.Core/Runtime/Math.cs` (fdlibm port)
- `Cosmos.Kernel.Core/Runtime/Internal/` (mirrors dotnet/runtime internals)

`Cosmos.Kernel.Plugs/` keeps its member names too (IDE1006 disabled there): the patcher matches plug members against their BCL/runtime targets by name (`PlugPatcher.Field.cs`), so renaming them would silently break patching.

## Validation
- `dotnet format ./nativeaot-patcher.slnx --exclude dotnet --verify-no-changes --severity error` → exit 0
- `.devcontainer/postCreateCommand.sh` (full package build, both arches) → exit 0
- `make test KERNEL=HelloWorld` → 3/3 passed
- `make test KERNEL=Network` → all passed