### PR TITLE
Honor Thread constructor maxStackSize via SystemNative_CreateThread

### DIFF
--- a/src/Cosmos.Kernel.Core/Bridge/Interop/libSystemNative.cs
+++ b/src/Cosmos.Kernel.Core/Bridge/Interop/libSystemNative.cs
@@ -1,10 +1,12 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Cosmos.Kernel.Core.CPU;
+using Cosmos.Kernel.Core.IO;
 using Cosmos.Kernel.Core.Scheduler;
 
 namespace Cosmos.Kernel.Core.Bridge.Interop;
 
-internal static class libSystemNative
+internal static unsafe partial class libSystemNative
 {
     [StructLayout(LayoutKind.Sequential)]
     internal struct ProcessCpuInformation
@@ -69,6 +71,87 @@ internal static class libSystemNative
     internal static int SystemNative_SchedGetCpu()
     {
         return (int)SchedulerManager.GetCurrentCpuId();
+    }
+
+    /// <summary>
+    /// Smallest honored thread stack — CoreCLR's arbitrary minimum for
+    /// stack-size settings (RhConfig.cpp), standing in for PTHREAD_STACK_MIN
+    /// in upstream's pal_threading.c. Requests below CoreLib's 128KB
+    /// MinExecutionStackSize are still honored, like upstream on Linux:
+    /// EnsureSufficientExecutionStack then throws on that thread.
+    /// </summary>
+    private const nuint MinStackSize = 64 * 1024;
+
+    /// <summary>Stack sizes are rounded up to whole pages.</summary>
+    private const nuint StackSizeAlignment = 4096;
+
+#if ARCH_X64
+    [LibraryImport("*", EntryPoint = "_native_x64_get_code_selector")]
+    [SuppressGCTransition]
+    private static partial ulong GetCurrentCodeSelector();
+#endif
+
+    /// <summary>
+    /// Backs CoreLib's <c>Interop.Sys.CreateThread</c> P/Invoke. Upstream
+    /// <c>Thread.CreateThread</c> resolves the stack size itself — the
+    /// constructor's <c>maxStackSize</c>, or <c>RhGetDefaultStackSize</c> when
+    /// unset — and passes it here, so honoring
+    /// <c>new Thread(start, maxStackSize)</c> needs no access to Thread's
+    /// private StartHelper.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "SystemNative_CreateThread")]
+    internal static int SystemNative_CreateThread(IntPtr stackSize, delegate* unmanaged<IntPtr, IntPtr> startAddress, IntPtr parameter)
+    {
+        // startAddress (CoreLib's ThreadEntryPoint) is unused: threads start at
+        // ThreadNative.EntryPointStub and the scheduler's InvokeCurrentThreadStart
+        // runs CoreLib's StartThread with the GCHandle<Thread> parameter itself.
+        _ = startAddress;
+
+        if (!SchedulerManager.Enabled)
+        {
+            // Same behavior as before the scheduler existed: report success,
+            // the thread simply never runs.
+            return 1;
+        }
+
+        nuint size = ((nuint)stackSize + (StackSizeAlignment - 1)) & ~(StackSizeAlignment - 1);
+        if (size < MinStackSize)
+        {
+            size = MinStackSize;
+        }
+
+        using (InternalCpu.DisableInterruptsScope())
+        {
+            // Create scheduler thread with ThreadFlags.Managed set.
+            // SchedulerManager.InvokeCurrentThreadStart evaluates it to
+            // call the managed startup or not.
+            Scheduler.Thread thread = new Scheduler.Thread
+            {
+                Id = SchedulerManager.AllocateThreadId(),
+                CpuId = 0,
+                State = Scheduler.ThreadState.Created,
+                Flags = ThreadFlags.Managed
+            };
+
+            nuint entryPoint = (nuint)(delegate* unmanaged<IntPtr, void>)&ThreadNative.EntryPointStub;
+#if ARCH_X64
+            ushort cs = (ushort)GetCurrentCodeSelector();
+            thread.InitializeStack(entryPoint, cs, (nuint)parameter, size);
+#elif ARCH_ARM64
+            // ARM64: no code selector needed, use 0.
+            thread.InitializeStack(entryPoint, 0, (nuint)parameter, size);
+#endif
+            SchedulerManager.CreateThread(0, thread);
+            SchedulerManager.ReadyThread(0, thread);
+
+            Serial.WriteString("[libSystemNative] Thread ");
+            Serial.WriteNumber(thread.Id);
+            Serial.WriteString(" scheduled, stack ");
+            Serial.WriteNumber((ulong)size);
+            Serial.WriteString(" bytes\n");
+        }
+
+        return 1;
     }
 
     private static ulong GetMonotonicNs()

--- a/src/Cosmos.Kernel.Core/Runtime/Thread.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Thread.cs
@@ -45,6 +45,28 @@ public class Thread
         pStackLow = pStackHigh - (nint)BootStack.Size;
     }
 
