### PR TITLE
Add missing SVGAII3D commands

### DIFF
--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/FIFOCommand.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/FIFOCommand.cs
@@ -92,8 +92,12 @@ public enum FIFOCommand
     /// Define alpha cursor.
     /// </summary>
     DEFINE_ALPHA_CURSOR = 22,
+
     DEFINE_SURFACE = 1040,
     SURFACE_COPY = 1040 + 2,
+    SETMATERIAL = 1040 + 12,
+    SETLIGHTDATA = 1040 + 13,
+    SETLIGHTENABLE = 1040 + 14,
     SETVIEWPORT = 1040 + 15,
     SETZRANGE = 1040 + 8,
 
@@ -101,6 +105,7 @@ public enum FIFOCommand
     DESTROY_CONTEXT = 1040 + 6,
     DEFINE_SURFACE_V2 = 1040 + 30,  // Use V2 surface definition
     DESTROY_SURFACE = 1040 + 1,
+    DESTROY_SHADER = 1040 + 20,
     SET_RENDER_TARGET = 1040 + 10,
     CLEAR = 1040 + 17,
     SET_VIEWPORT = 1040 + 15,

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/Face.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/Face.cs
@@ -1,0 +1,14 @@
+namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
+
+/// <summary>
+/// ID values.
+/// </summary>
+public enum Face : uint
+{
+    SVGA3D_FACE_INVALID = 0,
+    SVGA3D_FACE_NONE = 1,
+    SVGA3D_FACE_FRONT = 2,
+    SVGA3D_FACE_BACK = 3,
+    SVGA3D_FACE_FRONT_BACK = 4,
+    SVGA3D_FACE_MAX
+}

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/LightType.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/LightType.cs
@@ -1,0 +1,14 @@
+namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
+
+/// <summary>
+/// ID values.
+/// </summary>
+public enum LightType : uint
+{
+    SVGA3D_LIGHTTYPE_INVALID = 0,
+    SVGA3D_LIGHTTYPE_POINT = 1,
+    SVGA3D_LIGHTTYPE_SPOT1 = 2,
+    SVGA3D_LIGHTTYPE_SPOT2 = 3,
+    SVGA3D_LIGHTTYPE_DIRECTIONAL = 4,
+    SVGA3D_LIGHTTYPE_MAX
+}

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdDestroyShader.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdDestroyShader.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
+
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+public struct SVGA3dCmdDestroyShader
+{
+    public uint cid;
+    public uint shid;
+    public SVGA3dShaderType type;
+}

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetLightData.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetLightData.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
+
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+public struct SVGA3dCmdSetLightData
+{
+    public uint cid;
+    public uint index;
+    public SVGA3dLightData data;
+}

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetLightEnabled.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetLightEnabled.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
+
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+public struct SVGA3dCmdSetLightEnabled
+{
+    public uint cid;
+    public uint index;
+    public uint enabled;
+}

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetMaterial.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetMaterial.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
+
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+public struct SVGA3dCmdSetMaterial
+{
+    public uint cid;
+    public Face face;
+    public SVGA3dMaterial material;
+}

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/LightData.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/LightData.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Numerics;
+using System.Runtime.InteropServices;
+
+namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
+
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+public struct SVGA3dLightData
+{
+    public LightType type;
+    public uint inWorldSpace;
+    public Vector4 diffuse;
+    public Vector4 specular;
+    public Vector4 ambient;
+    public Vector4 position;
+    public Vector4 direction;
+    public float range;
+    public float falloff;
+    public Vector3 attenuation;
+    public float theta;
+    public float phi;
+}

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Material.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Material.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Numerics;
+using System.Runtime.InteropServices;
+
+namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
+
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+public struct SVGA3dMaterial
+{
+    public Vector4 diffuse;
+    public Vector4 ambient;
+    public Vector4 specular;
+    public Vector4 emissive;
+    public float shininess;
+}

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/VMwareSvgaII3D.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/VMwareSvgaII3D.cs
@@ -375,6 +375,58 @@ public unsafe class VMWareSVGAII3D
         *states = (SVGA3dRenderState*)&cmd[1];
     }
 
