### PR TITLE
Report real thread stack bounds to EnsureSufficientExecutionStack

### DIFF
--- a/src/Cosmos.Kernel.Boot.Limine/Limine.cs
+++ b/src/Cosmos.Kernel.Boot.Limine/Limine.cs
@@ -10,6 +10,7 @@ public static class Limine
     public static readonly LimineBootTimeRequest BootTime = new();
     public static readonly LimineEfiSystemTableRequest EfiSystemTable = new();
     public static readonly LimineExecutableCmdlineRequest ExecutableCmdline = new();
+    public static readonly LimineStackSizeRequest StackSize = new(LimineStackSizeRequest.DefaultRequestedSize);
 
     /// <summary>
     /// Pointer to the kernel command line (null-terminated C string) passed

--- a/src/Cosmos.Kernel.Boot.Limine/LimineStackSize.cs
+++ b/src/Cosmos.Kernel.Boot.Limine/LimineStackSize.cs
@@ -1,0 +1,31 @@
+using System.Runtime.InteropServices;
+
+namespace Cosmos.Kernel.Boot.Limine;
+
+/// <summary>
+/// Limine Stack Size request.
+/// Asks the bootloader to provide at least <see cref="StackSize"/> bytes of
+/// stack to the kernel entry point instead of the 64 KiB protocol default.
+/// The boot stack hosts the whole main kernel thread, and
+/// <c>RuntimeHelpers.EnsureSufficientExecutionStack</c> requires stacks larger
+/// than 128 KiB on 64-bit to ever succeed.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public readonly unsafe struct LimineStackSizeRequest(ulong stackSize)
+{
+    /// <summary>Boot stack size requested by Cosmos (1 MiB, the .NET main-thread convention).</summary>
+    public const ulong DefaultRequestedSize = 1024 * 1024;
+
+    public readonly LimineID ID = new(0x224ef0460a8e8926, 0xe1cb0fc25f46ea3d);
+    public readonly ulong Revision = 0;
+    public readonly LimineStackSizeResponse* Response;
+
+    /// <summary>Requested stack size in bytes; honored when <see cref="Response"/> is non-null.</summary>
+    public readonly ulong StackSize = stackSize;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public readonly struct LimineStackSizeResponse
+{
+    public readonly ulong Revision;
+}

--- a/src/Cosmos.Kernel.Core/Bridge/Import/BootNative.cs
+++ b/src/Cosmos.Kernel.Core/Bridge/Import/BootNative.cs
@@ -1,0 +1,19 @@
+// This code is licensed under MIT license (see LICENSE for details)
+
+using System.Runtime.InteropServices;
+
+namespace Cosmos.Kernel.Core.Bridge;
+
+/// <summary>
+/// Native imports for boot-time facts recorded by the C bootstrap (kmain.c).
+/// </summary>
+public static partial class BootNative
+{
+    /// <summary>
+    /// Top of the bootloader-provided stack, captured at kmain entry before any
+    /// managed code runs. Every managed frame of the boot thread lies below it.
+    /// </summary>
+    [LibraryImport("*", EntryPoint = "__cosmos_get_boot_stack_top")]
+    [SuppressGCTransition]
+    public static partial nuint GetBootStackTop();
+}

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Mark.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Mark.cs
@@ -131,12 +131,11 @@ public static unsafe partial class GarbageCollector
     /// <summary>
     /// Stack-end bound for the current thread when its <see cref="Scheduler.Thread"/> has no
     /// allocated <c>StackBase</c>/<c>StackSize</c> — the boot/idle thread runs on the bootloader's
-    /// stack. Returns the current SP plus the default stack size: a deliberately generous bound, so
-    /// a word or two of slop from this helper's own frame is immaterial.
+    /// stack, whose top kmain captured before any managed code ran.
     /// </summary>
     private static nuint GetCurrentStackEndForBootStack()
     {
-        return ContextSwitchNative.GetSp() + Scheduler.Thread.DefaultStackSize;
+        return Runtime.BootStack.Top;
     }
 
     /// <summary>

--- a/src/Cosmos.Kernel.Core/Runtime/BootStack.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/BootStack.cs
@@ -1,0 +1,23 @@
+using Cosmos.Kernel.Boot.Limine;
+using Cosmos.Kernel.Core.Bridge;
+
+namespace Cosmos.Kernel.Core.Runtime;
+
+/// <summary>
+/// Bounds of the bootloader-provided stack that the boot/idle thread runs on.
+/// The top is captured by kmain before any managed code executes; the size is
+/// the Limine stack-size request when honored, else the 64 KiB protocol default.
+/// </summary>
+public static unsafe class BootStack
+{
+    /// <summary>Stack size Limine guarantees when no stack-size request is honored.</summary>
+    private const nuint LimineDefaultStackSize = 64 * 1024;
+
+    /// <summary>Highest address of the boot stack (exclusive).</summary>
+    public static nuint Top => BootNative.GetBootStackTop();
+
+    /// <summary>Boot stack size in bytes.</summary>
+    public static nuint Size => Limine.StackSize.Response != null
+        ? (nuint)Limine.StackSize.StackSize
+        : LimineDefaultStackSize;
+}

--- a/src/Cosmos.Kernel.Core/Runtime/Thread.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Thread.cs
@@ -29,8 +29,20 @@ public class Thread
     [RuntimeExport("RhGetCurrentThreadStackBounds")]
     internal static void RhGetCurrentThreadStackBounds(out IntPtr pStackLow, out IntPtr pStackHigh)
     {
-        pStackLow = (nint)ContextSwitchNative.GetSp();
-        pStackHigh = pStackLow + (nint)Scheduler.Thread.DefaultStackSize;
+        if (CosmosFeatures.SchedulerEnabled)
+        {
+            Scheduler.Thread? current = SchedulerManager.GetCpuState(SchedulerManager.GetCurrentCpuId())?.CurrentThread;
+            if (current != null && current.StackBase != 0)
+            {
+                pStackLow = (nint)current.StackBase;
+                pStackHigh = (nint)(current.StackBase + current.StackSize);
+                return;
+            }
+        }
+
+        // Boot/idle thread: runs on the bootloader-provided stack.
+        pStackHigh = (nint)BootStack.Top;
+        pStackLow = pStackHigh - (nint)BootStack.Size;
     }
 
     [RuntimeExport("RhSetCurrentThreadName")]

--- a/src/Cosmos.Kernel.Core/Scheduler/Thread.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/Thread.cs
@@ -35,9 +35,13 @@ public unsafe class Thread : SchedulerExtensible
 
 
     /// <summary>
-    /// Default stack size for new threads (64KB).
+    /// Default stack size for new threads (256KB). Must stay above CoreLib's
+    /// 128KB MinExecutionStackSize (64-bit) or
+    /// RuntimeHelpers.EnsureSufficientExecutionStack — called by generated
+    /// record ToString/PrintMembers among others — throws
+    /// InsufficientExecutionStackException on every call (#433).
     /// </summary>
-    public const nuint DefaultStackSize = 64 * 1024;
+    public const nuint DefaultStackSize = 256 * 1024;
 
     /// <summary>
     /// Maximum number of threads tracked by the global thread registry.

--- a/src/Cosmos.Kernel/Bootstrap/kmain.c
+++ b/src/Cosmos.Kernel/Bootstrap/kmain.c
@@ -3,9 +3,22 @@
 // CPU features definition
 int g_cpuFeatures = 0;
 
+// Top of the bootloader-provided stack, captured at kmain entry so every
+// managed frame lies below it (RhGetCurrentThreadStackBounds, GC stack scan).
+static uintptr_t g_bootStackTop = 0;
+
+uintptr_t __cosmos_get_boot_stack_top(void)
+{
+    return g_bootStackTop;
+}
+
 // Entry point
 void kmain()
 {
+    // Capture the boot stack top before anything else runs; kmain's own frame
+    // is the highest thing on the Limine-provided stack.
+    g_bootStackTop = (uintptr_t)__builtin_frame_address(0);
+
     // Enable SIMD/XMM FIRST before ANY code execution
     // Without optimizations (-O), ILC generates XMM instructions even in simple functions
     _native_enable_simd();

--- a/src/Cosmos.Kernel/Bootstrap/kmain.h
+++ b/src/Cosmos.Kernel/Bootstrap/kmain.h
@@ -27,6 +27,9 @@ extern int g_requiredCpuFeatures;
 // Cross-platform SIMD enable
 extern void _native_enable_simd(void);
 
+// Top of the bootloader-provided stack, captured at kmain entry
+extern uintptr_t __cosmos_get_boot_stack_top(void);
+
 #ifdef __aarch64__
 // ARM64-specific: Disable alignment checking
 extern void _native_arm64_disable_alignment_check(void);

--- a/tests/Kernels/Cosmos.Kernel.Tests.Threading/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Threading/Kernel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Cosmos.Kernel.Core.IO;
@@ -15,7 +16,7 @@ namespace Cosmos.Kernel.Tests.Threading;
 public class Kernel : Sys.Kernel
 {
     /// <summary>Total number of tests announced to the test runner for this suite.</summary>
-    private const int ExpectedTestCount = 53;
+    private const int ExpectedTestCount = 56;
 
     /// <summary>Lock/unlock increment iterations each worker thread performs in the lock and spinlock contention tests.</summary>
     private const int LockIterationsPerThread = 100;
@@ -116,6 +117,9 @@ public class Kernel : Sys.Kernel
         TR.Run("Thread_Multiple_CanRunConcurrently", TestMultipleThreads);
         TR.Run("SpinLock_ProtectsSharedData_AcrossThreads", TestSpinLockWithThreads);
         TR.Run("Thread_ThreadStatics", TestThreadStatics);
+        TR.Run("Thread_EnsureSufficientExecutionStack_Passes", TestEnsureSufficientStackInThread);
+        TR.Run("Thread_RecordToString_Works", TestRecordToStringInThread);
+        TR.Run("MainThread_RecordToString_Works", TestRecordToStringOnMainThread);
         TR.Run("Mutex_IdleThreadContention_KeepsTicketAccounting", TestMutexIdleThreadContention);
         TR.Run("InterruptEvent_TwoWaiters_BothWake", TestInterruptEventTwoWaiters);
         TR.Run("Mutex_ThreeContenders_AllAcquire", TestMutexThreeContenders);
@@ -376,6 +380,112 @@ public class Kernel : Sys.Kernel
         Serial.WriteString("[Thread] Delegate executing!\n");
         _threadExecuted = true;
         Serial.WriteString("[Thread] Delegate completed!\n");
+    }
+
+    // ===== EnsureSufficientExecutionStack in spawned threads (#433) =====
+    // The generated ToString/PrintMembers of a record calls
+    // RuntimeHelpers.EnsureSufficientExecutionStack, which sizes the thread's
+    // stack via RhGetCurrentThreadStackBounds. Bounds narrower than CoreLib's
+    // 128KB MinExecutionStackSize (or bounds fabricated from the current SP)
+    // make every call throw InsufficientExecutionStackException.
+
+    /// <summary>Record whose generated ToString exercises EnsureSufficientExecutionStack (#433).</summary>
+    private record StackProbeRecord(int Answer, string Label);
+
+    private static volatile bool _stackProbeDone;
+    private static volatile bool _stackProbeSufficient;
+    private static string? _stackProbeError;
+    private static string? _stackProbeToString;
+
+    private static void TestEnsureSufficientStackInThread()
+    {
+        _stackProbeDone = false;
+        _stackProbeSufficient = false;
+        _stackProbeError = null;
+
+        var thread = new SysThread(EnsureSufficientStackWorker);
+        thread.Start();
+
+        for (int i = 0; i < TaskPollRetries && !_stackProbeDone; i++)
+        {
+            TimerManager.Wait(TaskPollIntervalMs);
+        }
+
+        Assert.True(_stackProbeDone, "EnsureSufficientExecutionStack worker should finish");
+        Assert.True(_stackProbeError == null, "EnsureSufficientExecutionStack should not throw in a spawned thread");
+        Assert.True(_stackProbeSufficient, "TryEnsureSufficientExecutionStack should report sufficient stack in a spawned thread");
+    }
+
+    private static void EnsureSufficientStackWorker()
+    {
+        _stackProbeSufficient = RuntimeHelpers.TryEnsureSufficientExecutionStack();
+        try
+        {
+            RuntimeHelpers.EnsureSufficientExecutionStack();
+        }
+        catch (InsufficientExecutionStackException e)
+        {
+            _stackProbeError = e.Message;
+            Serial.WriteString("[StackProbe] EnsureSufficientExecutionStack threw: ");
+            Serial.WriteString(e.Message);
+            Serial.WriteString("\n");
+        }
+        _stackProbeDone = true;
+    }
+
+    private static void TestRecordToStringInThread()
+    {
+        _stackProbeDone = false;
+        _stackProbeToString = null;
+        _stackProbeError = null;
+
+        var thread = new SysThread(RecordToStringWorker);
+        thread.Start();
+
+        for (int i = 0; i < TaskPollRetries && !_stackProbeDone; i++)
+        {
+            TimerManager.Wait(TaskPollIntervalMs);
+        }
+
+        Assert.True(_stackProbeDone, "record ToString worker should finish");
+        Assert.True(_stackProbeError == null, "record ToString should not throw in a spawned thread");
+        Assert.True(_stackProbeToString != null && _stackProbeToString.Contains("42"),
+            "record ToString should contain the property value");
+    }
+
+    private static void RecordToStringWorker()
+    {
+        try
+        {
+            _stackProbeToString = new StackProbeRecord(42, "yuki").ToString();
+            Serial.WriteString("[StackProbe] record ToString: ");
+            Serial.WriteString(_stackProbeToString);
+            Serial.WriteString("\n");
+        }
+        catch (InsufficientExecutionStackException e)
+        {
+            _stackProbeError = e.Message;
+            Serial.WriteString("[StackProbe] record ToString threw: ");
+            Serial.WriteString(e.Message);
+            Serial.WriteString("\n");
+        }
+        _stackProbeDone = true;
+    }
+
+    private static void TestRecordToStringOnMainThread()
+    {
+        // The main kernel thread is the scheduler's idle thread and runs on the
+        // bootloader-provided stack, so this exercises the boot-stack branch of
+        // RhGetCurrentThreadStackBounds (Limine stack-size request + captured top).
+        try
+        {
+            string s = new StackProbeRecord(7, "root").ToString();
+            Assert.True(s.Contains("7"), "record ToString on the main thread should contain the property value");
+        }
+        catch (InsufficientExecutionStackException)
+        {
+            Assert.Fail("record ToString should not throw InsufficientExecutionStackException on the main thread");
+        }
     }
 
     // ===== Mutex idle-thread contention (scheduler Mutex, not System.Threading) =====


### PR DESCRIPTION
Fixes #433

## Problem

Calling a record's `ToString()` on a spawned thread threw `InsufficientExecutionStackException`, even with a shallow call stack. Records surface it first because their generated `PrintMembers` calls `RuntimeHelpers.EnsureSufficientExecutionStack`, but any caller of that API was affected.

@Guillermo-Santos pointed at the right place (`RhGetCurrentThreadStackBounds`) and both of his hypotheses turned out to be the root cause — the 64KB-vs-128KB mismatch *and* the wrong pointer, compounding each other:

- `RhGetCurrentThreadStackBounds` made its answer up: it returned the **current stack pointer** as the low bound and SP + 64KB as the high bound, instead of the thread's actual stack allocation.
- Our stacks were 64KB, and CoreLib only trusts a stack once more than 128KB separates the two bounds (`MinExecutionStackSize` on 64-bit). For anything smaller, `GetSufficientStackLimit` caches the stack **top** as the per-thread limit — and since the stack pointer always sits below the top, every later `EnsureSufficientExecutionStack` call throws. So with a 64KB window the exception was deterministic on every thread.

Disassembling the kernel attached to the issue confirmed both points: the compiled code is `call _native_get_sp; add rax, 0x10000`, and `GetSufficientStackLimit`'s `cmovle` takes the always-throw branch because 0x10000 ≤ 0x20000. The remaining candidate from the issue comments — the `(nint)` cast — is not involved: the constant survives intact in the binary, and a rebuild with all-`nuint` arithmetic still failed the same way (53/55).

## Fix

- `RhGetCurrentThreadStackBounds` now reports the scheduler thread's real `StackBase .. StackBase + StackSize`.
- `DefaultStackSize` goes from 64KB to 256KB, so threads keep 128KB of usable depth above CoreLib's reserve.
- The boot/idle thread has no allocated stack (it runs on the bootloader's), so kmain captures the boot stack's top at entry — before any managed frame exists — and a new Limine stack-size request grows that stack to 1MB. Safe to keep: the page allocator only consumes `Usable` memmap entries, so the bootloader-reclaimable region hosting the stack is never recycled.
- The GC's `GetCurrentStackEndForBootStack` now returns the captured top. It used to return the GC-triggering thread's `GetSp() + 64KB`, which is the wrong stack entirely when the parked idle thread is the one being scanned.

## Reproduction and verification

Three new cells in the Threading suite: `Thread_EnsureSufficientExecutionStack_Passes` and `Thread_RecordToString_Works` reproduce the issue as reported; `MainThread_RecordToString_Works` exercises the boot-stack branch (Limine request honored + captured top) from the main kernel thread.

| Run | Result |
| --- | --- |
| Before fix, x64 | 53/55 — both thread cells throw `InsufficientExecutionStackException` |
| Cast removed only (issue hypothesis), x64 | 53/55 — unchanged |
| After fix, x64 | Threading 56/56 |
| After fix, arm64 | Threading 56/56 |
| After fix, x64 | GarbageCollector 44/44 |
