### PR TITLE
🐛 Analyzer: stop demanding plugs for statically linked P/Invokes

### DIFF
--- a/src/Cosmos.Build.Analyzer.Patcher/PatcherAnalyzer.cs
+++ b/src/Cosmos.Build.Analyzer.Patcher/PatcherAnalyzer.cs
@@ -473,10 +473,46 @@ namespace Cosmos.Build.Analyzer.Patcher
                                  .Any(m => m.HasAttribute("PlugMemberAttribute")) ??
                              false;
 
-            bool hasSpecialAttributes =
-                symbol.HasAttribute("MethodImplAttribute", "DllImportAttribute", "LibraryImportAttribute");
-            DebugLog($"[DEBUG] hasMethodInPlugClass: {hasMethod}, hasSpecialAttributes: {hasSpecialAttributes}");
-            return !hasMethod && hasSpecialAttributes;
+            if (hasMethod)
+            {
+                return false;
+            }
+
+            AttributeData? pInvoke = symbol.GetAttributes().FirstOrDefault(a =>
+                a.AttributeClass?.Name is "DllImportAttribute" or "LibraryImportAttribute");
+
+            if (pInvoke != null)
+            {
+                // Module "*" is a direct P/Invoke resolved by the kernel link step
+                // (GCCProject objects, native libraries) — no plug involved. Imports
+                // from a real library file can never load on bare metal, so those
+                // still need a plug.
+                bool isStaticallyLinked = pInvoke.ConstructorArguments.FirstOrDefault().Value is "*";
+                DebugLog($"[DEBUG] P/Invoke on {symbol.Name}, staticallyLinked: {isStaticallyLinked}");
+                return !isStaticallyLinked;
+            }
+
+            // [MethodImpl] marks a plug candidate only for runtime-provided icalls;
+            // flags like AggressiveInlining sit on ordinary managed bodies.
+            AttributeData? methodImpl = symbol.GetAttributes()
+                .FirstOrDefault(a => a.AttributeClass?.Name == "MethodImplAttribute");
+
+            return methodImpl != null && IsInternalCall(methodImpl);
+        }
+
+        /// <summary>
+        /// Checks if a [MethodImpl] attribute carries MethodImplOptions.InternalCall.
+        /// </summary>
+        private static bool IsInternalCall(AttributeData methodImpl)
+        {
+            int options = methodImpl.ConstructorArguments.FirstOrDefault().Value switch
+            {
+                short shortOptions => shortOptions,
+                int intOptions => intOptions,
+                _ => 0
+            };
+
+            return (options & (int)MethodImplOptions.InternalCall) != 0;
         }
 
         /// <summary>

--- a/tests/Cosmos.Tests.Build.Analyzer.Patcher/AnalyzerTests.cs
+++ b/tests/Cosmos.Tests.Build.Analyzer.Patcher/AnalyzerTests.cs
@@ -74,6 +74,48 @@ public class AnalyzerTests
     }
 
     [Fact]
+    public async Task Test_StaticallyLinkedPInvokeDoesNotNeedPlug()
+    {
+        const string code = """
+
+                                    using System.Runtime.CompilerServices;
+                                    using System.Runtime.InteropServices;
+
+                                    namespace ConsoleApplication1
+                                    {
+                                        public static unsafe partial class NativeCpu
+                                        {
+                                            [LibraryImport("*", EntryPoint = "native_x64_rdseed")]
+                                            [return: MarshalAs(UnmanagedType.U1)]
+                                            public static partial bool X64RdSeed(ulong* outVal);
+
+                                            [DllImport("*", EntryPoint = "native_x64_cpuid")]
+                                            public static extern void X64CpuId(uint leaf, uint* eax);
+
+                                            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                                            public static int Twice(int value) => value * 2;
+                                        }
+
+                                        public class Test
+                                        {
+                                            public unsafe void TestMethod()
+                                            {
+                                                ulong seed;
+                                                uint eax;
+                                                NativeCpu.X64RdSeed(&seed);
+                                                NativeCpu.X64CpuId(0, &eax);
+                                                NativeCpu.Twice(21);
+                                            }
+                                        }
+                                    }
+                            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(code);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == DiagnosticMessages.MemberNeedsPlug.Id);
+    }
+
+    [Fact]
     public async Task Test_MethodNotImplemented()
     {
         const string code = """


### PR DESCRIPTION
## Problem

`PatcherAnalyzer.CheckIfNeedsPlug` reported NAOT0002 (`Member 'X' in class 'Y' requires a plug`, severity Error) for any accessed method carrying `[DllImport]`, `[LibraryImport]` or `[MethodImpl]` — the P/Invoke module name was never consulted. A user kernel declaring its own statically linked import:

```csharp
[LibraryImport("*", EntryPoint = "native_x64_rdseed")]
[return: MarshalAs(UnmanagedType.U1)]
public static partial bool X64RdSeed(ulong* outVal);
```

failed CoreCompile at every `NativeCpu.X64RdSeed(...)` call site, before the patcher, ILC or GCC ever ran — even though module `"*"` is the framework's own interop pattern and the symbol is resolved at kernel link time from `GCCProject` objects. The blanket `[MethodImpl]` check was a second false positive: an ordinary managed method with `[MethodImpl(MethodImplOptions.AggressiveInlining)]` and a body also tripped NAOT0002. The #17 analyzer only counted `MethodImplOptions.InternalCall`; the #89 rework replaced that with a bare `HasAttribute` check.

This went unnoticed because `Cosmos.*` assemblies are exempt from NAOT0002, and the one shipping demo of user C interop (a40bf45f) declared the import in the calling class and invoked it as a bare `testGCC()` — an identifier, not the `Class.Method` member access the analyzer inspects. d8915315 later removed that call, so no example has exercised user C interop since.

## Fix

- `CheckIfNeedsPlug` resolves the module name from `[DllImport]`/`[LibraryImport]`: `"*"` is a direct P/Invoke resolved by the kernel link step and never needs a plug; imports naming a real library file still error, since those can never load on bare metal.
- `[MethodImpl]` only counts when it carries `MethodImplOptions.InternalCall`, restoring the #17 semantics.
- Known residual: a named-module import covered by a `<DirectPInvoke Include="..."/>` item still trips NAOT0002 — the analyzer cannot see MSBuild items; `"*"` is the recommended form.

## Reproduction and verification

Reporter's exact code (rdseed C file via `GCCProject` + the `[LibraryImport("*")]` class above + an `AggressiveInlining` helper) added to DevKernel and driven with the Makefile:

| Run | Result |
| --- | --- |
| Before fix, `make build` | `error NAOT0002: Member 'X64RdSeed' in class 'NativeCpu' requires a plug`; same for `Twice` (`AggressiveInlining`) |
| After fix, `make build` | ISO built, 0 errors; `native_x64_rdseed` statically linked in the ELF |
| After fix, `make run` | `[DevKernel] rdseed interop ok` on serial |
| Analyzer test suite | 5/5 passed — new `Test_StaticallyLinkedPInvokeDoesNotNeedPlug` covers `LibraryImport("*")`, `DllImport("*")` and `AggressiveInlining`; existing tests keep `DllImport("example.dll")` and `InternalCall` flagged |