+    public void SetLightEnable(uint cid, uint index, bool enabled)
+    {
+        SVGA3dCmdSetLightEnabled* cmd;
+        cmd = (SVGA3dCmdSetLightEnabled*)ReserveFIFO3D((uint)FIFOCommand.SETLIGHTENABLE, (uint)sizeof(SVGA3dCmdSetLightEnabled));
+        cmd->cid = cid;
+        cmd->index = index;
+        cmd->enabled = enabled ? 1u : 0u;
+    }
+
+    public void SetLightData(uint cid, uint index, SVGA3dLightData data)
+    {
+        SVGA3dCmdSetLightData* cmd;
+        cmd = (SVGA3dCmdSetLightData*)ReserveFIFO3D((uint)FIFOCommand.SETLIGHTDATA, (uint)sizeof(SVGA3dCmdSetLightData));
+        cmd->cid = cid;
+        cmd->index = index;
+
+        MemoryOp.MemCopy((byte*)&cmd->data, (byte*)&data, sizeof(SVGA3dLightData));
+    }
+
+    public void DestroyContext(uint cid)
+    {
+        uint* cmd;
+        cmd = (uint*)ReserveFIFO3D((uint)FIFOCommand.DESTROY_CONTEXT, sizeof(uint));
+        *cmd = cid;
+    }
+
+    public void DestroySurface(uint sid)
+    {
+        uint* cmd;
+        cmd = (uint*)ReserveFIFO3D((uint)FIFOCommand.DESTROY_SURFACE, sizeof(uint));
+        *cmd = sid;
+    }
+
+    public void DestroyShader(uint cid, uint shid, SVGA3dShaderType type)
+    {
+        SVGA3dCmdDestroyShader* cmd;
+        cmd = (SVGA3dCmdDestroyShader*)ReserveFIFO3D((uint)FIFOCommand.SETLIGHTENABLE, (uint)sizeof(SVGA3dCmdDestroyShader));
+        cmd->cid = cid;
+        cmd->shid = shid;
+        cmd->type = type;
+    }
+
+    public void SetMaterial(uint cid, Face face, SVGA3dMaterial material)
+    {
+        SVGA3dCmdSetMaterial* cmd;
+        cmd = (SVGA3dCmdSetMaterial*)ReserveFIFO3D((uint)FIFOCommand.SETMATERIAL, (uint)sizeof(SVGA3dCmdSetMaterial));
+        cmd->cid = cid;
+        cmd->face = face;
+
+        MemoryOp.MemCopy((byte*)&cmd->material, (byte*)&material, sizeof(SVGA3dMaterial));
+    }
+
     public void SetRenderState(uint cid, SVGA3dRenderState[] states)
     {
         SVGA3dRenderState* rs;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/VMwareSvgaII3D.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/VMwareSvgaII3D.cs
@@ -411,7 +411,7 @@ public unsafe class VMWareSVGAII3D
     public void DestroyShader(uint cid, uint shid, SVGA3dShaderType type)
     {
         SVGA3dCmdDestroyShader* cmd;
-        cmd = (SVGA3dCmdDestroyShader*)ReserveFIFO3D((uint)FIFOCommand.SETLIGHTENABLE, (uint)sizeof(SVGA3dCmdDestroyShader));
+        cmd = (SVGA3dCmdDestroyShader*)ReserveFIFO3D((uint)FIFOCommand.DESTROY_SHADER, (uint)sizeof(SVGA3dCmdDestroyShader));
         cmd->cid = cid;
         cmd->shid = shid;
         cmd->type = type;

--- a/tests/Kernels/Cosmos.Kernel.Tests.Graphic/Cosmos.Kernel.Tests.Graphic.csproj
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Graphic/Cosmos.Kernel.Tests.Graphic.csproj
@@ -16,8 +16,9 @@
 
   <!-- Hardware matrix (tests/profiles.json): `bare` keeps the default-adapter
        run (GOP over stdvga VBE on x64, ramfb on arm64); `vmware-svga` swaps in
-       the VMware SVGA II adapter — still GOP, over the device's embedded
-       Bochs VBE core, until an SVGAII driver exists for the suite to drive. -->
+       the VMware SVGA II adapter — the display still runs GOP over the
+       device's embedded Bochs VBE core, and the Svga3D_* FIFO tests bind the
+       SvgaIIDriver to the adapter without enabling it. -->
   <ItemGroup>
     <CosmosTestProfile Include="bare" />
     <CosmosTestProfile Include="vmware-svga" />

--- a/tests/Kernels/Cosmos.Kernel.Tests.Graphic/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Graphic/Kernel.cs
@@ -37,7 +37,7 @@ public class Kernel : Sys.Kernel
     protected override void BeforeRun()
     {
         Serial.WriteString("[Graphic Tests] Starting test suite\n");
-        TR.Start("Graphic Tests", expectedTests: 7);
+        TR.Start("Graphic Tests", expectedTests: 15);
 
         TR.Run("PCScreenFont_ChangeFont", TestPCScreenFont);
         TR.Run("Bitmap_Basic", TestBitmaps);
@@ -46,7 +46,21 @@ public class Kernel : Sys.Kernel
         TR.Run("Canvas_Basic", TestCanvasDrawing);
         TR.Run("VirtualCanvas_Basic", TestVirtualCanvas);
 
-        Serial.WriteString("[TypeCasting Tests] All tests completed\n");
+        // ==================== SVGA3D command layer ====================
+        // Struct sizes are host-independent and run on every cell; the FIFO
+        // wire-format tests bind the SVGA II adapter and only run on the
+        // vmware-svga profile (they skip on bare and on arm64).
+        Svga3DTests.Discover();
+        TR.Run("Svga3D_CommandStructSizes", Svga3DTests.TestCommandStructSizes);
+        TR.RunIf(Svga3DTests.DevicePresent, "Svga3D_DriverBind", Svga3DTests.TestDriverBind, Svga3DTests.SkipNoDevice);
+        TR.RunIf(Svga3DTests.Ready, "Svga3D_SetLightEnabled_Fifo", Svga3DTests.TestSetLightEnabled, Svga3DTests.SkipNoDevice);
+        TR.RunIf(Svga3DTests.Ready, "Svga3D_SetLightData_Fifo", Svga3DTests.TestSetLightData, Svga3DTests.SkipNoDevice);
+        TR.RunIf(Svga3DTests.Ready, "Svga3D_SetMaterial_Fifo", Svga3DTests.TestSetMaterial, Svga3DTests.SkipNoDevice);
+        TR.RunIf(Svga3DTests.Ready, "Svga3D_DestroyContext_Fifo", Svga3DTests.TestDestroyContext, Svga3DTests.SkipNoDevice);
+        TR.RunIf(Svga3DTests.Ready, "Svga3D_DestroySurface_Fifo", Svga3DTests.TestDestroySurface, Svga3DTests.SkipNoDevice);
+        TR.RunIf(Svga3DTests.Ready, "Svga3D_DestroyShader_Fifo", Svga3DTests.TestDestroyShader, Svga3DTests.SkipNoDevice);
+
+        Serial.WriteString("[Graphic Tests] All tests completed\n");
         TR.Finish();
     }
 

--- a/tests/Kernels/Cosmos.Kernel.Tests.Graphic/Svga3DTests.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Graphic/Svga3DTests.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Numerics;
+using Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
+using Cosmos.Kernel.HAL.Pci;
+using Cosmos.TestRunner.Framework;
+
+namespace Cosmos.Kernel.Tests.Graphic;
+
+/// <summary>
+/// Wire-format tests for the SVGA3D command layer (<see cref="VMWareSVGAII3D"/>).
+/// QEMU's vmware-svga device negotiates no 3D capability, so the commands can
+/// never be executed host-side; what CAN be validated under QEMU is the guest
+/// half of the contract: each call must place a correctly formed command —
+/// protocol command id, header size, field order and packing — into the FIFO.
+/// The driver is bound without ever enabling the device (no SetMode), and QEMU
+/// only consumes the FIFO while the device is enabled, so written commands sit
+/// inert in FIFO memory for inspection and are then discarded by rewinding
+/// NEXT_CMD. Expected ids and sizes are hard-coded from the SVGA3D protocol
+/// (svga3d_reg.h), not read back from the kernel's own enums, so a wrong enum
+/// value is caught instead of being compared against itself.
+/// </summary>
+public static unsafe class Svga3DTests
+{
+    /// <summary>Skip reason for the FIFO tests on cells without the adapter (the bare profile, and all of arm64).</summary>
+    public const string SkipNoDevice = "VMware SVGA II adapter not present — needs the vmware-svga profile";
+
+    /// <summary>PCI vendor id of VMware.</summary>
+    private const ushort VMwareVendorId = 0x15AD;
+
+    /// <summary>PCI device id of the SVGA II adapter.</summary>
+    private const ushort SvgaIIDeviceId = 0x0405;
+
+    /// <summary>SVGA_3D_CMD_SURFACE_DESTROY (SVGA_3D_CMD_BASE + 1).</summary>
+    private const uint CmdSurfaceDestroy = 1041;
+
+    /// <summary>SVGA_3D_CMD_CONTEXT_DESTROY (SVGA_3D_CMD_BASE + 6).</summary>
+    private const uint CmdContextDestroy = 1046;
+
+    /// <summary>SVGA_3D_CMD_SETMATERIAL (SVGA_3D_CMD_BASE + 12).</summary>
+    private const uint CmdSetMaterial = 1052;
+
+    /// <summary>SVGA_3D_CMD_SETLIGHTDATA (SVGA_3D_CMD_BASE + 13).</summary>
+    private const uint CmdSetLightData = 1053;
+
+    /// <summary>SVGA_3D_CMD_SETLIGHTENABLED (SVGA_3D_CMD_BASE + 14).</summary>
+    private const uint CmdSetLightEnabled = 1054;
+
+    /// <summary>SVGA_3D_CMD_SHADER_DESTROY (SVGA_3D_CMD_BASE + 20).</summary>
+    private const uint CmdShaderDestroy = 1060;
+
+    /// <summary>Size of SVGA3dCmdHeader (id + size) preceding every 3D command body.</summary>
+    private const uint HeaderBytes = 8;
+
+    /// <summary>Arbitrary context id used across the command tests.</summary>
+    private const uint TestCid = 7;
+
+    private static PciDevice? s_device;
+    private static SvgaIIDriver? s_driver;
+    private static VMWareSVGAII3D? s_svga3d;
+
+    /// <summary>True when the SVGA II adapter was enumerated on the PCI bus.</summary>
+    public static bool DevicePresent => s_device != null;
+
+    /// <summary>True when <see cref="TestDriverBind"/> bound the driver and 3D layer.</summary>
+    public static bool Ready => s_svga3d != null;
+
+    /// <summary>
+    /// Locate the SVGA II adapter on the PCI bus. Called once from BeforeRun;
+    /// the FIFO tests gate on the result so the bare cell skips cleanly.
+    /// </summary>
+    public static void Discover()
+    {
+        if (PciManager.Devices == null)
+        {
+            return;
+        }
+
+        for (int i = 0; i < (int)PciManager.Count; i++)
+        {
+            PciDevice device = PciManager.Devices[i];
+            if (device.VendorId == VMwareVendorId && device.DeviceId == SvgaIIDeviceId)
+            {
+                s_device = device;
+                return;
+            }
+        }
+    }
+
+    /// <summary>Bit pattern of a float, for asserting float fields through the dword-wide FIFO view.</summary>
+    private static uint FloatBits(float value) => *(uint*)&value;
+
+    /// <summary>Read the FIFO dword at an arbitrary byte offset.</summary>
+    private static uint FifoDword(uint byteOffset) => s_driver!.GetFIFO((FIFO)byteOffset);
+
+    /// <summary>NEXT_CMD before a command is written — where its header will land.</summary>
+    private static uint CaptureStart() => s_driver!.GetFIFO(FIFO.NextCmd);
+
+    /// <summary>
+    /// Discard everything written since <paramref name="start"/>. The device is
+    /// never enabled during this suite so nothing races the rewind, and it
+    /// guarantees the FIFO holds no 3D commands (which QEMU cannot parse) if
+    /// the device were ever enabled later.
+    /// </summary>
+    private static void Rewind(uint start) => s_driver!.SetFIFO(FIFO.NextCmd, start);
+
+    /// <summary>
+    /// Host-independent guard on the wire sizes of the command structs the 3D
+    /// layer reserves FIFO space with. Pack = 1 sequential layout must match
+    /// the SVGA3D protocol structs byte for byte; a drifted size corrupts the
+    /// FIFO stream at the very first command.
+    /// </summary>
+    public static void TestCommandStructSizes()
+    {
+        Assert.Equal(12, sizeof(SVGA3dCmdSetLightEnabled), "SVGA3dCmdSetLightEnabled is cid+index+enabled");
+        Assert.Equal(116, sizeof(SVGA3dLightData), "SVGA3dLightData matches the 116-byte protocol struct");
+        Assert.Equal(124, sizeof(SVGA3dCmdSetLightData), "SVGA3dCmdSetLightData is cid+index+SVGA3dLightData");
+        Assert.Equal(68, sizeof(SVGA3dMaterial), "SVGA3dMaterial matches the 68-byte protocol struct");
+        Assert.Equal(76, sizeof(SVGA3dCmdSetMaterial), "SVGA3dCmdSetMaterial is cid+face+SVGA3dMaterial");
+        Assert.Equal(12, sizeof(SVGA3dCmdDestroyShader), "SVGA3dCmdDestroyShader is cid+shid+type");
+    }
+
+    /// <summary>
+    /// Bind the driver and 3D layer to the adapter. Deliberately no SetMode:
+    /// the device stays disabled, the suite's GOP framebuffer keeps the
+    /// display, and QEMU never starts consuming the FIFO.
+    /// </summary>
+    public static void TestDriverBind()
+    {
+        try
+        {
+            SvgaIIDriver driver = new SvgaIIDriver(s_device!);
+            s_driver = driver;
+            s_svga3d = new VMWareSVGAII3D(driver);
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail("SVGAII driver bind threw: " + ex.Message);
+            return;
+        }
+
+        Assert.True(s_driver!.GetFIFO(FIFO.Min) < s_driver.GetFIFO(FIFO.Max), "FIFO Min/Max initialized");
+        Assert.Equal(s_driver.GetFIFO(FIFO.Min), s_driver.GetFIFO(FIFO.NextCmd), "FIFO NEXT_CMD starts at Min");
+    }
+
+    public static void TestSetLightEnabled()
+    {
+        uint start = CaptureStart();
+
+        s_svga3d!.SetLightEnable(TestCid, 2, true);
+
+        Assert.Equal(CmdSetLightEnabled, FifoDword(start), "command id is SETLIGHTENABLED");
+        Assert.Equal(12u, FifoDword(start + 4), "header size is the 12-byte body");
+        Assert.Equal(TestCid, FifoDword(start + 8), "cid");
+        Assert.Equal(2u, FifoDword(start + 12), "light index");
+        Assert.Equal(1u, FifoDword(start + 16), "enabled=true encodes as 1");
+        Assert.Equal(start + HeaderBytes + 12, s_driver!.GetFIFO(FIFO.NextCmd), "NEXT_CMD advanced by header+body");
+
+        Rewind(start);
+
+        s_svga3d.SetLightEnable(TestCid, 2, false);
+        Assert.Equal(0u, FifoDword(start + 16), "enabled=false encodes as 0");
+
+        Rewind(start);
+    }
+
+    public static void TestSetLightData()
+    {
+        SVGA3dLightData data = new SVGA3dLightData
+        {
+            type = LightType.SVGA3D_LIGHTTYPE_SPOT1,
+            inWorldSpace = 1,
+            diffuse = new Vector4(1f, 2f, 3f, 4f),
+            specular = new Vector4(5f, 6f, 7f, 8f),
+            ambient = new Vector4(9f, 10f, 11f, 12f),
+            position = new Vector4(13f, 14f, 15f, 16f),
+            direction = new Vector4(17f, 18f, 19f, 20f),
+            range = 21f,
+            falloff = 22f,
+            attenuation = new Vector3(23f, 24f, 25f),
+            theta = 26f,
+            phi = 27f,
+        };
+
+        uint start = CaptureStart();
+
+        s_svga3d!.SetLightData(TestCid, 1, data);
+
+        Assert.Equal(CmdSetLightData, FifoDword(start), "command id is SETLIGHTDATA");
+        Assert.Equal(124u, FifoDword(start + 4), "header size is the 124-byte body");
+        Assert.Equal(TestCid, FifoDword(start + 8), "cid");
+        Assert.Equal(1u, FifoDword(start + 12), "light index");
+        Assert.Equal((uint)LightType.SVGA3D_LIGHTTYPE_SPOT1, FifoDword(start + 16), "light type");
+        Assert.Equal(1u, FifoDword(start + 20), "inWorldSpace");
+        Assert.Equal(FloatBits(1f), FifoDword(start + 24), "diffuse.X");
+        Assert.Equal(FloatBits(4f), FifoDword(start + 36), "diffuse.W");
+        Assert.Equal(FloatBits(5f), FifoDword(start + 40), "specular.X");
+        Assert.Equal(FloatBits(9f), FifoDword(start + 56), "ambient.X");
+        Assert.Equal(FloatBits(13f), FifoDword(start + 72), "position.X");
+        Assert.Equal(FloatBits(17f), FifoDword(start + 88), "direction.X");
+        Assert.Equal(FloatBits(21f), FifoDword(start + 104), "range");
+        Assert.Equal(FloatBits(22f), FifoDword(start + 108), "falloff");
+        Assert.Equal(FloatBits(23f), FifoDword(start + 112), "attenuation.X");
+        Assert.Equal(FloatBits(25f), FifoDword(start + 120), "attenuation.Z");
+        Assert.Equal(FloatBits(26f), FifoDword(start + 124), "theta");
+        // phi is the last dword of the body: it landing here proves the whole
+        // 116-byte SVGA3dLightData copied with no packing drift anywhere.
+        Assert.Equal(FloatBits(27f), FifoDword(start + 128), "phi at end of body");
+        Assert.Equal(start + HeaderBytes + 124, s_driver!.GetFIFO(FIFO.NextCmd), "NEXT_CMD advanced by header+body");
+
+        Rewind(start);
+    }
+
+    public static void TestSetMaterial()
+    {
+        SVGA3dMaterial material = new SVGA3dMaterial
+        {
+            diffuse = new Vector4(1f, 2f, 3f, 4f),
+            ambient = new Vector4(5f, 6f, 7f, 8f),
+            specular = new Vector4(9f, 10f, 11f, 12f),
+            emissive = new Vector4(13f, 14f, 15f, 16f),
+            shininess = 32f,
+        };
+
+        uint start = CaptureStart();
+
+        s_svga3d!.SetMaterial(TestCid, Face.SVGA3D_FACE_FRONT_BACK, material);
+
+        Assert.Equal(CmdSetMaterial, FifoDword(start), "command id is SETMATERIAL");
+        Assert.Equal(76u, FifoDword(start + 4), "header size is the 76-byte body");
+        Assert.Equal(TestCid, FifoDword(start + 8), "cid");
+        Assert.Equal((uint)Face.SVGA3D_FACE_FRONT_BACK, FifoDword(start + 12), "face");
+        Assert.Equal(FloatBits(1f), FifoDword(start + 16), "diffuse.X");
+        Assert.Equal(FloatBits(5f), FifoDword(start + 32), "ambient.X");
+        Assert.Equal(FloatBits(9f), FifoDword(start + 48), "specular.X");
+        Assert.Equal(FloatBits(13f), FifoDword(start + 64), "emissive.X");
+        // shininess is the last dword of the body (see phi in TestSetLightData).
+        Assert.Equal(FloatBits(32f), FifoDword(start + 80), "shininess at end of body");
+        Assert.Equal(start + HeaderBytes + 76, s_driver!.GetFIFO(FIFO.NextCmd), "NEXT_CMD advanced by header+body");
+
+        Rewind(start);
+    }
+
+    public static void TestDestroyContext()
+    {
+        uint start = CaptureStart();
+
+        s_svga3d!.DestroyContext(TestCid);
+
+        Assert.Equal(CmdContextDestroy, FifoDword(start), "command id is CONTEXT_DESTROY");
+        Assert.Equal(4u, FifoDword(start + 4), "header size is the 4-byte body");
+        Assert.Equal(TestCid, FifoDword(start + 8), "cid");
+        Assert.Equal(start + HeaderBytes + 4, s_driver!.GetFIFO(FIFO.NextCmd), "NEXT_CMD advanced by header+body");
+
+        Rewind(start);
+    }
+
+    public static void TestDestroySurface()
+    {
+        uint start = CaptureStart();
+
+        s_svga3d!.DestroySurface(42);
+
+        Assert.Equal(CmdSurfaceDestroy, FifoDword(start), "command id is SURFACE_DESTROY");
+        Assert.Equal(4u, FifoDword(start + 4), "header size is the 4-byte body");
+        Assert.Equal(42u, FifoDword(start + 8), "sid");
+        Assert.Equal(start + HeaderBytes + 4, s_driver!.GetFIFO(FIFO.NextCmd), "NEXT_CMD advanced by header+body");
+
+        Rewind(start);
+    }
+
+    public static void TestDestroyShader()
+    {
+        uint start = CaptureStart();
+
+        s_svga3d!.DestroyShader(TestCid, 3, SVGA3dShaderType.SVGA3D_SHADERTYPE_PS);
+
+        Assert.Equal(CmdShaderDestroy, FifoDword(start), "command id is SHADER_DESTROY");
+        Assert.Equal(12u, FifoDword(start + 4), "header size is the 12-byte body");
+        Assert.Equal(TestCid, FifoDword(start + 8), "cid");
+        Assert.Equal(3u, FifoDword(start + 12), "shid");
+        Assert.Equal((uint)SVGA3dShaderType.SVGA3D_SHADERTYPE_PS, FifoDword(start + 16), "shader type");
+        Assert.Equal(start + HeaderBytes + 12, s_driver!.GetFIFO(FIFO.NextCmd), "NEXT_CMD advanced by header+body");
+
+        Rewind(start);
+    }
+}


### PR DESCRIPTION
### Added commands:

- SetLightEnabled     (enables a fixed function light)
- SetLightData          (sets the data of a fixed function light)
- SetMaterial             (sets the current render material)
- DestroyContext      (destroys/disposes a context)
- DestroySurface       (destroys/disposes a surface)
- DestroyShader        (destroys/disposes a shader)