### PR TITLE
Remove duplicate Cosmos.ArchitecturePicker.props import (MSB4011)

### DIFF
--- a/src/Cosmos.Build.Common/build/Cosmos.Architecture.props
+++ b/src/Cosmos.Build.Common/build/Cosmos.Architecture.props
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="Cosmos.ArchitecturePicker.props" />
-
   <!-- Architecture-specific tool paths -->
   <PropertyGroup Condition="'$(CosmosArch)' == 'x64'">
     <CosmosLinkerEmulation>elf_x86_64</CosmosLinkerEmulation>

--- a/tests/Cosmos.Tests.BuildCache/BuildWarningTests.cs
+++ b/tests/Cosmos.Tests.BuildCache/BuildWarningTests.cs
@@ -1,0 +1,32 @@
+namespace Cosmos.Tests.BuildCache;
+
+/// <summary>
+/// Build hygiene tests — the kernel build output must stay free of MSBuild
+/// authoring warnings so real warnings and errors remain visible.
+/// Same collection as the cache tests so DevKernel builds never run in parallel.
+/// </summary>
+[Collection("BuildCache")]
+public class BuildWarningTests : IClassFixture<BuildFixture>
+{
+    private readonly BuildFixture _fixture;
+
+    public BuildWarningTests(BuildFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    // ==================================================================
+    // Issue #391: Cosmos.Build.Common.props and Cosmos.Architecture.props
+    // both imported Cosmos.ArchitecturePicker.props, so every kernel build
+    // logged MSB4011 "cannot be imported again" for the second import.
+    // ==================================================================
+    [Fact]
+    public void Build_EmitsNoDuplicateImportWarning()
+    {
+        BuildResult result = _fixture.Build();
+
+        Assert.True(result.Success, $"Build failed:\n{result.Output}");
+        Assert.DoesNotContain("MSB4011", result.Output);
+        Assert.DoesNotContain("cannot be imported again", result.Output);
+    }
+}


### PR DESCRIPTION
Every kernel build logged a MSB4011 warning because `Cosmos.ArchitecturePicker.props` was imported twice: once by `Cosmos.Build.Common.props` (NuGet props auto-import, evaluated at the top of the project) and again by `Cosmos.Architecture.props`, pulled in by `Cosmos.Build.Common.targets`. NuGet always evaluates a package's `.props` before its `.targets`, so the picker is guaranteed to be imported already when `Cosmos.Architecture.props` is evaluated — the second import can simply be removed, as suggested by @Guillermo-Santos.

Also adds `BuildWarningTests` to `Cosmos.Tests.BuildCache`: builds DevKernel and asserts the output contains no MSB4011 / "cannot be imported again" warning. It fails before the fix and passes after; `make test KERNEL=HelloWorld` still passes with zero MSB4011 in the full build log.

Fixes #391