+    /// <summary>
+    /// Default stack size CoreLib's Thread.CreateThread uses when the
+    /// constructor's maxStackSize is unset (&lt;= 0).
+    /// </summary>
+    [RuntimeExport("RhGetDefaultStackSize")]
+    internal static IntPtr RhGetDefaultStackSize()
+    {
+        return (nint)Scheduler.Thread.DefaultStackSize;
+    }
+
+    /// <summary>
+    /// Entry-point address CoreLib passes to SystemNative_CreateThread. Unused:
+    /// Cosmos threads start at ThreadNative.EntryPointStub and the scheduler's
+    /// InvokeCurrentThreadStart runs CoreLib's StartThread with the
+    /// GCHandle&lt;Thread&gt; parameter itself.
+    /// </summary>
+    [RuntimeExport("RhGetThreadEntryPointAddress")]
+    internal static IntPtr RhGetThreadEntryPointAddress()
+    {
+        return IntPtr.Zero;
+    }
+
     [RuntimeExport("RhSetCurrentThreadName")]
     internal static unsafe void RhSetCurrentThreadName(ushort* name)
     {

--- a/src/Cosmos.Kernel.Core/build/InteropAPI.txt
+++ b/src/Cosmos.Kernel.Core/build/InteropAPI.txt
@@ -8,3 +8,4 @@
 
 libSystem.Native!SystemNative_SchedGetCpu
 libSystem.Native!SystemNative_GetCpuUtilization
+libSystem.Native!SystemNative_CreateThread

--- a/src/Cosmos.Kernel.Plugs/System/Threading/ThreadPlug.cs
+++ b/src/Cosmos.Kernel.Plugs/System/Threading/ThreadPlug.cs
@@ -1,79 +1,20 @@
 using Cosmos.Build.API.Attributes;
-using Cosmos.Kernel.Core.Bridge;
-using Cosmos.Kernel.Core.CPU;
-using Cosmos.Kernel.Core.IO;
-using Cosmos.Kernel.Core.Scheduler;
-using Cosmos.Kernel.System.Timer;
 using SysThread = System.Threading.Thread;
-using SchedThread = Cosmos.Kernel.Core.Scheduler.Thread;
-using System.Runtime.InteropServices;
-using System.Runtime.CompilerServices;
-
-
-#if ARCH_X64
-using Cosmos.Kernel.Core.X64.Cpu;
-#endif
 
 namespace Cosmos.Kernel.Plugs.System.Threading;
 
 [Plug(typeof(SysThread))]
-public static unsafe class ThreadPlug
+public static class ThreadPlug
 {
-    [PlugMember]
-    public static bool CreateThread(SysThread aThis, GCHandle<SysThread> thisThreadHandle)
-    {
-        Serial.WriteString("[ThreadPlug] CreateThread(GCHandle<Thread>)\n");
-
-        // Initialize the '_stopped' field
-        _stopped(aThis) = new ManualResetEvent(false);
-
-        if (SchedulerManager.Enabled)
-        {
-            using (InternalCpu.DisableInterruptsScope())
-            {
-                // Create scheduler thread with the ThreadFlags.Managed set.
-                // SchedulerManager.InvokeCurrentThreadStart evaluates it to
-                // call the managed startup or not.
-                SchedThread thread = new SchedThread
-                {
-                    Id = SchedulerManager.AllocateThreadId(),
-                    CpuId = 0,
-                    State = Cosmos.Kernel.Core.Scheduler.ThreadState.Created,
-                    Flags = ThreadFlags.Managed
-                };
-
-                Serial.WriteString("[ThreadPlug] Thread ");
-                Serial.WriteNumber(thread.Id);
-                Serial.WriteString(" - setting up stack\n");
-
-                // Initial RIP/PC is the stable native entry-point stub in Core;
-                // the scheduler's InvokeCurrentThreadStart runs the registered delegate.
-                nuint entryPoint = (nuint)(delegate* unmanaged<IntPtr, void>)&ThreadNative.EntryPointStub;
-#if ARCH_X64
-                ushort cs = (ushort)Idt.GetCurrentCodeSelector();
-                thread.InitializeStack(entryPoint, cs, (nuint)GCHandle<SysThread>.ToIntPtr(thisThreadHandle));
-#elif ARCH_ARM64
-                // ARM64: no code selector needed, use 0.
-                thread.InitializeStack(entryPoint, 0, (nuint)GCHandle<SysThread>.ToIntPtr(thisThreadHandle));
-#endif
-                Serial.WriteString("[ThreadPlug] Stack initialized, registering with scheduler\n");
-
-                SchedulerManager.CreateThread(0, thread);
-                SchedulerManager.ReadyThread(0, thread);
-
-                Serial.WriteString("[ThreadPlug] Thread ");
-                Serial.WriteNumber(thread.Id);
-                Serial.WriteString(" scheduled for execution\n");
-            }
-        }
-
-        return true;
-    }
+    // Thread.CreateThread is deliberately NOT plugged: the upstream body reads
+    // the constructor's maxStackSize from the private StartHelper (unreachable
+    // from a plug — UnsafeAccessor rejects byref returns of inaccessible field
+    // types) and hands the resolved size to SystemNative_CreateThread, exported
+    // by Core's libSystemNative. RhGetDefaultStackSize /
+    // RhGetThreadEntryPointAddress in Cosmos.Kernel.Core.Runtime.Thread
+    // complete its dependencies.
 
     // TODO: Implement RhYield
     [PlugMember]
     public static bool Yield() => true;
-
-    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_stopped")]
-    private static extern ref ManualResetEvent _stopped(SysThread aThis);
 }

--- a/tests/Kernels/Cosmos.Kernel.Tests.Threading/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Threading/Kernel.cs
@@ -16,7 +16,7 @@ namespace Cosmos.Kernel.Tests.Threading;
 public class Kernel : Sys.Kernel
 {
     /// <summary>Total number of tests announced to the test runner for this suite.</summary>
-    private const int ExpectedTestCount = 56;
+    private const int ExpectedTestCount = 58;
 
     /// <summary>Lock/unlock increment iterations each worker thread performs in the lock and spinlock contention tests.</summary>
     private const int LockIterationsPerThread = 100;
@@ -120,6 +120,8 @@ public class Kernel : Sys.Kernel
         TR.Run("Thread_EnsureSufficientExecutionStack_Passes", TestEnsureSufficientStackInThread);
         TR.Run("Thread_RecordToString_Works", TestRecordToStringInThread);
         TR.Run("MainThread_RecordToString_Works", TestRecordToStringOnMainThread);
+        TR.Run("Thread_MaxStackSize_IsHonored", TestThreadMaxStackSizeHonored);
+        TR.Run("Thread_MaxStackSize_TinyRequestIsFloored", TestThreadTinyStackSizeFloored);
         TR.Run("Mutex_IdleThreadContention_KeepsTicketAccounting", TestMutexIdleThreadContention);
         TR.Run("InterruptEvent_TwoWaiters_BothWake", TestInterruptEventTwoWaiters);
         TR.Run("Mutex_ThreeContenders_AllAcquire", TestMutexThreeContenders);
@@ -486,6 +488,68 @@ public class Kernel : Sys.Kernel
         {
             Assert.Fail("record ToString should not throw InsufficientExecutionStackException on the main thread");
         }
+    }
+
+    // ===== Thread constructor maxStackSize (#435) =====
+    // Upstream Thread.CreateThread resolves the constructor's maxStackSize
+    // (<= 0 means RhGetDefaultStackSize) and passes it to the exported
+    // SystemNative_CreateThread, which page-aligns it and floors it at 64KB.
+    // The worker reads its own scheduler thread's StackSize to observe what
+    // was actually allocated.
+
+    /// <summary>Requested stack size for the honored-request test (512KB, above the default).</summary>
+    private const int LargeRequestedStackSize = 512 * 1024;
+    /// <summary>Requested stack size for the floored-request test (16KB, below the 64KB floor).</summary>
+    private const int TinyRequestedStackSize = 16 * 1024;
+    /// <summary>Smallest stack SystemNative_CreateThread allocates for a managed thread.</summary>
+    private const int MinThreadStackSize = 64 * 1024;
+
+    private static volatile bool _stackSizeProbeDone;
+    private static ulong _observedStackSize;
+    private static volatile bool _observedStackSufficient;
+
+    private static void StackSizeProbeWorker()
+    {
+        _observedStackSize = SchedulerManager.GetCpuState(SchedulerManager.GetCurrentCpuId())!.CurrentThread!.StackSize;
+        _observedStackSufficient = RuntimeHelpers.TryEnsureSufficientExecutionStack();
+        _stackSizeProbeDone = true;
+    }
+
+    private static void RunStackSizeProbe(int requestedStackSize)
+    {
+        _stackSizeProbeDone = false;
+        _observedStackSize = 0;
+        _observedStackSufficient = false;
+
+        var thread = new SysThread(StackSizeProbeWorker, requestedStackSize);
+        thread.Start();
+
+        for (int i = 0; i < TaskPollRetries && !_stackSizeProbeDone; i++)
+        {
+            TimerManager.Wait(TaskPollIntervalMs);
+        }
+    }
+
+    private static void TestThreadMaxStackSizeHonored()
+    {
+        RunStackSizeProbe(LargeRequestedStackSize);
+
+        Assert.True(_stackSizeProbeDone, "stack-size probe worker should finish");
+        Assert.True(_observedStackSize == LargeRequestedStackSize,
+            "scheduler thread should get the requested 512KB stack");
+        Assert.True(_observedStackSufficient,
+            "a 512KB stack should pass TryEnsureSufficientExecutionStack");
+    }
+
+    private static void TestThreadTinyStackSizeFloored()
+    {
+        RunStackSizeProbe(TinyRequestedStackSize);
+
+        Assert.True(_stackSizeProbeDone, "floored stack-size probe worker should finish");
+        Assert.True(_observedStackSize == MinThreadStackSize,
+            "a 16KB request should be floored to the 64KB minimum");
+        Assert.False(_observedStackSufficient,
+            "a 64KB stack sits below CoreLib's 128KB reserve, so TryEnsureSufficientExecutionStack reports false (upstream-faithful)");
     }
 
     // ===== Mutex idle-thread contention (scheduler Mutex, not System.Threading) =====


### PR DESCRIPTION
Fixes #435

## Problem

`new Thread(start, maxStackSize)` was silently ignored: `ThreadPlug.CreateThread` always allocated `DefaultStackSize`. With stacks committed upfront (no demand paging), kernels spawning many small workers had no way back to a leaner footprint after #434 raised the default to 256KB.

The fix — reading `_startHelper._maxStackSize` from the plug — is impossible: `StartHelper` is a private nested type, and `UnsafeAccessor` field accessors with an `[UnsafeAccessorType]` byref return are specified to throw `NotSupportedException` (`Verify_Type_GetInstanceFields_NotSupported` in the runtime's own tests; confirmed live as a kernel crash).

## Fix

Let upstream do the reading and plug the seam below it instead:

- `Thread.CreateThread` is no longer plugged. The upstream body legally reads the private `StartHelper`, resolves `<= 0` to `RhGetDefaultStackSize`, and passes the result to `Interop.Sys.CreateThread`.
- Core exports the two FCalls that body needs: `RhGetDefaultStackSize` (returns `DefaultStackSize`, 256KB) and `RhGetThreadEntryPointAddress` (unused address — Cosmos threads start at `ThreadNative.EntryPointStub` and the scheduler runs CoreLib's `StartThread` with the GCHandle parameter itself).
- Core's `libSystemNative` exports `SystemNative_CreateThread` — the old plug body, now receiving the resolved stack size as a plain parameter. It page-aligns the request and floors it at 64KB, CoreCLR's arbitrary minimum for stack-size settings (`RhConfig.cpp`), standing in for the `PTHREAD_STACK_MIN` clamp in upstream's `pal_threading.c`. The export lives in Core because only Core is in `UnmanagedEntryPointsAssembly` (`--generateunmanagedentrypoints`).
- `InteropAPI.txt` gains `libSystem.Native!SystemNative_CreateThread`. Without the direct-link entry the P/Invoke compiled as a lazy import whose stub returned garbage "success", so `StartCore` spun forever waiting for a thread that was never created.

Requests below CoreLib's 128KB `MinExecutionStackSize` are honored, matching upstream on Linux: `EnsureSufficientExecutionStack` throws on such a thread by contract. Sub-128KB workers are therefore for code that stays off record `ToString` and friends.

## Reproduction and verification

Two new Threading cells: the worker reads its own scheduler thread's `StackSize`. `Thread_MaxStackSize_IsHonored` requests 512KB and expects exactly that plus a passing `TryEnsureSufficientExecutionStack`; `Thread_MaxStackSize_TinyRequestIsFloored` requests 16KB and expects the 64KB floor plus `TryEnsureSufficientExecutionStack` reporting false.

Serial log confirms the sizes end-to-end: default threads log `stack 262144 bytes`, the probes log `524288` and `65536`.

| Run | Result |
| --- | --- |
| Threading x64 | 58/58 |
| Threading arm64 | 58/58 |
| GarbageCollector x64 | 44/44 |
