### PR TITLE
Public API tracking, package validation, and versioned docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -243,3 +243,26 @@ end_of_line = lf
 
 [*.{cmd,bat}]
 end_of_line = crlf
+
+# Public API tracking (Microsoft.CodeAnalysis.PublicApiAnalyzers, opt-in via
+# CosmosTrackPublicApi): every public surface change must land in the
+# project's PublicAPI.Unshipped.txt, reseeded with `make api`.
+[*.cs]
+dotnet_diagnostic.RS0016.severity = error
+dotnet_diagnostic.RS0017.severity = error
+# Optional-parameter overload style rules: not a goal for this surface.
+dotnet_diagnostic.RS0026.severity = none
+dotnet_diagnostic.RS0027.severity = none
+
+# Vendored code stays out of the declared surface: the tracking files list the
+# repo's own API only, and these types go internal in the pre-release surface
+# cleanup. Must come after the [*.cs] section above (later sections win).
+[src/Cosmos.Kernel.System/{IO/Compression/SharpZipLib,Graphics/Images/Png,Graphics/Fonts/TrueType}/**.cs]
+dotnet_diagnostic.RS0016.severity = none
+dotnet_diagnostic.RS0017.severity = none
+
+# Kernel.VersionString is generated from $(VersionPrefix) into the obj dir:
+# tracking a version-stamped constant would churn the file on every bump.
+[**/KernelVersion.g.cs]
+dotnet_diagnostic.RS0016.severity = none
+dotnet_diagnostic.RS0017.severity = none

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -48,6 +48,11 @@ jobs:
     - name: Verify output
       run: find docs/_site -type f | head -50
 
+    # keep_files: the dev site lives at the root of the published branch, next
+    # to the frozen per-release copies (v*/ subfolders, latest/, versions.json)
+    # that release.yml publishes on tags. Without it every dev deploy would
+    # wipe them. Tradeoff: files deleted from docs/ linger on the branch until
+    # overwritten; acceptable, they are unreachable from the rebuilt site.
     - name: Publish to GitHub Pages
       if: github.repository == 'valentinbreiz/nativeaot-patcher'
       uses: peaceiris/actions-gh-pages@v3
@@ -55,6 +60,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages
         publish_dir: ./docs/_site
+        keep_files: true
 
     # Same mechanism as the gen2 docs CD, but authenticated with a write
     # deploy key of the org Pages repository instead of the expired GH_PAGES
@@ -67,3 +73,4 @@ jobs:
         external_repository: CosmosOS/cosmosos.github.io
         publish_branch: master
         publish_dir: ./docs/_site
+        keep_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ name: Release
 #   2. Publish them to NuGet.org
 #   3. Build the Windows installer
 #   4. Create a GitHub release
+#   5. Publish a frozen copy of the docs to gh-pages under vX.Y.Z/ (plus
+#      latest/ and versions.json, consumed by the version dropdown)
 #
 # `workflow_dispatch` is available for manual reruns / testing; manual runs
 # only build artifacts and DO NOT publish to NuGet or create a GitHub release.
@@ -95,6 +97,30 @@ jobs:
           dotnet nuget locals all --clear
           ./.devcontainer/postCreateCommand.sh
 
+      # Final breaking-change guard on the API-tracked packages, comparing the
+      # freshly built nupkg against the CosmosApiBaselineVersion release on
+      # NuGet.org. Inert until that property is set in Directory.Build.props
+      # (first Gen3 release): pack-time package validation is also keyed on it.
+      - name: 🛡️ API compatibility guard
+        run: |
+          baseline=$(grep -oP '<CosmosApiBaselineVersion>\K[^<]+' Directory.Build.props || true)
+          if [[ -z "$baseline" ]]; then
+            echo "CosmosApiBaselineVersion is empty (no Gen3 release on NuGet yet): skipping."
+            exit 0
+          fi
+          dotnet tool install -g Microsoft.DotNet.ApiCompat.Tool
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          for id in Cosmos.Kernel.System; do
+            lower=$(echo "$id" | tr '[:upper:]' '[:lower:]')
+            echo "Comparing $id ${{ steps.version.outputs.version }} against baseline $baseline"
+            curl -sSfL \
+              "https://api.nuget.org/v3-flatcontainer/$lower/$baseline/$lower.$baseline.nupkg" \
+              -o "/tmp/$lower.baseline.nupkg"
+            apicompat package \
+              --baseline-package "/tmp/$lower.baseline.nupkg" \
+              "artifacts/package/release/$id.${{ steps.version.outputs.version }}.nupkg"
+          done
+
       - name: 📤 Upload packages
         uses: actions/upload-artifact@v4
         with:
@@ -131,6 +157,84 @@ jobs:
               --source https://api.nuget.org/v3/index.json \
               --skip-duplicate
           done
+
+  # ── Versioned docs (tag pushes only) ─────────────────────────────────────────
+  # Freezes the docs of this release under gh-pages/vX.Y.Z/, refreshes the
+  # latest/ alias, and rewrites versions.json (read by the version dropdown in
+  # docs/templates/custom). The dev site that build-docs.yml publishes at the
+  # branch root keeps these folders thanks to its keep_files: true.
+  publish-docs:
+    name: Publish Versioned Docs
+    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'valentinbreiz/nativeaot-patcher'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Install DocFX
+        run: |
+          dotnet tool update -g docfx
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
+      # Same restore scope as build-docs.yml: Cosmos.Kernel transitively
+      # project-references everything the DocFX metadata pass compiles.
+      - name: Restore docs projects
+        run: dotnet restore src/Cosmos.Kernel/Cosmos.Kernel.csproj
+
+      - name: Build Docs
+        run: |
+          cd docs
+          docfx docfx.json
+
+      # versions.json lists the frozen releases already on gh-pages plus this
+      # one, newest first. The dropdown adds the dev entry (site root) itself.
+      - name: Compose versions.json
+        id: version
+        run: |
+          version="${GITHUB_REF#refs/tags/}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          git fetch origin gh-pages --depth=1 || true
+          mkdir -p /tmp/pages-root
+          {
+            git ls-tree --name-only FETCH_HEAD 2>/dev/null | grep -E '^v[0-9]' || true
+            echo "$version"
+          } | sort -uVr | python3 -c '
+          import json, sys
+          versions = [line.strip() for line in sys.stdin if line.strip()]
+          json.dump({"latest": versions[0], "versions": versions}, sys.stdout, indent=2)
+          ' > /tmp/pages-root/versions.json
+          cat /tmp/pages-root/versions.json
+
+      - name: Publish frozen copy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./docs/_site
+          destination_dir: ${{ steps.version.outputs.version }}
+
+      - name: Refresh latest alias
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./docs/_site
+          destination_dir: latest
+
+      - name: Publish versions.json
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: /tmp/pages-root
+          keep_files: true
 
   # ── Windows Installer ────────────────────────────────────────────────────────
   build-installer-windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ on:
         description: 'Version override (e.g., 3.0.44). Leave empty to derive from global.json.'
         required: false
         type: string
+      docs_tag:
+        description: 'Backfill versioned docs for an existing tag (e.g. v3.0.82). Only runs publish-docs.'
+        required: false
+        type: string
   push:
     tags:
       - 'v*'
@@ -158,20 +162,32 @@ jobs:
               --skip-duplicate
           done
 
-  # ── Versioned docs (tag pushes only) ─────────────────────────────────────────
-  # Freezes the docs of this release under gh-pages/vX.Y.Z/, refreshes the
+  # ── Versioned docs ───────────────────────────────────────────────────────────
+  # Freezes the docs of a release under gh-pages/vX.Y.Z/, refreshes the
   # latest/ alias, and rewrites versions.json (read by the version dropdown in
   # docs/templates/custom). The dev site that build-docs.yml publishes at the
   # branch root keeps these folders thanks to its keep_files: true.
+  #
+  # Runs on v* tag pushes; dispatching with docs_tag backfills a tag released
+  # before this job existed (docs built from the tag's source, current
+  # templates/custom overlaid so the frozen pages carry the version dropdown).
   publish-docs:
     name: Publish Versioned Docs
-    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'valentinbreiz/nativeaot-patcher'
+    if: github.repository == 'valentinbreiz/nativeaot-patcher' && (startsWith(github.ref, 'refs/tags/v') || inputs.docs_tag != '')
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.docs_tag || github.ref }}
+
+      - name: Overlay current template (backfill only)
+        if: inputs.docs_tag != ''
+        run: |
+          git fetch origin main --depth=1
+          git checkout FETCH_HEAD -- docs/templates/custom
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -198,16 +214,23 @@ jobs:
       - name: Compose versions.json
         id: version
         run: |
-          version="${GITHUB_REF#refs/tags/}"
+          version="${{ inputs.docs_tag }}"
+          if [[ -z "$version" ]]; then
+            version="${GITHUB_REF#refs/tags/}"
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           git fetch origin gh-pages --depth=1 || true
           mkdir -p /tmp/pages-root
           {
             git ls-tree --name-only FETCH_HEAD 2>/dev/null | grep -E '^v[0-9]' || true
             echo "$version"
-          } | sort -uVr | python3 -c '
+          } | sort -uVr > /tmp/versions.txt
+          # A backfilled old tag must not steal the latest/ alias.
+          newest=$(head -1 /tmp/versions.txt)
+          echo "is_latest=$([[ "$newest" == "$version" ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          python3 -c '
           import json, sys
-          versions = [line.strip() for line in sys.stdin if line.strip()]
+          versions = [line.strip() for line in open("/tmp/versions.txt") if line.strip()]
           json.dump({"latest": versions[0], "versions": versions}, sys.stdout, indent=2)
           ' > /tmp/pages-root/versions.json
           cat /tmp/pages-root/versions.json
@@ -221,6 +244,7 @@ jobs:
           destination_dir: ${{ steps.version.outputs.version }}
 
       - name: Refresh latest alias
+        if: steps.version.outputs.is_latest == 'true'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This document covers how to report issues, collect the diagnostics a report need
 
 ## Reporting Issues
 
-Open issues through the [issue templates](https://github.com/CosmosOS/Cosmos/issues/new/choose). An actionable report contains three things: the **exact command** that was run, the **versions** involved, and the **full output** — a build log or serial log, not a screenshot of the last line.
+Open issues through the [issue templates](https://github.com/CosmosOS/Cosmos/issues/new/choose). An actionable report contains three things: the **exact command** that was run, the **versions** involved, and the **full output**: a build log or serial log, not a screenshot of the last line.
 
 ### Build or publish failures
 
@@ -15,16 +15,16 @@ Include:
 - The exact command and the directory it was run from (`cosmos build`, a VSCode task, or the full `dotnet publish` command line)
 - The output of `dotnet --version` and the host OS
 - The Cosmos.Sdk version: the `Sdk="Cosmos.Sdk/X.Y.Z"` line and `PackageReference` versions from the `.csproj`
-- The full build output — re-run with `--verbosity normal` if the failing step is not visible in the minimal log
+- The full build output; re-run with `--verbosity normal` if the failing step is not visible in the minimal log
 - The output of `cosmos check` if the failure looks toolchain-related (missing linker, assembler, QEMU)
 
 ### Kernel crashes
 
 Include:
 
-- The full serial log from boot to crash, not only the exception block — GC activity and driver init lines before the crash are often the actual clue
+- The full serial log from boot to crash, not only the exception block: GC activity and driver init lines before the crash are often the actual clue
 - The stack trace symbolicated to function names (see [Symbolicating a Stack Trace](#symbolicating-a-stack-trace)), or the kernel `.elf` attached as a zip
-- How the kernel was launched: `cosmos run`, a VSCode task, or the manual QEMU command line — attached disks, memory size, and input devices all affect reproduction
+- How the kernel was launched: `cosmos run`, a VSCode task, or the manual QEMU command line (attached disks, memory size, and input devices all affect reproduction)
 - A link to a repository that reproduces the crash, when possible
 
 ---
@@ -61,10 +61,10 @@ The `ip` address is where the CPU faulted; the numbered entries are the call cha
 
 | Symptom | Resolution |
 |---------|------------|
-| Framework build fails right after cloning | Run `./.devcontainer/postCreateCommand.sh` (or `make setup`) first — it builds all packages and registers the local NuGet source |
+| Framework build fails right after cloning | Run `./.devcontainer/postCreateCommand.sh` (or `make setup`) first: it builds all packages and registers the local NuGet source |
 | `undefined symbol: _native_*` / `Rhp*` at link time | The architecture-native package was not restored. Fixed after 3.0.68; on older SDKs pass `-p:CosmosArch=x64` (or `arm64`) to `dotnet publish`, or use `cosmos build` |
 | QEMU shows nothing or boots to the BIOS | Check the ISO architecture matches the QEMU binary, and force CD boot with `-boot d` when a disk is also attached |
-| An API that works in a normal .NET app throws in the kernel | Kernels are AOT-compiled — see [NativeAOT limitations](https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/limitations.md) — and not all of the base library is plugged yet |
+| An API that works in a normal .NET app throws in the kernel | Kernels are AOT-compiled (see [NativeAOT limitations](https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/limitations.md)) and not all of the base library is plugged yet |
 
 ---
 
@@ -87,7 +87,7 @@ The full rules are in the [Coding Guidelines](docs/articles/dev/coding-guideline
 - C# 14 / .NET 10, 4-space indentation, Allman braces
 - Braces are always required; use explicit types instead of `var`
 - Private fields `_camelCase`, static fields `s_camelCase`, constants `PascalCase`
-- Nullable reference types are enabled solution-wide; do not introduce nullable warnings — declare `?` honestly, guard late-initialized state with `[MemberNotNull]` helpers, and avoid the null-forgiving `!`
+- Nullable reference types are enabled solution-wide; do not introduce nullable warnings: declare `?` honestly, guard late-initialized state with `[MemberNotNull]` helpers, and avoid the null-forgiving `!`
 - Kernel code must be AOT-compatible: no reflection, no dynamic code generation
 - Architecture-specific code goes behind `#if ARCH_X64` / `#if ARCH_ARM64`, only in `Cosmos.Kernel.Core` or `Cosmos.Kernel.Plugs`
 
@@ -118,6 +118,6 @@ Before submitting a PR, run the suites relevant to the change. CI runs both arch
 
 ## Getting Help
 
-- [Documentation site](https://cosmosos.github.io/index.html) — User Guide and Developer Docs
+- [Documentation site](https://cosmosos.github.io/index.html): User Guide and Developer Docs
 - [Discord](https://discord.com/invite/kwtBwv6jhD)
 - [Existing issues](https://github.com/CosmosOS/Cosmos/issues)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -67,6 +67,32 @@
 
   <!-- Clang defaults to 'clang' on PATH — set by Cosmos.Build.CC.props -->
 
+  <!--
+    Public API tracking, opt-in per project with
+    <CosmosTrackPublicApi>true</CosmosTrackPublicApi>.
+
+    Microsoft.CodeAnalysis.PublicApiAnalyzers requires every public symbol to
+    be declared in PublicAPI.Shipped.txt (frozen at release) or
+    PublicAPI.Unshipped.txt (pending), next to the csproj. Any surface change
+    then shows up as a reviewable txt diff in the PR; `make api` reseeds the
+    files after a deliberate change (RS0016/RS0017 code fixes).
+
+    The same flag enables NuGet package validation. Baseline validation
+    (breaking-change detection against the last published release) activates
+    once CosmosApiBaselineVersion is set below: leave it empty until the first
+    Gen3 release is on NuGet.org, then pin it to that version.
+  -->
+  <PropertyGroup>
+    <CosmosApiBaselineVersion></CosmosApiBaselineVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(CosmosTrackPublicApi)' == 'true'">
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion Condition="'$(CosmosApiBaselineVersion)' != ''">$(CosmosApiBaselineVersion)</PackageValidationBaselineVersion>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(CosmosTrackPublicApi)' == 'true'">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
+  </ItemGroup>
+
   <!-- Native ASM files come from the NuGet packages (Cosmos.Kernel.Native.X64/ARM64).
        Local-source overrides removed to avoid duplicate-symbol conflicts when both the
        local copy and the NuGet copy are picked up by AsmSearchPath. To iterate on native

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,6 +33,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Testing.Verifiers.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.14.0" />

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,17 @@ DEV_DISK_FLAGS := -drive file=$(AHCI_IMG),if=none,id=ahcidisk,format=raw \
                   -drive file=$(NVME_IMG),if=none,id=nvmedisk,format=raw \
                   -device nvme,drive=nvmedisk,serial=cosmos-nvme
 
-.PHONY: setup build clean distclean run run-dev debug-dev disks test test-cache
+.PHONY: setup build clean distclean run run-dev debug-dev disks test test-cache api
 
 setup:
 	./.devcontainer/postCreateCommand.sh
+
+# Reseed the PublicAPI.*.txt files of the API-tracked projects: builds the
+# project, then applies the RS0016/RS0017 code fixes (declare new public
+# symbols, drop deleted ones). Run after any deliberate public surface change.
+api:
+	dotnet format analyzers src/Cosmos.Kernel.System/Cosmos.Kernel.System.csproj \
+		--diagnostics RS0016 RS0017 --severity info
 
 build:
 	dotnet publish -c Debug -r $(RID) \

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Cosmos gen2 (the current public Cosmos OS) compiles C# IL to x86 assembly throug
 
 ## Documentation
 
-[Documentation site](https://cosmosos.github.io/index.html) — split into a **User Guide** (build your own OS with Cosmos) and **Developer Docs** (contribute to Cosmos itself / architecture internals).
+[Documentation site](https://cosmosos.github.io/index.html): split into a **User Guide** (build your own OS with Cosmos) and **Developer Docs** (contribute to Cosmos itself / architecture internals).
 
 **User Guide**
 
@@ -96,4 +96,4 @@ See the live list on the [Contributors page](https://github.com/CosmosOS/Cosmos/
 
 ## License
 
-[MIT](LICENSE) — Copyright (c) 2024 Kaleb McGhie (zarlo) and contributors.
+[MIT](LICENSE): Copyright (c) 2024 Kaleb McGhie (zarlo) and contributors.

--- a/docs/articles/dev/build/patcher-build.md
+++ b/docs/articles/dev/build/patcher-build.md
@@ -158,8 +158,8 @@ flowchart TD
 
 ## Outputs
 
-- Patched app assembly: `$(IntermediateOutputPath)/cosmos/$(AssemblyName)_patched.dll` — main project output after plug application.
-- Reference assemblies for ILC: `$(IntermediateOutputPath)/cosmos/ref/*.dll` — patched where plugs apply; otherwise copied unmodified for resolution.
+- Patched app assembly: `$(IntermediateOutputPath)/cosmos/$(AssemblyName)_patched.dll`, the main project output after plug application.
+- Reference assemblies for ILC: `$(IntermediateOutputPath)/cosmos/ref/*.dll`, patched where plugs apply; otherwise copied unmodified for resolution.
 - Intermediate directories are created on demand under `$(IntermediateOutputPath)/cosmos/`.
 
 Notes:

--- a/docs/articles/dev/coding-guidelines.md
+++ b/docs/articles/dev/coding-guidelines.md
@@ -205,7 +205,7 @@ Use `static class` for stateless kernel utilities that have no per-instance stat
 Use a `static class` with an `Initialize()` method and an `IsInitialized` property. Managers coordinate subsystem state without requiring an instance:
 
 ```csharp
-// Simple manager — no underlying instance to expose
+// Simple manager: no underlying instance to expose
 public static class TimerManager
 {
     private static ITimerDevice? _timer;
@@ -217,7 +217,7 @@ public static class TimerManager
     public static void Wait(int ms) { ... }
 }
 
-// Manager wrapping a pluggable implementation — expose via Current
+// Manager wrapping a pluggable implementation: expose via Current
 public static class SchedulerManager
 {
     private static IScheduler? _currentScheduler;
@@ -404,7 +404,7 @@ Plugs replace BCL methods at the IL level. The patcher rewires calls at build ti
 
 There are two patterns depending on the caller:
 
-**`[RuntimeExport]`** — for NativeAOT runtime stubs (called by the runtime itself). These match the `[RuntimeImport]` declarations in [`System.Private.CoreLib/RuntimeImports.cs`](https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs):
+**`[RuntimeExport]`**: for NativeAOT runtime stubs (called by the runtime itself). These match the `[RuntimeImport]` declarations in [`System.Private.CoreLib/RuntimeImports.cs`](https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs):
 
 ```csharp
 [RuntimeExport("RhNewArray")]
@@ -414,7 +414,7 @@ internal static unsafe void* RhNewArray(MethodTable* pEEType, int length)
 }
 ```
 
-**`[UnmanagedCallersOnly]`** — for C# methods callable from native C code (bridges):
+**`[UnmanagedCallersOnly]`**: for C# methods callable from native C code (bridges):
 
 ```csharp
 [UnmanagedCallersOnly(EntryPoint = "__cosmos_serial_write")]
@@ -590,7 +590,7 @@ private static void ThrowIfKeyboardDisabled()
 
 ## 12. Nullable Reference Types
 
-Nullable reference types are enabled solution-wide (`<Nullable>enable</Nullable>` in `Directory.Build.props`). Annotations are part of the API contract: a reference type without `?` is a promise that it is never null. New and modified code must not introduce nullable warnings — annotate honestly instead of silencing.
+Nullable reference types are enabled solution-wide (`<Nullable>enable</Nullable>` in `Directory.Build.props`). Annotations are part of the API contract: a reference type without `?` is a promise that it is never null. New and modified code must not introduce nullable warnings: annotate honestly instead of silencing.
 
 ### Rules
 
@@ -605,10 +605,10 @@ Nullable reference types are enabled solution-wide (`<Nullable>enable</Nullable>
 
 ### Honest Annotations
 
-A member that can return `null` is declared with `?` — never hide it behind `!` to preserve an old signature. Conversely, do not add runtime null checks for values the annotations already guarantee: no `if (buffer == null) throw` on a non-nullable parameter, no `?? "fallback"` on a non-nullable return.
+A member that can return `null` is declared with `?`: never hide it behind `!` to preserve an old signature. Conversely, do not add runtime null checks for values the annotations already guarantee: no `if (buffer == null) throw` on a non-nullable parameter, no `?? "fallback"` on a non-nullable return.
 
 ```csharp
-// Declare what can actually be null — callers are forced to handle it
+// Declare what can actually be null: callers are forced to handle it
 public static IScheduler? Current => _currentScheduler;
 public static PerCpuState? GetCpuState(uint cpuId) => _cpuStates?[cpuId];
 
@@ -618,7 +618,7 @@ private byte[] _window = [];                 // not: private byte[]? _window;
 
 ### Guard Helpers
 
-Managers with deferred initialization expose `ThrowIf*NotInitialized()` guards annotated with `[MemberNotNull(...)]` and call them at the top of public entry points (see [Managers](#4-class--type-design)). One call proves the field non-null for the rest of the method — no `!` and no per-line checks:
+Managers with deferred initialization expose `ThrowIf*NotInitialized()` guards annotated with `[MemberNotNull(...)]` and call them at the top of public entry points (see [Managers](#4-class--type-design)). One call proves the field non-null for the rest of the method, with no `!` and no per-line checks:
 
 ```csharp
 private static PerCpuState[]? _cpuStates;
@@ -672,7 +672,7 @@ Null-forgiving `!` is a last resort for invariants flow analysis cannot see (eg.
 
 The format CI (`dotnet format --severity error`) enforces the null-handling style rules in `.editorconfig`: `csharp_style_throw_expression`, `dotnet_style_coalesce_expression`, `dotnet_style_null_propagation`, `csharp_style_prefer_null_check_over_type_check`, `csharp_style_pattern_matching_over_as_with_null_check`, `dotnet_style_prefer_is_null_check_over_reference_equality_method`, and `csharp_style_conditional_delegate_call`.
 
-Nullable warnings (`CS86xx`) are not errors yet — do not introduce new ones.
+Nullable warnings (`CS86xx`) are not errors yet: do not introduce new ones.
 
 ---
 
@@ -727,7 +727,7 @@ public static long TscFrequency { get; set; } = 1_000_000_000;
 // stackalloc for small buffers (no heap allocation)
 Span<byte> buffer = stackalloc byte[64];
 
-// field keyword — auto-property with validation without a manual backing field
+// field keyword: auto-property with validation without a manual backing field
 public int Priority
 {
     get => field;
@@ -772,7 +772,7 @@ if (ptr == null)                  // Good
 Use `[FeatureSwitchDefinition]` for compile-time feature toggling (trimmed by NativeAOT linker). All feature flags live in `Cosmos.Kernel.Core.CosmosFeatures`:
 
 ```csharp
-// In CosmosFeatures.cs — one property per feature
+// In CosmosFeatures.cs: one property per feature
 [FeatureSwitchDefinition("Cosmos.Kernel.HAL.Interrupts.Enabled")]
 public static bool InterruptsEnabled =>
     AppContext.TryGetSwitch("Cosmos.Kernel.HAL.Interrupts.Enabled", out bool enabled)
@@ -841,7 +841,7 @@ public static void Halt(string message) { ... }
 
 ### Inline Comments
 
-Use sparingly — only when the code isn't self-explanatory:
+Use sparingly, only when the code isn't self-explanatory:
 
 ```csharp
 // Stack layout (growing downward from top):

--- a/docs/articles/dev/install-dev.md
+++ b/docs/articles/dev/install-dev.md
@@ -61,4 +61,4 @@ cosmos.patcher --version
 cosmos --version
 ```
 
-If any step fails, re-run the script — it is designed to be idempotent and will clean up previous state before rebuilding.
+If any step fails, re-run the script: it is designed to be idempotent and will clean up previous state before rebuilding.

--- a/docs/articles/dev/kernel-project-layout.md
+++ b/docs/articles/dev/kernel-project-layout.md
@@ -1,6 +1,6 @@
 # Kernel Project Layout
 
-The Cosmos kernel is composed of layered projects to enforce a clean dependency graph. Dependencies flow **downward only** — a project must never reference a project above it in the hierarchy.
+The Cosmos kernel is composed of layered projects to enforce a clean dependency graph. Dependencies flow **downward only**: a project must never reference a project above it in the hierarchy.
 
 ## Dependency Graph
 
@@ -29,13 +29,13 @@ flowchart LR;
 | Project | Purpose |
 |---------|---------|
 | **Cosmos.Kernel.System** | High-level OS APIs: Console, Graphics, Network, Timer, Mouse. The layer user kernels interact with. |
-| **Cosmos.Kernel.HAL** | Hardware Abstraction Layer — shared logic, platform registration (`PlatformHAL`), device managers, arch-independent drivers (AHCI, NVMe, virtio). |
+| **Cosmos.Kernel.HAL** | Hardware Abstraction Layer: shared logic, platform registration (`PlatformHAL`), device managers, arch-independent drivers (AHCI, NVMe, virtio). |
 | **Cosmos.Kernel.HAL.Interfaces** | Pure interfaces (`IPlatformInitializer`, `ICpuOps`, `IKeyboardDevice`, etc.). No implementations. |
 | **Cosmos.Kernel.HAL.X64** | x86-64 HAL implementations (PCI, APIC, PS/2, ACPI, etc.). |
 | **Cosmos.Kernel.HAL.ARM64** | ARM64 HAL implementations (GIC, PL011, generic timer, etc.). |
 | **Cosmos.Kernel.Core** | Low-level runtime: memory management, GC, scheduler, serial I/O, panic handler. |
-| **Cosmos.Kernel.Native.X64** | x86-64 assembly files (`.s`, GAS syntax) — interrupt stubs, context switching, SIMD. |
-| **Cosmos.Kernel.Native.ARM64** | ARM64 assembly files (`.s`, GAS syntax) — exception vectors, context switching. |
+| **Cosmos.Kernel.Native.X64** | x86-64 assembly files (`.s`, GAS syntax): interrupt stubs, context switching, SIMD. |
+| **Cosmos.Kernel.Native.ARM64** | ARM64 assembly files (`.s`, GAS syntax): exception vectors, context switching. |
 | **Cosmos.Kernel.Native.MultiArch** | Cross-platform native C code (ACPI, libc stubs). |
 | **Cosmos.Kernel.Plugs** | IL-level method replacements for BCL types (`Console`, `Thread`, `Environment`, etc.). |
 | **Cosmos.Kernel.Boot.Limine** | Limine bootloader protocol integration. |
@@ -45,7 +45,7 @@ flowchart LR;
 
 | Project | Purpose |
 |---------|---------|
-| **Cosmos.Build.Patcher** | IL patcher — applies plugs and patches at build time. |
+| **Cosmos.Build.Patcher** | IL patcher: applies plugs and patches at build time. |
 | **Cosmos.Build.Ilc** | Custom ILC (IL Compiler) integration for NativeAOT. |
 | **Cosmos.Build.Asm** | Clang assembly compilation (GAS-syntax `.s` files for both x64 and ARM64). |
 | **Cosmos.Build.CC** | Clang cross-compilation for x64 and ARM64 bare-metal targets. |

--- a/docs/articles/dev/public-api.md
+++ b/docs/articles/dev/public-api.md
@@ -1,0 +1,83 @@
+# Public API Tracking
+
+The public surface of the kernel packages is declared in text files checked into the repository, enforced by Roslyn analyzers at build time, guarded against breaking changes at release time, and published as one frozen documentation site per release. This page describes the three mechanisms and the contributor workflow they impose.
+
+---
+
+## The declared surface
+
+Projects opt in with `<CosmosTrackPublicApi>true</CosmosTrackPublicApi>` in their `.csproj` (wired in `Directory.Build.props`). Today that covers `Cosmos.Kernel.System`; `Cosmos.Kernel.Core` and the HAL packages follow once their surfaces are audited.
+
+An opted-in project references [Microsoft.CodeAnalysis.PublicApiAnalyzers](https://github.com/dotnet/roslyn-analyzers/blob/main/src/PublicApiAnalyzers/PublicApiAnalyzers.Help.md), which requires every `public` symbol to appear in one of two files next to the `.csproj`:
+
+| File | Contents |
+|------|----------|
+| `PublicAPI.Shipped.txt` | The surface of the last release. Frozen: it only changes when a release is cut. |
+| `PublicAPI.Unshipped.txt` | Surface added, changed, or removed since then. Emptied into `Shipped` at release time. |
+
+Two diagnostics enforce the contract, both raised as build errors:
+
+| Rule | Meaning |
+|------|---------|
+| `RS0016` | A public symbol exists in code but is not declared in either file. |
+| `RS0017` | A declared symbol no longer exists in code. |
+
+The effect is that any change to the public surface, deliberate or accidental, must land in the same commit as a diff of `PublicAPI.Unshipped.txt`, where the review can see it.
+
+Three categories stay out of the files, the first two through `.editorconfig` overrides that set `RS0016`/`RS0017` to `none` under their paths:
+
+- The vendored directories (`SharpZipLib`, the PNG decoder, the TrueType fonts). Their types that are still `public` leak into the package anyway; making them `internal` is part of the pre-release surface cleanup, and keeping them out of the files means that cleanup will not churn the declared surface.
+- The generated `KernelVersion.g.cs` that carries `Kernel.VersionString`: the declared-API format records constant values, and this one changes with every version stamp.
+- `internal` symbols, including everything exposed to the test kernels through `InternalsVisibleTo`.
+
+### Changing the public API
+
+1. Make the code change. The build now fails with `RS0016` or `RS0017`.
+2. Run `make api` from the repository root. It rebuilds the tracked projects and applies the analyzer's code fixes to `PublicAPI.Unshipped.txt`. The IDE quick fix ("Add to public API") on each diagnostic is equivalent.
+3. Commit the txt diff together with the code.
+
+Removing or changing a symbol that already shipped is recorded as a `*REMOVED*` line in `Unshipped`, which is exactly what it is: a breaking change, visible as such in the PR. Before the first release, while `Shipped` is empty, a removal simply drops the line.
+
+---
+
+## Package validation
+
+The same `CosmosTrackPublicApi` flag enables [NuGet package validation](https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/overview) on the project, and `Directory.Build.props` holds the baseline knob:
+
+```xml
+<CosmosApiBaselineVersion></CosmosApiBaselineVersion>
+```
+
+The property is empty until the first Gen3 release is published on NuGet.org. Once it is pinned to that version, two guards activate on their own:
+
+- `PackageValidationBaselineVersion` makes every pack compare the package against the baseline release and fail on binary breaking changes.
+- The `API compatibility guard` step in `release.yml` downloads the baseline package from NuGet.org and runs [Microsoft.DotNet.ApiCompat.Tool](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/global-tool) against the freshly built one, as a final gate before publishing.
+
+An intentional breaking change is recorded in a `CompatibilitySuppressions.xml` next to the project (`dotnet pack /p:ApiCompatGenerateSuppressionFile=true` generates it), so it too becomes a reviewable diff.
+
+---
+
+## Versioned docs
+
+The docs site at the root of `gh-pages` follows the main branch: it is the dev documentation, rebuilt by `build-docs.yml` on every docs push. Releases get frozen copies next to it, published by the `publish-docs` job of `release.yml` when a `v*` tag is pushed:
+
+| Path | Contents |
+|------|----------|
+| `/` | Dev docs, follows main. |
+| `/vX.Y.Z/` | The docs as built from tag `vX.Y.Z`, never rebuilt. |
+| `/latest/` | Alias of the newest release, stable URL for external links. |
+| `/versions.json` | The release list, newest first, plus the `latest` marker. |
+
+The version dropdown in the site navbar comes from `docs/templates/custom/public/main.js`. It reads `versions.json`, lists `dev` plus every release, and keeps the reader on the same page across versions when the page exists there. It only appears once `versions.json` exists, i.e. after the first tagged release; until then the site behaves exactly as before.
+
+The dev deploys use `keep_files: true` so they never wipe the `v*/` folders, at the cost of deleted dev pages lingering on the branch until overwritten.
+
+---
+
+## Release checklist
+
+What cutting a release changes in this system:
+
+1. Tag `vX.Y.Z`. CI builds the packages, runs the API compatibility guard, publishes to NuGet.org, and freezes `/vX.Y.Z/` docs.
+2. Move the contents of `PublicAPI.Unshipped.txt` into `PublicAPI.Shipped.txt` (drop the `*REMOVED*` pairs), leaving `Unshipped` empty.
+3. Set `CosmosApiBaselineVersion` in `Directory.Build.props` to `X.Y.Z` so the next cycle validates against this release.

--- a/docs/articles/dev/testing.md
+++ b/docs/articles/dev/testing.md
@@ -16,14 +16,14 @@ dotnet test
 
 ### Test Projects
 
-- **Cosmos.Tests.Build.Asm** – Verifies the assembly build task runs via clang.
+- **Cosmos.Tests.Build.Asm**: Verifies the assembly build task runs via clang.
   - `Test1`
-- **Cosmos.Tests.Build.Analyzer.Patcher** – Validates that code does not contain plug architecture errors.
+- **Cosmos.Tests.Build.Analyzer.Patcher**: Validates that code does not contain plug architecture errors.
   - `Test_AnalyzeAccessedMember`
   - `Test_MethodNotImplemented`
   - `Test_StaticConstructorTooManyParameters`
   - `Test_StaticConstructorNotImplemented`
-- **Cosmos.Tests.Scanner** – Validates that all required plugs are detected correctly.
+- **Cosmos.Tests.Scanner**: Validates that all required plugs are detected correctly.
   - `LoadPlugMethods_ShouldReturnPublicStaticMethods`
   - `LoadPlugMethods_ShouldReturnEmpty_WhenNoMethodsExist`
   - `LoadPlugMethods_ShouldContainAddMethod_WhenPlugged`
@@ -31,7 +31,7 @@ dotnet test
   - `LoadPlugs_ShouldIgnoreClassesWithoutPlugAttribute`
   - `LoadPlugs_ShouldHandleOptionalPlugs`
   - `FindPluggedAssemblies_ShouldReturnMatchingAssemblies`
-- **Cosmos.Tests.Patcher** – Ensures that plugs are applied successfully to target methods and types.
+- **Cosmos.Tests.Patcher**: Ensures that plugs are applied successfully to target methods and types.
   - `PatchAssembly_ShouldSkipWhenNoMatchingPlugs`
   - `PatchObjectWithAThis_ShouldPlugInstanceCorrectly`
   - `PatchConstructor_ShouldPlugCtorCorrectly`
@@ -39,8 +39,8 @@ dotnet test
   - `PatchType_ShouldReplaceAllMethodsCorrectly`
   - `PatchType_ShouldPlugAssembly`
   - `AddMethod_BehaviorBeforeAndAfterPlug`
-- **Cosmos.Tests.NativeWrapper** – Contains runtime assets; no unit tests.
-- **Cosmos.Tests.NativeLibrary** – Provides native code used in tests; no unit tests.
+- **Cosmos.Tests.NativeWrapper**: Contains runtime assets; no unit tests.
+- **Cosmos.Tests.NativeLibrary**: Provides native code used in tests; no unit tests.
 
 ---
 
@@ -57,9 +57,9 @@ Kernel integration tests compile a real NativeAOT kernel, boot it in QEMU, and c
 
 #### HelloWorld Tests
 
-- `Test_BasicArithmetic` – Addition (2+2=4)
-- `Test_BooleanLogic` – True/False assertions
-- `Test_IntegerComparison` – Equality and comparison operators
+- `Test_BasicArithmetic`: Addition (2+2=4)
+- `Test_BooleanLogic`: True/False assertions
+- `Test_IntegerComparison`: Equality and comparison operators
 
 #### Memory Tests
 
@@ -73,19 +73,19 @@ Kernel integration tests compile a real NativeAOT kernel, boot it in QEMU, and c
 - `Memory_StringConcat`, `Memory_StringBuilder`
 - `Memory_ZeroLengthArray`, `Memory_EmptyString`, `Memory_LargeAllocation`
 
-**Generic Collections – List (14 tests):**
+**Generic Collections - List (14 tests):**
 - `Collections_ListInt`, `Collections_ListString`, `Collections_ListByte`
 - `Collections_ListLong`, `Collections_ListStruct`
 - `Collections_ListContains`, `Collections_ListIndexOf`, `Collections_ListRemoveAt`
 - `Collections_ListInsert`, `Collections_ListRemove`, `Collections_ListClear`
 - `Collections_ListToArray`, `Collections_ListForeach`, `Collections_ListEmpty`
 
-**Generic Collections – Dictionary (9 tests):**
+**Generic Collections - Dictionary (9 tests):**
 - `Collections_DictCustomComparer`, `Collections_DictAddGet`, `Collections_DictIndexer`
 - `Collections_DictContains`, `Collections_DictRemove`, `Collections_DictClear`
 - `Collections_DictTryGetValue`, `Collections_DictKeysValues`, `Collections_DictEmpty`
 
-**Generic Collections – IEnumerable (1 test):**
+**Generic Collections - IEnumerable (1 test):**
 - `Collections_IEnumerable`
 
 **Memory Copy / SIMD (15 tests):**
@@ -115,10 +115,10 @@ Kernel integration tests compile a real NativeAOT kernel, boot it in QEMU, and c
 **Using Tasks (recommended):**
 1. Press `Ctrl+Shift+P` → "Tasks: Run Task"
 2. Select one of:
-   - **Run Test: HelloWorld (x64)** – Console + XML output
-   - **Run Test: HelloWorld (x64, Console Only)** – Console output only
-   - **Run Test: HelloWorld (ARM64)** – ARM64 test with XML output
-   - **Dev Test: HelloWorld (x64)** – Developer mode with verbose output
+   - **Run Test: HelloWorld (x64)**: Console + XML output
+   - **Run Test: HelloWorld (x64, Console Only)**: Console output only
+   - **Run Test: HelloWorld (ARM64)**: ARM64 test with XML output
+   - **Dev Test: HelloWorld (x64)**: Developer mode with verbose output
 
 **Debug test runner:**
 1. Open the Run & Debug panel (`Ctrl+Shift+D`)
@@ -225,7 +225,7 @@ After the final `TestSuiteEnd` message the kernel also sends an 8-byte terminati
 
 ### Commands (Kernel → Host, `Ds2Vs`)
 
-Test-runner-specific commands occupy the range **100–106**. The original CosmosOS debug commands (0–25) are also defined but are not used by the test runner.
+Test-runner-specific commands occupy the range **100-106**. The original CosmosOS debug commands (0-25) are also defined but are not used by the test runner.
 
 | Command | Value | Payload format | Description |
 |---------|-------|----------------|-------------|
@@ -292,10 +292,10 @@ tests/
 ├── Cosmos.TestRunner.Protocol/      # Shared protocol definitions
 │   ├── Consts.cs                    # Magic signature and constants
 │   └── Messages.cs                  # Typed message classes
-├── Cosmos.Tests.Build.Asm/          # Unit tests – Clang assembly build task
-├── Cosmos.Tests.Build.Analyzer.Patcher/ # Unit tests – plug analyzer
-├── Cosmos.Tests.Scanner/            # Unit tests – plug scanner
-├── Cosmos.Tests.Patcher/            # Unit tests – IL patcher
+├── Cosmos.Tests.Build.Asm/          # Unit tests: Clang assembly build task
+├── Cosmos.Tests.Build.Analyzer.Patcher/ # Unit tests: plug analyzer
+├── Cosmos.Tests.Scanner/            # Unit tests: plug scanner
+├── Cosmos.Tests.Patcher/            # Unit tests: IL patcher
 ├── Cosmos.Tests.NativeWrapper/      # Runtime assets (no tests)
 ├── Cosmos.Tests.NativeLibrary/      # Native code for tests (no tests)
 └── Kernels/                         # Kernel test projects
@@ -369,15 +369,15 @@ public class Kernel : Sys.Kernel
 
 The `Sys.Kernel` base class drives a fixed lifecycle:
 
-1. `OnBoot()` – system initialization (called automatically, rarely overridden)
-2. `BeforeRun()` – **run all tests here**, then call `Stop()`
-3. `Run()` – called in a loop until `Stop()` is invoked; leave empty for test kernels
-4. `AfterRun()` – called once after the loop exits; call `Cosmos.Kernel.Kernel.Halt()` here
+1. `OnBoot()`: system initialization (called automatically, rarely overridden)
+2. `BeforeRun()`: **run all tests here**, then call `Stop()`
+3. `Run()`: called in a loop until `Stop()` is invoked; leave empty for test kernels
+4. `AfterRun()`: called once after the loop exits; call `Cosmos.Kernel.Kernel.Halt()` here
 
 ### Available Assertions
 
 ```csharp
-// Equality – typed overloads (int, uint, long, byte, bool, string, byte[], int[])
+// Equality: typed overloads (int, uint, long, byte, bool, string, byte[], int[])
 Assert.Equal(expected, actual);
 Assert.Equal<T>(expected, actual);   // Generic overload (requires IEquatable<T>)
 
@@ -423,11 +423,11 @@ Assert.Fail("Custom error message");
 The CI workflow (`.github/workflows/kernel-tests.yml`) runs kernel integration tests on both x64 and ARM64.
 
 **Jobs:**
-- `helloworld-tests` – Matrix build for x64/arm64
-- `helloworld-results` – Combined PR comment
-- `memory-tests` – Matrix build for x64/arm64
-- `memory-results` – Combined PR comment
-- `test-summary` – Final status summary
+- `helloworld-tests`: Matrix build for x64/arm64
+- `helloworld-results`: Combined PR comment
+- `memory-tests`: Matrix build for x64/arm64
+- `memory-results`: Combined PR comment
+- `test-summary`: Final status summary
 
 **Triggers:**
 - Push to `main`
@@ -437,9 +437,9 @@ The CI workflow (`.github/workflows/kernel-tests.yml`) runs kernel integration t
 **PR Comments:** Each test suite posts a comment with separate rows for x64 and arm64, showing test counts, duration, and links to artifacts.
 
 **Artifacts (30-day retention):**
-- `test-results-{suite}-{arch}.xml` – JUnit XML results
-- `uart-log-{suite}-{arch}` – Full UART output
-- `{Suite}-Test-ISO-{arch}` – Bootable kernel ISO + ELF
+- `test-results-{suite}-{arch}.xml`: JUnit XML results
+- `uart-log-{suite}-{arch}`: Full UART output
+- `{Suite}-Test-ISO-{arch}`: Bootable kernel ISO + ELF
 
 ### Example CI Step
 
@@ -469,8 +469,8 @@ The CI workflow (`.github/workflows/kernel-tests.yml`) runs kernel integration t
 | Stage | x64 | ARM64 |
 |-------|-----|-------|
 | Kernel build | ~60 s | ~70 s |
-| HelloWorld execution | 2–5 s | 5–10 s |
-| Memory execution | 60–120 s | 120–240 s |
+| HelloWorld execution | 2-5 s | 5-10 s |
+| Memory execution | 60-120 s | 120-240 s |
 
 ---
 

--- a/docs/articles/dev/toc.yml
+++ b/docs/articles/dev/toc.yml
@@ -8,6 +8,8 @@
   href: plugs.md
 - name: Testing
   href: testing.md
+- name: Public API Tracking
+  href: public-api.md
 - name: Garbage Collector
   href: garbage-collector.md
 - name: Garbage Collector - Precise Stack Scan

--- a/docs/articles/user/debugging.md
+++ b/docs/articles/user/debugging.md
@@ -30,7 +30,7 @@ The configuration names above are what the template generates. When working on t
 
 ## Serial log
 
-Every kernel boot phase logs to the serial port (COM1); `cosmos run` and `make run` connect it to your terminal. When a kernel does not come up, or crashes before the debugger is useful, the serial log is the first thing to read — see [Kernel Startup](startup.md) for a phase-by-phase walkthrough and how to symbolicate crash addresses.
+Every kernel boot phase logs to the serial port (COM1); `cosmos run` and `make run` connect it to your terminal. When a kernel does not come up, or crashes before the debugger is useful, the serial log is the first thing to read; see [Kernel Startup](startup.md) for a phase-by-phase walkthrough and how to symbolicate crash addresses.
 
 ---
 

--- a/docs/articles/user/filesystem.md
+++ b/docs/articles/user/filesystem.md
@@ -1,7 +1,7 @@
 # File System
 
 In this article, we will discuss using the Cosmos Gen3 VFS (virtual file system).
-Unlike Gen2, where you talked to `CosmosVFS` and a plugged subset of `System.IO`, Gen3 gives you the **standard .NET `System.IO` API** — `File`, `Directory`, `FileStream`, `StreamReader`/`StreamWriter`, `FileInfo`/`DirectoryInfo` — running unmodified on top of the kernel's VFS. You mount a filesystem at a Unix-style mount point and use ordinary rooted paths.
+Unlike Gen2, where you talked to `CosmosVFS` and a plugged subset of `System.IO`, Gen3 gives you the **standard .NET `System.IO` API** (`File`, `Directory`, `FileStream`, `StreamReader`/`StreamWriter`, `FileInfo`/`DirectoryInfo`) running unmodified on top of the kernel's VFS. You mount a filesystem at a Unix-style mount point and use ordinary rooted paths.
 
 The main differences if you come from Gen2:
 
@@ -69,11 +69,11 @@ if (VfsManager.TryMount("fat", "0", MountFlags.None, "/mnt", out VfsManager.VfsM
 
 From this point on, everything under `/mnt` is served by the FAT driver, and everything in this article is plain `System.IO`.
 
-**Note**: `/` itself is a *virtual root*. It always exists — even with nothing mounted — and enumerating it lists the mount points. You cannot create files directly in it (`IOException`, read-only file system); create them under a mount point like `/mnt`.
+**Note**: `/` itself is a *virtual root*. It always exists, even with nothing mounted, and enumerating it lists the mount points. You cannot create files directly in it (`IOException`, read-only file system); create them under a mount point like `/mnt`.
 
 ### Alternative: a RAM disk
 
-For quick experiments you don't need a disk image at all. A block device is just an `IBlockDevice` (from `Cosmos.Kernel.HAL.Interfaces.Devices`), and a RAM-backed one fits in a few lines — this is exactly what the kernel test suites use:
+For quick experiments you don't need a disk image at all. A block device is just an `IBlockDevice` (from `Cosmos.Kernel.HAL.Interfaces.Devices`), and a RAM-backed one fits in a few lines; this is exactly what the kernel test suites use:
 
 ```csharp
 internal sealed class MemoryBlockDevice : IBlockDevice
@@ -131,7 +131,7 @@ if (!VfsManager.TryFormat("fat", "0", options))
 }
 ```
 
-Formatting is refused while the source is mounted — unmount first with `VfsManager.TryUnmount("/mnt")`.
+Formatting is refused while the source is mounted: unmount first with `VfsManager.TryUnmount("/mnt")`.
 
 ## List mounted volumes
 
@@ -160,7 +160,7 @@ foreach (string file in files)
 }
 ```
 
-Search patterns work too — this is the stock BCL enumeration engine:
+Search patterns work too; this is the stock BCL enumeration engine:
 
 ```csharp
 string[] logs = Directory.GetFiles("/mnt", "*.txt");
@@ -190,7 +190,7 @@ foreach (string directory in directories)
 
 ## Read all the files in a directory
 
-We get the file list and print the content of each file. As in Gen2, keep filesystem code inside `try`/`catch` — the exceptions are the standard `System.IO` ones and they are catchable:
+We get the file list and print the content of each file. As in Gen2, keep filesystem code inside `try`/`catch`: the exceptions are the standard `System.IO` ones and they are catchable:
 
 ```csharp
 try
@@ -281,7 +281,7 @@ Console.WriteLine("Read " + data.Length + " bytes");
 
 ## Copy, move, delete
 
-Unlike Gen2, `File.Move` is fully supported — no copy-and-delete workaround needed. A move onto an existing destination throws `IOException` unless you pass `overwrite: true`; the overwrite is crash-safe (the destination is kept as a backup until the rename lands).
+Unlike Gen2, `File.Move` is fully supported, no copy-and-delete workaround needed. A move onto an existing destination throws `IOException` unless you pass `overwrite: true`; the overwrite is crash-safe (the destination is kept as a backup until the rename lands).
 
 ```csharp
 try
@@ -356,7 +356,7 @@ The standard `System.IO` exception contract applies, so you can catch precisely:
 - Deleting a non-empty directory without `recursive: true` → `IOException`
 - `File.Copy`/`File.Move` onto an existing file without overwrite → `IOException`
 
-With **nothing mounted at all**, `System.IO` still degrades gracefully: `Directory.Exists("/")` is `true`, enumerating `/` returns an empty list, and every access to another path fails with one of the exceptions above — never a kernel fault.
+With **nothing mounted at all**, `System.IO` still degrades gracefully: `Directory.Exists("/")` is `true`, enumerating `/` returns an empty list, and every access to another path fails with one of the exceptions above, never a kernel fault.
 
 ## Current limitations
 
@@ -367,14 +367,14 @@ With **nothing mounted at all**, `System.IO` still degrades gracefully: `Directo
 
 ## How it works
 
-Your code calls the stock BCL, which bottoms out in the Unix PAL (`Interop.Sys.*` P/Invokes). Those ~45 entry points are [plugged](../dev/plugs.md) in `Cosmos.Kernel.Plugs` — a file-descriptor table adapts the PAL contract (fds, dir streams, PAL errnos) and delegates to `VfsManager`, which owns path resolution, the mount table, the current directory and open-handle semantics, and dispatches to the mounted filesystem driver, which reads and writes an `IBlockDevice` (AHCI or NVMe via `StorageManager`, RAM via `MemoryBlockDevice`).
+Your code calls the stock BCL, which bottoms out in the Unix PAL (`Interop.Sys.*` P/Invokes). Those ~45 entry points are [plugged](../dev/plugs.md) in `Cosmos.Kernel.Plugs`: a file-descriptor table adapts the PAL contract (fds, dir streams, PAL errnos) and delegates to `VfsManager`, which owns path resolution, the mount table, the current directory and open-handle semantics, and dispatches to the mounted filesystem driver, which reads and writes an `IBlockDevice` (AHCI or NVMe via `StorageManager`, RAM via `MemoryBlockDevice`).
 
 ```
 File / Directory / FileStream          (stock BCL)
         │
 Interop.Sys.* PAL calls                (stock BCL, plugged)
         │
-FileDescriptorTable                    (Cosmos.Kernel.Plugs — fds, dir streams, errno)
+FileDescriptorTable                    (Cosmos.Kernel.Plugs: fds, dir streams, errno)
         │
 VfsManager                             (mounts, paths, CWD, open handles)
         │

--- a/docs/articles/user/graphics.md
+++ b/docs/articles/user/graphics.md
@@ -1,6 +1,6 @@
 # Graphics
 
-In this article, we will discuss the Cosmos Graphics Subsystem (CGS) on Cosmos Gen3: how to get a drawing surface and put shapes, text and images on the screen. CGS is based on the abstraction of a **Canvas** — an empty space you draw on. It is a drawing layer, not a widget toolkit: there are no windows or buttons, but everything you need to build them.
+In this article, we will discuss the Cosmos Graphics Subsystem (CGS) on Cosmos Gen3: how to get a drawing surface and put shapes, text and images on the screen. CGS is based on the abstraction of a **Canvas**, an empty space you draw on. It is a drawing layer, not a widget toolkit: there are no windows or buttons, but everything you need to build them.
 
 The main differences if you come from Gen2:
 
@@ -8,7 +8,7 @@ The main differences if you come from Gen2:
 |---|---|---|
 | Canvas API | `Cosmos.System.Graphics` | Same API, in `Cosmos.Kernel.System.Graphics` |
 | Video drivers | VBE, VGA, VMWare SVGA II | Limine-provided framebuffer (x64 and ARM64) |
-| `Display()` | Required on double-buffered drivers | Always required — the canvas is double-buffered |
+| `Display()` | Required on double-buffered drivers | Always required: the canvas is double-buffered |
 | Video mode | Switchable at runtime | Fixed at boot by the bootloader |
 | Text console | Separate VGA text mode | Rendered on the same canvas |
 | Colors | `System.Drawing.Color` | `System.Drawing.Color` |
@@ -36,7 +36,7 @@ using Cosmos.Kernel.System.Graphics.Fonts;
 
 ## Getting a canvas
 
-`Canvas.GetFullScreen()` returns the canvas backed by the screen — the framebuffer the bootloader set up at boot:
+`Canvas.GetFullScreen()` returns the canvas backed by the screen, the framebuffer the bootloader set up at boot:
 
 ```csharp
 Canvas canvas = Canvas.GetFullScreen();
@@ -51,13 +51,13 @@ Console.WriteLine("Refresh:    " + canvas.RefreshRate + " Hz");
 
 Two things to know before you start drawing:
 
-- **The resolution is fixed at boot.** Unlike Gen2, requesting a different `Mode` does not reprogram the video card — the canvas always has the resolution the bootloader chose. Use `canvas.Width` and `canvas.Height` instead of assuming one.
-- **Nothing appears until you call `Display()`.** The canvas is double-buffered: every drawing call goes to a back buffer, and `Display()` swaps the finished frame to video memory. Draw the whole frame, then call `Display()` once — that is also what keeps animations flicker-free.
-- **`Console` shares the screen with you.** There is no separate text mode: `Console.WriteLine` is itself rendered on the full-screen canvas (and calls `Display()` on every write). Once you start drawing, stop writing to `Console` — the next write would paint text right over your graphics. This also means an uncaught exception prints over whatever you drew, which — unlike Gen2, where the screen just froze — at least tells you what went wrong.
+- **The resolution is fixed at boot.** Unlike Gen2, requesting a different `Mode` does not reprogram the video card: the canvas always has the resolution the bootloader chose. Use `canvas.Width` and `canvas.Height` instead of assuming one.
+- **Nothing appears until you call `Display()`.** The canvas is double-buffered: every drawing call goes to a back buffer, and `Display()` swaps the finished frame to video memory. Draw the whole frame, then call `Display()` once; that is also what keeps animations flicker-free.
+- **`Console` shares the screen with you.** There is no separate text mode: `Console.WriteLine` is itself rendered on the full-screen canvas (and calls `Display()` on every write). Once you start drawing, stop writing to `Console`: the next write would paint text right over your graphics. This also means an uncaught exception prints over whatever you drew, which, unlike Gen2 where the screen just froze, at least tells you what went wrong.
 
 ## Drawing shapes
 
-The canvas offers the classic set of primitives — points, lines, rectangles, circles, ellipses, arcs, triangles and polygons, most in outlined and filled variants:
+The canvas offers the classic set of primitives (points, lines, rectangles, circles, ellipses, arcs, triangles and polygons), most in outlined and filled variants:
 
 ```csharp
 Canvas canvas = Canvas.GetFullScreen();
@@ -81,7 +81,7 @@ canvas.DrawCircle(Color.Chartreuse, 130, 200, 40);
 canvas.DrawFilledCircle(Color.MediumOrchid, 130, 320, 40);
 canvas.DrawEllipse(Color.DeepSkyBlue, 300, 350, 60, 30);
 
-/* An arc — angles are in degrees */
+/* An arc: angles are in degrees */
 canvas.DrawArc(500, 400, 50, 50, Color.CadetBlue, 90, 270);
 
 /* Triangles and polygons */
@@ -100,13 +100,13 @@ Colors are plain `System.Drawing.Color` values, so the full named palette (`Colo
 
 ## Drawing text
 
-Text rendering uses PSF (PC Screen Font) bitmap fonts — the format the Linux console uses, in both its **PSF1** and **PSF2** versions. A 16x32 [Spleen](https://github.com/fcambus/spleen) font is built in as `PCScreenFont.DefaultFont`, and `PCScreenFont.LoadFont(byte[])` loads any other PSF font at runtime.
+Text rendering uses PSF (PC Screen Font) bitmap fonts, the format the Linux console uses, in both its **PSF1** and **PSF2** versions. A 16x32 [Spleen](https://github.com/fcambus/spleen) font is built in as `PCScreenFont.DefaultFont`, and `PCScreenFont.LoadFont(byte[])` loads any other PSF font at runtime.
 
 There are plenty of ready-made PSF fonts to download:
 
-- [The Zap Group's console fonts](https://www.zap.org.au/projects/console-fonts-zap/) — classic 8x16 PSF1 fonts (`zap-light16.psf`, `zap-vga16.psf`).
-- [Terminus](https://terminus-font.sourceforge.net/) — PSF2 in many sizes; most Linux distributions already ship it under `/usr/share/consolefonts/` as `.psf.gz` files (decompress with `gunzip` first, the kernel reads plain `.psf`).
-- [Spleen](https://github.com/fcambus/spleen) — PSF2 releases from 5x8 up to 32x64.
+- [The Zap Group's console fonts](https://www.zap.org.au/projects/console-fonts-zap/): classic 8x16 PSF1 fonts (`zap-light16.psf`, `zap-vga16.psf`).
+- [Terminus](https://terminus-font.sourceforge.net/): PSF2 in many sizes; most Linux distributions already ship it under `/usr/share/consolefonts/` as `.psf.gz` files (decompress with `gunzip` first, the kernel reads plain `.psf`).
+- [Spleen](https://github.com/fcambus/spleen): PSF2 releases from 5x8 up to 32x64.
 
 A font is just a file, so the easiest way to ship one is on the FAT disk from the [File System](filesystem.md) article. Here `zap16.psf` is Zap Light (PSF1) and `term24.psf` is Terminus 12x24 (PSF2), copied onto the disk under FAT-friendly names:
 
@@ -141,7 +141,7 @@ canvas.Display();
 
 PSF fonts are bitmaps: one size, one cell, no curves. For real typography the `TrueTypeFont` class loads a `.ttf` file and rasterizes it at any pixel size, with anti-aliased edges, per-glyph widths and pair kerning. The parser and rasterizer are pure managed code (see the [Credits](../../credits.md) page), so a malformed font file throws an exception instead of corrupting memory.
 
-`TrueTypeFont` derives from `Font`, so it goes wherever a bitmap font goes — passed to the plain `DrawString` overload it draws at its `SizePx` (set in the constructor, 16 by default). The dedicated overload takes the size explicitly, and each (character, size) pair is rasterized once and cached, so drawing the same text again is cheap:
+`TrueTypeFont` derives from `Font`, so it goes wherever a bitmap font goes: passed to the plain `DrawString` overload it draws at its `SizePx` (set in the constructor, 16 by default). The dedicated overload takes the size explicitly, and each (character, size) pair is rasterized once and cached, so drawing the same text again is cheap:
 
 ```csharp
 Canvas canvas = Canvas.GetFullScreen();
@@ -158,7 +158,7 @@ canvas.DrawString("Anti-aliased, kerned and scalable to any size.", dejavu, 24, 
 int y = 200;
 foreach (int size in new[] { 14, 20, 28, 40 })
 {
-    canvas.DrawString("Cosmos at " + size + "px — AV To Wa", dejavu, size, Color.DeepSkyBlue, 60, y);
+    canvas.DrawString("Cosmos at " + size + "px - AV To Wa", dejavu, size, Color.DeepSkyBlue, 60, y);
     y += dejavu.GetLineHeight(size) + 10;
 }
 
@@ -172,7 +172,7 @@ The `(x, y)` you pass is the top-left of the text line, like the PSF overload. F
 
 ## Drawing images
 
-Images are represented by the `Bitmap` class. You can build one in code from raw pixel data — each pixel is four bytes in **B, G, R, A** order:
+Images are represented by the `Bitmap` class. You can build one in code from raw pixel data: each pixel is four bytes in **B, G, R, A** order:
 
 ```csharp
 Canvas canvas = Canvas.GetFullScreen();
@@ -195,7 +195,7 @@ canvas.DrawImage(bitmap, 100, 150, 128, 128);
 canvas.Display();
 ```
 
-More usefully, `Bitmap` can load an uncompressed 24-bit or 32-bit **BMP file** through standard `System.IO` — for example from a FAT disk mounted as shown in the [File System](filesystem.md) article:
+More usefully, `Bitmap` can load an uncompressed 24-bit or 32-bit **BMP file** through standard `System.IO`, for example from a FAT disk mounted as shown in the [File System](filesystem.md) article:
 
 ```csharp
 /* logo.bmp is a 24-bit BMP on the FAT partition mounted at /mnt */
@@ -211,13 +211,13 @@ canvas.Display();
 <!-- screenshot: the 2x2 bitmap raw and scaled, plus the logo loaded from disk centered on screen -->
 ![Drawing images](images/graphics-images.png)
 
-**PNG** files work the same way through the `Png` class — also an `Image`, so it goes wherever a `Bitmap` goes. The whole format is supported (grayscale, truecolor and palette, with or without alpha, interlaced or not), decoded by pure managed code (see the [Credits](../../credits.md) page). Transparent pixels blend with what is already on the canvas:
+**PNG** files work the same way through the `Png` class, also an `Image`, so it goes wherever a `Bitmap` goes. The whole format is supported (grayscale, truecolor and palette, with or without alpha, interlaced or not), decoded by pure managed code (see the [Credits](../../credits.md) page). Transparent pixels blend with what is already on the canvas:
 
 ```csharp
 /* logo.png is a PNG with transparency on the FAT partition mounted at /mnt */
 Png logo = new Png("/mnt/logo.png");
 
-/* Draw it scaled to half size, centered — transparent pixels blend with the background */
+/* Draw it scaled to half size, centered: transparent pixels blend with the background */
 int width = (int)logo.Width / 2;
 int height = (int)logo.Height / 2;
 canvas.DrawImage(logo, (canvas.Width - width) / 2, (canvas.Height - height) / 2, width, height);
@@ -228,11 +228,11 @@ canvas.Display();
 <!-- screenshot: the Cosmos logo PNG decoded from disk, scaled and alpha-blended over the background -->
 ![Drawing a PNG](images/graphics-png.png)
 
-`DrawImageAlpha` draws with per-pixel alpha blending, and `canvas.GetImage(x, y, width, height)` does the reverse — it copies a region of the canvas back into a `Bitmap`.
+`DrawImageAlpha` draws with per-pixel alpha blending, and `canvas.GetImage(x, y, width, height)` does the reverse: it copies a region of the canvas back into a `Bitmap`.
 
 ## Off-screen canvases
 
-A `Canvas` does not have to be the screen. Constructing one with a size gives you a memory-backed canvas with the exact same drawing API — compose a tile or sprite once, then blit it to the screen with `DrawCanvas` as many times as you like:
+A `Canvas` does not have to be the screen. Constructing one with a size gives you a memory-backed canvas with the exact same drawing API: compose a tile or sprite once, then blit it to the screen with `DrawCanvas` as many times as you like:
 
 ```csharp
 Canvas canvas = Canvas.GetFullScreen();
@@ -266,14 +266,14 @@ Color color = canvas.GetPointColor(69, 69);   // Color.Red
 ## Current limitations
 
 - Only 32-bit color depth is supported end to end; BMP loading additionally accepts 24-bit files.
-- The video mode cannot be changed at runtime — the framebuffer resolution is whatever the bootloader negotiated at boot.
+- The video mode cannot be changed at runtime: the framebuffer resolution is whatever the bootloader negotiated at boot.
 - Supported image formats are BMP (uncompressed, 24 or 32 bpp) and PNG; there is no JPEG support.
 - No hardware acceleration: every primitive is drawn pixel by pixel by the CPU.
 - `FullScreenCanvas.Disable()` exists but there is no VGA text mode to fall back to on UEFI machines.
 
 ## How it works
 
-`Canvas.GetFullScreen()` returns a `GopCanvas`, a canvas backed by the framebuffer that the [Limine](https://limine-bootloader.org/) bootloader requests from the firmware (UEFI GOP) before handing control to the kernel. This is why the same code works unmodified on x64 and ARM64 — the kernel never touches a video card directly. Drawing calls land in a back buffer in ordinary memory; `Display()` copies the whole back buffer into the mapped framebuffer in one go. The kernel console ([`KernelConsole`](https://github.com/valentinbreiz/nativeaot-patcher/blob/main/src/Cosmos.Kernel.System/Graphics/KernelConsole.cs)) renders `Console` output onto that same canvas with the default PSF font, calling `Display()` after every write.
+`Canvas.GetFullScreen()` returns a `GopCanvas`, a canvas backed by the framebuffer that the [Limine](https://limine-bootloader.org/) bootloader requests from the firmware (UEFI GOP) before handing control to the kernel. This is why the same code works unmodified on x64 and ARM64: the kernel never touches a video card directly. Drawing calls land in a back buffer in ordinary memory; `Display()` copies the whole back buffer into the mapped framebuffer in one go. The kernel console ([`KernelConsole`](https://github.com/valentinbreiz/nativeaot-patcher/blob/main/src/Cosmos.Kernel.System/Graphics/KernelConsole.cs)) renders `Console` output onto that same canvas with the default PSF font, calling `Display()` after every write.
 
 ```
 Canvas API (shapes, text, images)      (Cosmos.Kernel.System.Graphics)

--- a/docs/articles/user/network.md
+++ b/docs/articles/user/network.md
@@ -120,14 +120,14 @@ Console.WriteLine(NetworkConfigManager.Get(device).IPAddress.ToString());
 
 ## UDP
 
-UDP uses the standard .NET `UdpClient` — no Cosmos-specific classes. Sends go out immediately; for receives, poll `Available` (a receive with nothing pending would block):
+UDP uses the standard .NET `UdpClient`, no Cosmos-specific classes. Sends go out immediately; for receives, poll `Available` (a receive with nothing pending would block):
 
 ```csharp
 using System.Net.Sockets;
 
 var udpClient = new UdpClient(4242);
 
-/* Send data — 10.0.2.2 is the host under QEMU user networking */
+/* Send data: 10.0.2.2 is the host under QEMU user networking */
 byte[] message = Encoding.ASCII.GetBytes("Hello from CosmosOS!");
 udpClient.Send(message, message.Length, new IPEndPoint(IPAddress.Parse("10.0.2.2"), 4242));
 
@@ -244,15 +244,15 @@ dnsClient.Close();
 
 ## Current limitations
 
-- ICMP is not implemented yet — no ping, in either direction.
+- ICMP is not implemented yet: no ping, in either direction.
 - `System.Net.Dns` is not plugged; use the Cosmos `DnsClient` shown above.
-- No TLS, so no `HttpClient`/HTTPS — raw TCP only.
+- No TLS, so no `HttpClient`/HTTPS: raw TCP only.
 - One NIC: the stack talks to `NetworkManager.PrimaryDevice`.
 - Half-close is not supported: `Close()` on an established TCP connection expects the peer to answer the FIN handshake within 5 seconds and throws if it keeps the connection open.
 
 ## How it works
 
-Your code calls the standard .NET socket classes, whose PAL bottoms out in `Socket`-level [plugs](../dev/plugs.md) in `Cosmos.Kernel.Plugs` (`SocketPlug`, `TcpClientPlug`, `TcpListenerPlug`, `UdpClientPlug`, `NetworkStreamPlug`). Those delegate to the Cosmos network stack — the TCP state machine and UDP layer over IPv4, ARP and Ethernet — which sends and receives frames through the `NetworkDevice` driver registered with `NetworkManager`. The Cosmos `DHCPClient` and `DnsClient` sit directly on the Cosmos UDP layer.
+Your code calls the standard .NET socket classes, whose PAL bottoms out in `Socket`-level [plugs](../dev/plugs.md) in `Cosmos.Kernel.Plugs` (`SocketPlug`, `TcpClientPlug`, `TcpListenerPlug`, `UdpClientPlug`, `NetworkStreamPlug`). Those delegate to the Cosmos network stack (the TCP state machine and UDP layer over IPv4, ARP and Ethernet), which sends and receives frames through the `NetworkDevice` driver registered with `NetworkManager`. The Cosmos `DHCPClient` and `DnsClient` sit directly on the Cosmos UDP layer.
 
 ```
 TcpClient / TcpListener / UdpClient / NetworkStream     (stock BCL)

--- a/docs/articles/user/startup.md
+++ b/docs/articles/user/startup.md
@@ -10,7 +10,7 @@ The main differences if you come from Gen2:
 | Firmware | BIOS | UEFI, on x64 and ARM64 |
 | Bootloader | Limine | Limine |
 | Entry plumbing | IL2CPU emits the call to `Kernel.Start()` | A source generator emits `CosmosEntryPoint.Main()` |
-| Lifecycle | `BeforeRun` / `Run` / `AfterRun` | `BeforeRun` / `Run` / `AfterRun` — unchanged |
+| Lifecycle | `BeforeRun` / `Run` / `AfterRun` | `BeforeRun` / `Run` / `AfterRun` (unchanged) |
 
 ## The boot chain
 
@@ -26,23 +26,23 @@ kmain()           native C bootstrap (Cosmos.Kernel/Bootstrap/kmain.c)
     └─ Phase 4    User kernel: Main(argc, argv) → Kernel.Start()
 ```
 
-The [Limine](https://limine-bootloader.org/) bootloader loads the kernel ELF produced by the build pipeline, and jumps to `kmain()` — a small C bootstrap compiled into every kernel. From there:
+The [Limine](https://limine-bootloader.org/) bootloader loads the kernel ELF produced by the build pipeline, and jumps to `kmain()`, a small C bootstrap compiled into every kernel. From there:
 
-- **Phase 1 — CPU.** SIMD is enabled first (NativeAOT-generated code uses XMM registers from the very first instruction) and the serial port is initialized, so everything after this line is logged. On ARM64 the alignment check is disabled here too.
-- **Phase 2 — Platform.** The bootstrap asks Limine for the ACPI RSDP and the higher-half direct-map offset, then does an early ACPI parse: the MADT (where the interrupt controllers and CPUs are) and the MCFG (where PCIe configuration space lives).
-- **Phase 3 — Managed runtime.** The NativeAOT startup path runs. This is where the C# world comes alive, one package at a time (see the next section).
-- **Phase 4 — User kernel.** The bootstrap builds `argv` from the kernel command line and calls the managed `Main`, which ends up in your kernel's `Start()`.
+- **Phase 1: CPU.** SIMD is enabled first (NativeAOT-generated code uses XMM registers from the very first instruction) and the serial port is initialized, so everything after this line is logged. On ARM64 the alignment check is disabled here too.
+- **Phase 2: Platform.** The bootstrap asks Limine for the ACPI RSDP and the higher-half direct-map offset, then does an early ACPI parse: the MADT (where the interrupt controllers and CPUs are) and the MCFG (where PCIe configuration space lives).
+- **Phase 3: Managed runtime.** The NativeAOT startup path runs. This is where the C# world comes alive, one package at a time (see the next section).
+- **Phase 4: User kernel.** The bootstrap builds `argv` from the kernel command line and calls the managed `Main`, which ends up in your kernel's `Start()`.
 
 ## Phase 3: how the managed kernel comes up
 
 Each Cosmos package contributes a *library initializer* that the runtime executes before any of your code, in dependency order:
 
-1. **Cosmos.Kernel.Core** — carves the heap out of the Limine memory map, initializes the garbage collector, then registers the type system (statics, static constructors, module initializers).
-2. **Cosmos.Kernel.HAL** — platform HAL, the interrupt controller, PCI enumeration over ECAM, platform hardware (APIC/GIC, device drivers such as the NIC), and the AHCI/NVMe storage controllers.
-3. **Cosmos.Kernel.System** — the service managers: `TimerManager`, `KeyboardManager`, `MouseManager`, `NetworkManager`, `StorageManager`.
-4. **Cosmos.Kernel** — CPU exception handlers and the scheduler (one idle thread per CPU, preemption on a 10 ms quantum).
+1. **Cosmos.Kernel.Core**: carves the heap out of the Limine memory map, initializes the garbage collector, then registers the type system (statics, static constructors, module initializers).
+2. **Cosmos.Kernel.HAL**: platform HAL, the interrupt controller, PCI enumeration over ECAM, platform hardware (APIC/GIC, device drivers such as the NIC), and the AHCI/NVMe storage controllers.
+3. **Cosmos.Kernel.System**: the service managers `TimerManager`, `KeyboardManager`, `MouseManager`, `NetworkManager`, `StorageManager`.
+4. **Cosmos.Kernel**: CPU exception handlers and the scheduler (one idle thread per CPU, preemption on a 10 ms quantum).
 
-Every step in 2–4 is gated by a feature switch (`CosmosEnableInterrupts`, `CosmosEnablePCI`, `CosmosEnableTimer`, `CosmosEnableKeyboard`, `CosmosEnableMouse`, `CosmosEnableNetwork`, `CosmosEnableStorage`, `CosmosEnableGraphics`, `CosmosEnableScheduler` — all `true` by default). Set one to `false` in your `.csproj` and the corresponding subsystem is skipped here and compiled out of the kernel.
+Every step in 2-4 is gated by a feature switch (`CosmosEnableInterrupts`, `CosmosEnablePCI`, `CosmosEnableTimer`, `CosmosEnableKeyboard`, `CosmosEnableMouse`, `CosmosEnableNetwork`, `CosmosEnableStorage`, `CosmosEnableGraphics`, `CosmosEnableScheduler`, all `true` by default). Set one to `false` in your `.csproj` and the corresponding subsystem is skipped here and compiled out of the kernel.
 
 ## The generated entry point
 
@@ -74,13 +74,13 @@ public static class CosmosEntryPoint
 
 `Cosmos.Kernel.System.Kernel` is the abstract base class of every user kernel. Its `Start()` drives the whole lifecycle:
 
-1. Calls `OnBoot()`, whose default implementation runs `Global.Init()` — this initializes the graphical `KernelConsole`, which is what makes `Console.WriteLine` work.
+1. Calls `OnBoot()`, whose default implementation runs `Global.Init()`: this initializes the graphical `KernelConsole`, which is what makes `Console.WriteLine` work.
 2. Enables hardware interrupts (everything before this point ran with interrupts off).
-3. Turns off the early-boot text renderer — up to here, the boot log you see on screen is the serial log mirrored by a minimal framebuffer writer; from now on the screen belongs to `Console` and the [Canvas](graphics.md).
+3. Turns off the early-boot text renderer: up to here, the boot log you see on screen is the serial log mirrored by a minimal framebuffer writer; from now on the screen belongs to `Console` and the [Canvas](graphics.md).
 4. Calls `BeforeRun()` once.
 5. Calls `Run()` in a loop until `Stop()` is called.
 6. Calls `AfterRun()` once.
-7. Halts the CPU. There is no operating system to return to — a kernel never exits.
+7. Halts the CPU. There is no operating system to return to: a kernel never exits.
 
 ## A minimal kernel
 
@@ -107,16 +107,16 @@ public class Kernel : Sys.Kernel
 }
 ```
 
-- `BeforeRun()` — one-time setup: mount a [filesystem](filesystem.md), configure the [network](network.md), draw a splash screen.
-- `Run()` — your main loop body. It is called again as soon as it returns, so it does not need to loop itself; keep it re-entrant.
-- `Stop()` — call it from anywhere to exit the loop after the current `Run()` completes.
-- `AfterRun()` — optional cleanup once the loop has ended.
+- `BeforeRun()`: one-time setup (mount a [filesystem](filesystem.md), configure the [network](network.md), draw a splash screen).
+- `Run()`: your main loop body. It is called again as soon as it returns, so it does not need to loop itself; keep it re-entrant.
+- `Stop()`: call it from anywhere to exit the loop after the current `Run()` completes.
+- `AfterRun()`: optional cleanup once the loop has ended.
 
 An uncaught exception inside `Run()` propagates out of the loop, so wrap the body in `try`/`catch` if a command failing should not take the kernel down.
 
 ## Customizing startup
 
-`OnBoot()` runs *before* interrupts are enabled and before the console exists — the right place for early hardware setup:
+`OnBoot()` runs *before* interrupts are enabled and before the console exists, the right place for early hardware setup:
 
 ```csharp
 protected override void OnBoot()
@@ -127,11 +127,11 @@ protected override void OnBoot()
 }
 ```
 
-For total control you can override `Start()` itself and take over the lifecycle — the default implementation in [`Cosmos.Kernel.System/Kernel.cs`](https://github.com/valentinbreiz/nativeaot-patcher/blob/main/src/Cosmos.Kernel.System/Kernel.cs) is small and a good starting point to copy from.
+For total control you can override `Start()` itself and take over the lifecycle: the default implementation in [`Cosmos.Kernel.System/Kernel.cs`](https://github.com/valentinbreiz/nativeaot-patcher/blob/main/src/Cosmos.Kernel.System/Kernel.cs) is small and a good starting point to copy from.
 
 ## The kernel command line
 
-Limine passes a command line to the kernel — the `cmdline:` entry of the `Bootloader/limine.conf` file in your kernel project. It comes out the standard way:
+Limine passes a command line to the kernel: the `cmdline:` entry of the `Bootloader/limine.conf` file in your kernel project. It comes out the standard way:
 
 ```csharp
 foreach (string arg in Environment.GetCommandLineArgs())
@@ -142,7 +142,7 @@ foreach (string arg in Environment.GetCommandLineArgs())
 
 ## Watching a boot
 
-Every phase above logs to the serial port (COM1), which `make run` and `cosmos run` connect to your terminal — the first thing to read when a kernel does not come up:
+Every phase above logs to the serial port (COM1), which `make run` and `cosmos run` connect to your terminal, the first thing to read when a kernel does not come up:
 
 ```
 ========================================

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,38 +8,38 @@ Check out the [Roadmap](roadmap.md) to see our progress toward the first release
 
 The documentation is split in two parts, depending on what you want to do with gen3:
 
-- **[User Guide](articles/user/install.md)** — you want to **build your own OS** with Cosmos: installing the toolchain, using the filesystem, debugging your kernel.
-- **[Developer Docs](articles/dev/install-dev.md)** — you want to **contribute to Cosmos itself** or understand its internals: architecture, build pipeline, runtime subsystems.
+- **[User Guide](articles/user/install.md)**: you want to **build your own OS** with Cosmos (installing the toolchain, using the filesystem, debugging your kernel).
+- **[Developer Docs](articles/dev/install-dev.md)**: you want to **contribute to Cosmos itself** or understand its internals (architecture, build pipeline, runtime subsystems).
 
 ## User Guide
 
 Everything you need to create, build and run your own Cosmos kernel:
 
- - [Installation Guide](articles/user/install.md) — set up the toolchain and create your first kernel from VS Code.
- - [Kernel Startup](articles/user/startup.md) — the boot chain and the `BeforeRun`/`Run`/`AfterRun` lifecycle.
- - [File System](articles/user/filesystem.md) — mount a disk and use the standard .NET `System.IO` API (`File`, `Directory`, streams).
- - [Network](articles/user/network.md) — DHCP, UDP and TCP through the standard .NET `System.Net.Sockets` API, plus DNS.
- - [Graphics](articles/user/graphics.md) — draw shapes, text and images on the screen with the Canvas API.
- - [Debugging with VSCode and QEMU](articles/user/debugging.md) — set breakpoints in your kernel with remote GDB.
+ - [Installation Guide](articles/user/install.md): set up the toolchain and create your first kernel from VS Code.
+ - [Kernel Startup](articles/user/startup.md): the boot chain and the `BeforeRun`/`Run`/`AfterRun` lifecycle.
+ - [File System](articles/user/filesystem.md): mount a disk and use the standard .NET `System.IO` API (`File`, `Directory`, streams).
+ - [Network](articles/user/network.md): DHCP, UDP and TCP through the standard .NET `System.Net.Sockets` API, plus DNS.
+ - [Graphics](articles/user/graphics.md): draw shapes, text and images on the screen with the Canvas API.
+ - [Debugging with VSCode and QEMU](articles/user/debugging.md): set breakpoints in your kernel with remote GDB.
 
 ## Developer Docs
 
 Architecture and internals, for contributors and the curious:
 
- - [Dev Container Setup](articles/dev/install-dev.md) — build the framework from source.
- - [Kernel Project Layout](articles/dev/kernel-project-layout.md) — the layered project graph.
- - [Coding Guidelines](articles/dev/coding-guidelines.md) — style and architecture patterns.
- - [Plugs](articles/dev/plugs.md) — the IL-level method replacement system.
- - [Testing](articles/dev/testing.md) — unit tests and QEMU kernel test suites.
+ - [Dev Container Setup](articles/dev/install-dev.md): build the framework from source.
+ - [Kernel Project Layout](articles/dev/kernel-project-layout.md): the layered project graph.
+ - [Coding Guidelines](articles/dev/coding-guidelines.md): style and architecture patterns.
+ - [Plugs](articles/dev/plugs.md): the IL-level method replacement system.
+ - [Testing](articles/dev/testing.md): unit tests and QEMU kernel test suites.
  - [Public API Tracking](articles/dev/public-api.md): declared surface files, package validation, versioned docs.
- - [Garbage Collector](articles/dev/garbage-collector.md) — the mark-and-sweep GC.
+ - [Garbage Collector](articles/dev/garbage-collector.md): the mark-and-sweep GC.
  - [Garbage Collector - Precise Stack Scan](articles/dev/garbage-collector-gcinfo.md): how GCInfo makes the triggering thread's stack scan exact.
  - [Garbage Collector - Glossary](articles/dev/garbage-collector-glossary.md): background notes on the GC concepts the articles build on.
- - [Scheduler](articles/dev/scheduler.md) — the preemptive, pluggable scheduler.
+ - [Scheduler](articles/dev/scheduler.md): the preemptive, pluggable scheduler.
  - [Scheduler - Writing a Scheduler](articles/dev/scheduler-plugging.md): how to implement and install a scheduling policy.
  - [Scheduler - Glossary](articles/dev/scheduler-glossary.md): background notes on the scheduling concepts the article builds on.
- - [Kernel Compilation Steps](articles/dev/build/kernel-compilation-steps.md) — C# to bootable ISO, end to end.
- - [Cosmos.Build.Asm](articles/dev/build/asm-build.md), [Cosmos.Build.GCC](articles/dev/build/gcc-build.md), [Cosmos.Build.Patcher](articles/dev/build/patcher-build.md), [Cosmos.Build.Ilc](articles/dev/build/ilc-build.md) — the build pipeline components.
+ - [Kernel Compilation Steps](articles/dev/build/kernel-compilation-steps.md): C# to bootable ISO, end to end.
+ - [Cosmos.Build.Asm](articles/dev/build/asm-build.md), [Cosmos.Build.GCC](articles/dev/build/gcc-build.md), [Cosmos.Build.Patcher](articles/dev/build/patcher-build.md), [Cosmos.Build.Ilc](articles/dev/build/ilc-build.md): the build pipeline components.
 
 ## Resources
 - [Cosmos Gen3: The NativeAOT Era and the End of IL2CPU?](https://valentin.bzh/posts/3)

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ Architecture and internals, for contributors and the curious:
  - [Coding Guidelines](articles/dev/coding-guidelines.md) — style and architecture patterns.
  - [Plugs](articles/dev/plugs.md) — the IL-level method replacement system.
  - [Testing](articles/dev/testing.md) — unit tests and QEMU kernel test suites.
+ - [Public API Tracking](articles/dev/public-api.md): declared surface files, package validation, versioned docs.
  - [Garbage Collector](articles/dev/garbage-collector.md) — the mark-and-sweep GC.
  - [Garbage Collector - Precise Stack Scan](articles/dev/garbage-collector-gcinfo.md): how GCInfo makes the triggering thread's stack scan exact.
  - [Garbage Collector - Glossary](articles/dev/garbage-collector-glossary.md): background notes on the GC concepts the articles build on.

--- a/docs/templates/custom/public/main.css
+++ b/docs/templates/custom/public/main.css
@@ -2,3 +2,14 @@
     height: 40px;
     width: auto;
 }
+
+/* Version dropdown injected by main.js next to #navbar */
+.version-select {
+    display: flex;
+    align-items: center;
+    margin-left: .75rem;
+}
+
+.version-select select {
+    width: auto;
+}

--- a/docs/templates/custom/public/main.js
+++ b/docs/templates/custom/public/main.js
@@ -55,7 +55,7 @@ async function initVersionSelector() {
         : folder === 'latest' ? manifest.latest
         : folder;
     const select = document.createElement('select');
-    select.className = 'form-select form-select-sm';
+    select.className = 'form-select';
     select.setAttribute('aria-label', 'Documentation version');
     for (const name of ['dev', ...manifest.versions]) {
         const option = document.createElement('option');

--- a/docs/templates/custom/public/main.js
+++ b/docs/templates/custom/public/main.js
@@ -20,10 +20,78 @@ function applyDiagramTheme() {
     }
 }
 
+// Version selector. Released docs are frozen by release.yml into vX.Y.Z/
+// subfolders next to the dev site, plus a latest/ alias, described by a
+// versions.json at the outer root. The dropdown only appears once that file
+// exists, i.e. after the first tagged release. The site root is taken from
+// the docfx:rel meta; when its last path segment is a version folder, the
+// outer root (where versions.json and the sibling versions live) is one
+// level up.
+const versionFolder = /^(v\d[^/]*|latest)$/;
+
+async function initVersionSelector() {
+    const rel = document.querySelector('meta[name="docfx:rel"]')?.content ?? '';
+    const siteRoot = new URL(rel || './', location.href);
+    const segments = siteRoot.pathname.split('/').filter(s => s !== '');
+    const folder = segments.length > 0 ? segments[segments.length - 1] : '';
+    const inVersion = versionFolder.test(folder);
+    const outerRoot = inVersion ? new URL('../', siteRoot) : siteRoot;
+
+    let manifest;
+    try {
+        const res = await fetch(new URL('versions.json', outerRoot));
+        if (!res.ok) {
+            return;
+        }
+        manifest = await res.json();
+    } catch {
+        return;
+    }
+    if (!Array.isArray(manifest.versions) || manifest.versions.length === 0) {
+        return;
+    }
+
+    const current = !inVersion ? 'dev'
+        : folder === 'latest' ? manifest.latest
+        : folder;
+    const select = document.createElement('select');
+    select.className = 'form-select form-select-sm';
+    select.setAttribute('aria-label', 'Documentation version');
+    for (const name of ['dev', ...manifest.versions]) {
+        const option = document.createElement('option');
+        option.value = name === 'dev' ? './' : name + '/';
+        option.textContent = name === manifest.latest ? name + ' (latest)' : name;
+        if (name === current) {
+            option.setAttribute('selected', '');
+        }
+        select.append(option);
+    }
+
+    // Keep the reader on the same page when it exists in the target version,
+    // fall back to that version's landing page when it does not.
+    const pagePath = location.pathname.slice(siteRoot.pathname.length);
+    select.addEventListener('change', async () => {
+        const targetRoot = new URL(select.value, outerRoot);
+        const samePage = new URL(pagePath, targetRoot);
+        try {
+            const probe = await fetch(samePage, { method: 'HEAD' });
+            location.href = probe.ok ? samePage : targetRoot;
+        } catch {
+            location.href = targetRoot;
+        }
+    });
+
+    const container = document.createElement('div');
+    container.className = 'version-select';
+    container.append(select);
+    document.getElementById('navbar')?.after(container);
+}
+
 export default {
     start: () => {
         new MutationObserver(applyDiagramTheme)
             .observe(document.documentElement, { attributes: true, attributeFilter: ['data-bs-theme'] });
         applyDiagramTheme();
+        initVersionSelector();
     }
 }

--- a/src/Cosmos.Kernel.System/Cosmos.Kernel.System.csproj
+++ b/src/Cosmos.Kernel.System/Cosmos.Kernel.System.csproj
@@ -4,6 +4,9 @@
     <IsMultiArchPackage>true</IsMultiArchPackage>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
+    <!-- Public surface tracked in PublicAPI.Shipped/Unshipped.txt (see Directory.Build.props) -->
+    <CosmosTrackPublicApi>true</CosmosTrackPublicApi>
+
     <!-- Package Metadata -->
     <PackageId>Cosmos.Kernel.System</PackageId>
     <Title>Cosmos Kernel System</Title>

--- a/src/Cosmos.Kernel.System/PublicAPI.Shipped.txt
+++ b/src/Cosmos.Kernel.System/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Cosmos.Kernel.System/PublicAPI.Unshipped.txt
+++ b/src/Cosmos.Kernel.System/PublicAPI.Unshipped.txt
@@ -1,0 +1,1078 @@
+#nullable enable
+abstract Cosmos.Kernel.System.Kernel.Run() -> void
+abstract Cosmos.Kernel.System.Keyboard.ScanMapBase.InitKeys() -> void
+const Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.BootSectorLba = 0 -> ulong
+const Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.AttributesOffset = 11 -> int
+const Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.ClusterHighShift = 16 -> int
+const Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.ClusterWordBytes = 2 -> int
+const Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.ClusterWordMask = 65535 -> uint
+const Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.DeletedMarker = 229 -> byte
+const Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.DirectorySizeOnDisk = 0 -> uint
+const Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.EmptyFirstCluster = 0 -> uint
+const Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.EndOfDirectoryMarker = 0 -> byte
+const Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.EntrySize = 32 -> int
+const Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.FirstClusterHighOffset = 20 -> int
+const Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.FirstClusterLowOffset = 26 -> int
+const Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.MaxLfnNameLength = 255 -> int
+const Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.SizeFieldBytes = 4 -> int
+const Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.SizeOffset = 28 -> int
+const Cosmos.Kernel.System.Filesystems.Fat.FatTable.Fat32BadCluster = 268435447 -> uint
+const Cosmos.Kernel.System.Filesystems.Fat.FatTable.Fat32EndOfChain = 268435448 -> uint
+const Cosmos.Kernel.System.Filesystems.Fat.FatTable.FirstDataCluster = 2 -> uint
+const Cosmos.Kernel.System.Filesystems.Fat.FatTable.FreeCluster = 0 -> uint
+const Cosmos.Kernel.System.Graphics.Fonts.PCScreenFont.Default.DefaultFontKey = "Cosmos.Kernel.System.Graphics.Fonts.DefaultFont" -> string!
+const Cosmos.Kernel.System.Graphics.Fonts.PCScreenFont.Default.DefaultFontName = "Cosmos.Kernel.System.Graphics.Fonts.DefaultFont.psf" -> string!
+const Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.TcpWindowSize = 8192 -> ushort
+const Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSRecordType.A = 1 -> ushort
+const Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSRecordType.CNAME = 5 -> ushort
+const Cosmos.Kernel.System.Storage.Gpt.FirstUsableLba = 34 -> ulong
+const Cosmos.Kernel.System.Storage.Gpt.PrimaryHeaderLba = 1 -> ulong
+const Cosmos.Kernel.System.Storage.Gpt.ProtectiveMbrStartLba = 1 -> uint
+Cosmos.Kernel.System.Conversion.Base64
+Cosmos.Kernel.System.Filesystems.Fat.FatAttr
+Cosmos.Kernel.System.Filesystems.Fat.FatAttr.Archive = 32 -> Cosmos.Kernel.System.Filesystems.Fat.FatAttr
+Cosmos.Kernel.System.Filesystems.Fat.FatAttr.Directory = 16 -> Cosmos.Kernel.System.Filesystems.Fat.FatAttr
+Cosmos.Kernel.System.Filesystems.Fat.FatAttr.Hidden = 2 -> Cosmos.Kernel.System.Filesystems.Fat.FatAttr
+Cosmos.Kernel.System.Filesystems.Fat.FatAttr.Lfn = Cosmos.Kernel.System.Filesystems.Fat.FatAttr.ReadOnly | Cosmos.Kernel.System.Filesystems.Fat.FatAttr.Hidden | Cosmos.Kernel.System.Filesystems.Fat.FatAttr.System | Cosmos.Kernel.System.Filesystems.Fat.FatAttr.VolumeId -> Cosmos.Kernel.System.Filesystems.Fat.FatAttr
+Cosmos.Kernel.System.Filesystems.Fat.FatAttr.None = 0 -> Cosmos.Kernel.System.Filesystems.Fat.FatAttr
+Cosmos.Kernel.System.Filesystems.Fat.FatAttr.ReadOnly = 1 -> Cosmos.Kernel.System.Filesystems.Fat.FatAttr
+Cosmos.Kernel.System.Filesystems.Fat.FatAttr.System = 4 -> Cosmos.Kernel.System.Filesystems.Fat.FatAttr
+Cosmos.Kernel.System.Filesystems.Fat.FatAttr.VolumeId = 8 -> Cosmos.Kernel.System.Filesystems.Fat.FatAttr
+Cosmos.Kernel.System.Filesystems.Fat.FatBootSector
+Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.BytesPerCluster.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.BytesPerSector.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.ClusterCount.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.ClusterToLba(uint cluster) -> ulong
+Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.DataStartLba.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.FatSectorCount.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.FatStartLba.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.NumberOfFats.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.ReservedSectorCount.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.RootCluster.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.RootEntryCount.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.RootSectorCount.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.RootStartLba.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.SectorsPerCluster.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.TotalSectorCount.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.Type.get -> Cosmos.Kernel.System.Filesystems.Fat.FatType
+Cosmos.Kernel.System.Filesystems.Fat.FatDirectory
+Cosmos.Kernel.System.Filesystems.Fat.FatDirEntry
+Cosmos.Kernel.System.Filesystems.Fat.FatDirEntry.Attributes.get -> Cosmos.Kernel.System.Filesystems.Fat.FatAttr
+Cosmos.Kernel.System.Filesystems.Fat.FatDirEntry.ByteOffset.get -> int
+Cosmos.Kernel.System.Filesystems.Fat.FatDirEntry.FatDirEntry(string! name, string! shortName, Cosmos.Kernel.System.Filesystems.Fat.FatAttr attributes, uint firstCluster, uint size, int byteOffset, int lfnEntryCount) -> void
+Cosmos.Kernel.System.Filesystems.Fat.FatDirEntry.FirstCluster.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatDirEntry.IsDirectory.get -> bool
+Cosmos.Kernel.System.Filesystems.Fat.FatDirEntry.IsVolumeId.get -> bool
+Cosmos.Kernel.System.Filesystems.Fat.FatDirEntry.LfnEntryCount.get -> int
+Cosmos.Kernel.System.Filesystems.Fat.FatDirEntry.Name.get -> string!
+Cosmos.Kernel.System.Filesystems.Fat.FatDirEntry.ShortName.get -> string!
+Cosmos.Kernel.System.Filesystems.Fat.FatDirEntry.Size.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatFilesystemType
+Cosmos.Kernel.System.Filesystems.Fat.FatFilesystemType.FatFilesystemType() -> void
+Cosmos.Kernel.System.Filesystems.Fat.FatFilesystemType.FatFilesystemType(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device) -> void
+Cosmos.Kernel.System.Filesystems.Fat.FatFilesystemType.TryDestroy(System.ReadOnlySpan<char> source) -> bool
+Cosmos.Kernel.System.Filesystems.Fat.FatFilesystemType.TryFormat(System.ReadOnlySpan<char> source, Cosmos.Kernel.HAL.Vfs.IVfsFormatOptions? options) -> bool
+Cosmos.Kernel.System.Filesystems.Fat.FatFilesystemType.TryMount(System.ReadOnlySpan<char> source, Cosmos.Kernel.HAL.Vfs.MountFlags flags, out Cosmos.Kernel.HAL.Vfs.IVfsSuperblock? superblock) -> bool
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.FatFormatOptions() -> void
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.FatSectorCount.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.FatSectorCount.init -> void
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.NumberOfFats.get -> byte
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.NumberOfFats.init -> void
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.ReservedSectorCount.get -> ushort
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.ReservedSectorCount.init -> void
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.RootCluster.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.RootCluster.init -> void
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.RootEntryCount.get -> ushort
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.RootEntryCount.init -> void
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.SectorsPerCluster.get -> byte
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.SectorsPerCluster.init -> void
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.Type.get -> Cosmos.Kernel.System.Filesystems.Fat.FatType
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.Type.init -> void
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.VolumeLabel.get -> string?
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.VolumeLabel.init -> void
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.VolumeSerial.get -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatFormatOptions.VolumeSerial.init -> void
+Cosmos.Kernel.System.Filesystems.Fat.FatTable
+Cosmos.Kernel.System.Filesystems.Fat.FatTable.AllocateChain(uint count) -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatTable.CountFree() -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatTable.EndOfChainMarker() -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatTable.ExtendChain(uint lastCluster, uint count) -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatTable.FatTable(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, Cosmos.Kernel.System.Filesystems.Fat.FatBootSector! boot) -> void
+Cosmos.Kernel.System.Filesystems.Fat.FatTable.FindFree() -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatTable.Free(uint firstCluster) -> void
+Cosmos.Kernel.System.Filesystems.Fat.FatTable.Get(uint cluster) -> uint
+Cosmos.Kernel.System.Filesystems.Fat.FatTable.GetChain(uint firstCluster) -> System.Collections.Generic.List<uint>!
+Cosmos.Kernel.System.Filesystems.Fat.FatTable.IsBadCluster(uint entry) -> bool
+Cosmos.Kernel.System.Filesystems.Fat.FatTable.IsDataCluster(uint cluster) -> bool
+Cosmos.Kernel.System.Filesystems.Fat.FatTable.IsEndOfChain(uint entry) -> bool
+Cosmos.Kernel.System.Filesystems.Fat.FatTable.Set(uint cluster, uint value) -> void
+Cosmos.Kernel.System.Filesystems.Fat.FatType
+Cosmos.Kernel.System.Filesystems.Fat.FatType.Fat12 = 1 -> Cosmos.Kernel.System.Filesystems.Fat.FatType
+Cosmos.Kernel.System.Filesystems.Fat.FatType.Fat16 = 2 -> Cosmos.Kernel.System.Filesystems.Fat.FatType
+Cosmos.Kernel.System.Filesystems.Fat.FatType.Fat32 = 3 -> Cosmos.Kernel.System.Filesystems.Fat.FatType
+Cosmos.Kernel.System.Filesystems.Fat.FatType.Unknown = 0 -> Cosmos.Kernel.System.Filesystems.Fat.FatType
+Cosmos.Kernel.System.Global
+Cosmos.Kernel.System.Graphics.Bitmap
+Cosmos.Kernel.System.Graphics.Bitmap.Bitmap(byte[]! imageData) -> void
+Cosmos.Kernel.System.Graphics.Bitmap.Bitmap(byte[]! imageData, Cosmos.Kernel.System.Graphics.ColorOrder colorOrder = Cosmos.Kernel.System.Graphics.ColorOrder.BGR) -> void
+Cosmos.Kernel.System.Graphics.Bitmap.Bitmap(string! path) -> void
+Cosmos.Kernel.System.Graphics.Bitmap.Bitmap(string! path, Cosmos.Kernel.System.Graphics.ColorOrder colorOrder = Cosmos.Kernel.System.Graphics.ColorOrder.BGR) -> void
+Cosmos.Kernel.System.Graphics.Bitmap.Bitmap(uint width, uint height, byte[]! pixelData, Cosmos.Kernel.System.Graphics.ColorDepth colorDepth) -> void
+Cosmos.Kernel.System.Graphics.Bitmap.Bitmap(uint width, uint height, Cosmos.Kernel.System.Graphics.ColorDepth colorDepth) -> void
+Cosmos.Kernel.System.Graphics.Bitmap.Save(string! path) -> void
+Cosmos.Kernel.System.Graphics.Bitmap.Save(System.IO.Stream! stream, Cosmos.Kernel.System.Graphics.ImageFormat imageFormat = Cosmos.Kernel.System.Graphics.ImageFormat.BMP) -> void
+Cosmos.Kernel.System.Graphics.Canvas
+Cosmos.Kernel.System.Graphics.Canvas.Buffer -> int[]?
+Cosmos.Kernel.System.Graphics.Canvas.Canvas() -> void
+Cosmos.Kernel.System.Graphics.Canvas.Canvas(Cosmos.Kernel.System.Graphics.Mode mode) -> void
+Cosmos.Kernel.System.Graphics.Canvas.Canvas(int width, int height, Cosmos.Kernel.System.Graphics.ColorDepth colorDepth = Cosmos.Kernel.System.Graphics.ColorDepth.ColorDepth32) -> void
+Cosmos.Kernel.System.Graphics.Canvas.CheckIfModeIsValid(Cosmos.Kernel.System.Graphics.Mode mode) -> bool
+Cosmos.Kernel.System.Graphics.Canvas.Clear() -> void
+Cosmos.Kernel.System.Graphics.Canvas.DrawImageAlpha(Cosmos.Kernel.System.Graphics.Image! image, int x, int y, bool preventOffBoundPixels = true) -> void
+Cosmos.Kernel.System.Graphics.Canvas.GetBuffer() -> int[]?
+Cosmos.Kernel.System.Graphics.Canvas.Height.get -> int
+Cosmos.Kernel.System.Graphics.Canvas.ThrowIfCoordNotValid(int x, int y) -> void
+Cosmos.Kernel.System.Graphics.Canvas.ThrowIfModeIsNotValid(Cosmos.Kernel.System.Graphics.Mode mode) -> void
+Cosmos.Kernel.System.Graphics.Canvas.TrimLine(ref int x1, ref int y1, ref int x2, ref int y2) -> void
+Cosmos.Kernel.System.Graphics.Canvas.Width.get -> int
+Cosmos.Kernel.System.Graphics.Cell
+Cosmos.Kernel.System.Graphics.Cell.BackgroundColor -> uint
+Cosmos.Kernel.System.Graphics.Cell.Cell() -> void
+Cosmos.Kernel.System.Graphics.Cell.Cell(char c, uint foreground, uint background) -> void
+Cosmos.Kernel.System.Graphics.Cell.Char -> char
+Cosmos.Kernel.System.Graphics.Cell.ForegroundColor -> uint
+Cosmos.Kernel.System.Graphics.ColorDepth
+Cosmos.Kernel.System.Graphics.ColorDepth.ColorDepth16 = 16 -> Cosmos.Kernel.System.Graphics.ColorDepth
+Cosmos.Kernel.System.Graphics.ColorDepth.ColorDepth24 = 24 -> Cosmos.Kernel.System.Graphics.ColorDepth
+Cosmos.Kernel.System.Graphics.ColorDepth.ColorDepth32 = 32 -> Cosmos.Kernel.System.Graphics.ColorDepth
+Cosmos.Kernel.System.Graphics.ColorDepth.ColorDepth4 = 4 -> Cosmos.Kernel.System.Graphics.ColorDepth
+Cosmos.Kernel.System.Graphics.ColorDepth.ColorDepth8 = 8 -> Cosmos.Kernel.System.Graphics.ColorDepth
+Cosmos.Kernel.System.Graphics.ColorOrder
+Cosmos.Kernel.System.Graphics.ColorOrder.BGR = 1 -> Cosmos.Kernel.System.Graphics.ColorOrder
+Cosmos.Kernel.System.Graphics.ColorOrder.RGB = 0 -> Cosmos.Kernel.System.Graphics.ColorOrder
+Cosmos.Kernel.System.Graphics.Fonts.Font
+Cosmos.Kernel.System.Graphics.Fonts.Font.ConvertByteToBitAddress(byte byteToConvert, int bitToReturn) -> bool
+Cosmos.Kernel.System.Graphics.Fonts.Font.Data.get -> byte[]!
+Cosmos.Kernel.System.Graphics.Fonts.Font.Font(byte width, byte height, byte[]! data) -> void
+Cosmos.Kernel.System.Graphics.Fonts.Font.Height.get -> byte
+Cosmos.Kernel.System.Graphics.Fonts.Font.Width.get -> byte
+Cosmos.Kernel.System.Graphics.Fonts.PCScreenFont
+Cosmos.Kernel.System.Graphics.Fonts.PCScreenFont.CreateVGAFont() -> byte[]!
+Cosmos.Kernel.System.Graphics.Fonts.PCScreenFont.Default
+Cosmos.Kernel.System.Graphics.Fonts.PCScreenFont.PCScreenFont(byte width, byte height, byte[]! data, System.Collections.Generic.List<Cosmos.Kernel.System.Graphics.Fonts.UnicodeMapping>! _unicodeMappings) -> void
+Cosmos.Kernel.System.Graphics.Fonts.TrueTypeFont
+Cosmos.Kernel.System.Graphics.Fonts.TrueTypeFont.GetAdvance(char c, int sizePx) -> int
+Cosmos.Kernel.System.Graphics.Fonts.TrueTypeFont.GetAscent(int sizePx) -> int
+Cosmos.Kernel.System.Graphics.Fonts.TrueTypeFont.GetKerning(char left, char right, int sizePx) -> int
+Cosmos.Kernel.System.Graphics.Fonts.TrueTypeFont.GetLineHeight(int sizePx) -> int
+Cosmos.Kernel.System.Graphics.Fonts.TrueTypeFont.GetLineMetrics(int sizePx, out int ascent, out int descent, out int lineGap) -> void
+Cosmos.Kernel.System.Graphics.Fonts.TrueTypeFont.HasGlyph(char c) -> bool
+Cosmos.Kernel.System.Graphics.Fonts.TrueTypeFont.MeasureString(string! text, int sizePx) -> int
+Cosmos.Kernel.System.Graphics.Fonts.TrueTypeFont.SizePx.get -> int
+Cosmos.Kernel.System.Graphics.Fonts.TrueTypeFont.SizePx.set -> void
+Cosmos.Kernel.System.Graphics.Fonts.TrueTypeFont.TrueTypeFont(byte[]! fontData, int sizePx = 16) -> void
+Cosmos.Kernel.System.Graphics.Fonts.TrueTypeFont.TrueTypeFont(string! path, int sizePx = 16) -> void
+Cosmos.Kernel.System.Graphics.Fonts.TrueTypeFont.TrueTypeFont(System.IO.Stream! stream, int sizePx = 16) -> void
+Cosmos.Kernel.System.Graphics.Fonts.UnicodeMapping
+Cosmos.Kernel.System.Graphics.Fonts.UnicodeMapping.ASCIICharacters -> System.Collections.Generic.List<byte>!
+Cosmos.Kernel.System.Graphics.Fonts.UnicodeMapping.FontPosition -> int
+Cosmos.Kernel.System.Graphics.Fonts.UnicodeMapping.UnicodeCharacters -> System.Collections.Generic.List<ushort>!
+Cosmos.Kernel.System.Graphics.Fonts.UnicodeMapping.UnicodeCharactersWithModifiers -> System.Collections.Generic.List<ushort[]!>!
+Cosmos.Kernel.System.Graphics.Fonts.UnicodeMapping.UnicodeMapping() -> void
+Cosmos.Kernel.System.Graphics.FullScreenCanvas
+Cosmos.Kernel.System.Graphics.Image
+Cosmos.Kernel.System.Graphics.Image.Depth.get -> Cosmos.Kernel.System.Graphics.ColorDepth
+Cosmos.Kernel.System.Graphics.Image.Depth.set -> void
+Cosmos.Kernel.System.Graphics.Image.Height.get -> uint
+Cosmos.Kernel.System.Graphics.Image.Height.set -> void
+Cosmos.Kernel.System.Graphics.Image.Image(uint width, uint height, Cosmos.Kernel.System.Graphics.ColorDepth color) -> void
+Cosmos.Kernel.System.Graphics.Image.RawData -> int[]!
+Cosmos.Kernel.System.Graphics.Image.Width.get -> uint
+Cosmos.Kernel.System.Graphics.Image.Width.set -> void
+Cosmos.Kernel.System.Graphics.ImageFormat
+Cosmos.Kernel.System.Graphics.ImageFormat.BMP = 0 -> Cosmos.Kernel.System.Graphics.ImageFormat
+Cosmos.Kernel.System.Graphics.KernelConsole
+Cosmos.Kernel.System.Graphics.KernelConsole.BackgroundColor.get -> uint
+Cosmos.Kernel.System.Graphics.KernelConsole.BackgroundColor.set -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.Canvas.get -> Cosmos.Kernel.System.Graphics.Canvas!
+Cosmos.Kernel.System.Graphics.KernelConsole.Clear() -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.Cols.get -> int
+Cosmos.Kernel.System.Graphics.KernelConsole.CursorVisible.get -> bool
+Cosmos.Kernel.System.Graphics.KernelConsole.CursorVisible.set -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.CursorX.get -> int
+Cosmos.Kernel.System.Graphics.KernelConsole.CursorX.set -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.CursorY.get -> int
+Cosmos.Kernel.System.Graphics.KernelConsole.CursorY.set -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.Font.get -> Cosmos.Kernel.System.Graphics.Fonts.Font!
+Cosmos.Kernel.System.Graphics.KernelConsole.Font.set -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.ForegroundColor.get -> uint
+Cosmos.Kernel.System.Graphics.KernelConsole.ForegroundColor.set -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.GetCellAt(int col, int row) -> Cosmos.Kernel.System.Graphics.Cell
+Cosmos.Kernel.System.Graphics.KernelConsole.GetCharAt(int col, int row) -> char
+Cosmos.Kernel.System.Graphics.KernelConsole.IsAvailable.get -> bool
+Cosmos.Kernel.System.Graphics.KernelConsole.KernelConsole(Cosmos.Kernel.System.Graphics.Canvas! canvas, Cosmos.Kernel.System.Graphics.Fonts.Font? font = null) -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.MoveCursorDown() -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.MoveCursorLeft() -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.MoveCursorRight() -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.MoveCursorUp() -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.Redraw() -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.ResetColors() -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.Rows.get -> int
+Cosmos.Kernel.System.Graphics.KernelConsole.SetBackgroundColor(System.ConsoleColor color) -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.SetCellAt(int col, int row, Cosmos.Kernel.System.Graphics.Cell cell) -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.SetCursorPosition(int x, int y) -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.SetForegroundColor(System.ConsoleColor color) -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.Write(char c) -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.Write(string! text) -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.Write(System.ReadOnlySpan<char> buffer) -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.WriteLine() -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.WriteLine(char c) -> void
+Cosmos.Kernel.System.Graphics.KernelConsole.WriteLine(string! text) -> void
+Cosmos.Kernel.System.Graphics.Mode
+Cosmos.Kernel.System.Graphics.Mode.ColorDepth.get -> Cosmos.Kernel.System.Graphics.ColorDepth
+Cosmos.Kernel.System.Graphics.Mode.CompareTo(Cosmos.Kernel.System.Graphics.Mode other) -> int
+Cosmos.Kernel.System.Graphics.Mode.Equals(Cosmos.Kernel.System.Graphics.Mode other) -> bool
+Cosmos.Kernel.System.Graphics.Mode.Height.get -> uint
+Cosmos.Kernel.System.Graphics.Mode.Mode() -> void
+Cosmos.Kernel.System.Graphics.Mode.Mode(uint columns, uint rows, Cosmos.Kernel.System.Graphics.ColorDepth colorDepth) -> void
+Cosmos.Kernel.System.Graphics.Mode.Width.get -> uint
+Cosmos.Kernel.System.Graphics.Png
+Cosmos.Kernel.System.Graphics.Png.Png(byte[]! imageData) -> void
+Cosmos.Kernel.System.Graphics.Png.Png(string! path) -> void
+Cosmos.Kernel.System.Graphics.Png.Png(System.IO.Stream! stream) -> void
+Cosmos.Kernel.System.Graphics.SVGAII3DCanvas
+Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.CopyPixels(int srcX, int srcY, int dstX, int dstY, int width = 1, int height = 1) -> void
+Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.CreateCursor() -> void
+Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.DefineAlphaCursor(int hotspotX, int hotspotY, int width, int height, int[]! data) -> void
+Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.Driver.get -> Cosmos.Kernel.HAL.Devices.Graphic.SVGAII.SvgaIIDriver!
+Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.Driver3D.get -> Cosmos.Kernel.HAL.Devices.Graphic.SVGAII.VMWareSVGAII3D?
+Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.GetPixel(int x, int y) -> System.Drawing.Color
+Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.HasHardwareCursor.get -> bool
+Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.MovePixel(int x, int y, int newX, int newY) -> void
+Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.SetCursor(bool visible, int x, int y) -> void
+Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.SVGAII3DCanvas(Cosmos.Kernel.HAL.Pci.PciDevice! device) -> void
+Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.SVGAII3DCanvas(Cosmos.Kernel.HAL.Pci.PciDevice! device, Cosmos.Kernel.System.Graphics.Mode aMode) -> void
+Cosmos.Kernel.System.IO.ConsoleStream
+Cosmos.Kernel.System.IO.ConsoleStream.ConsoleStream(System.IO.FileAccess access) -> void
+Cosmos.Kernel.System.IO.ConsoleTextWriter
+Cosmos.Kernel.System.IO.ConsoleTextWriter.ConsoleTextWriter() -> void
+Cosmos.Kernel.System.IO.KeyboardTextReader
+Cosmos.Kernel.System.IO.KeyboardTextReader.KeyboardTextReader() -> void
+Cosmos.Kernel.System.Kernel
+Cosmos.Kernel.System.Kernel.Kernel() -> void
+Cosmos.Kernel.System.Kernel.mStarted -> bool
+Cosmos.Kernel.System.Kernel.mStopped -> bool
+Cosmos.Kernel.System.Kernel.Stop() -> void
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.A = 47 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.AltGr = 82 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Apostrophe = 58 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.B = 70 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Backquote = 17 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Backslash = 30 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Backspace = 31 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.BiggerThan = 60 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.C = 68 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.CapsLock = 46 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Colon = 57 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Comma = 73 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.D = 49 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.D0 = 27 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.D1 = 18 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.D2 = 19 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.D3 = 20 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.D4 = 21 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.D5 = 22 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.D6 = 23 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.D7 = 24 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.D8 = 25 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.D9 = 26 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Delete = 88 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.DownArrow = 92 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.E = 35 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.End = 89 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Enter = 45 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Equal = 29 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Escape = 1 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.ExclamationPoint = 61 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.F = 50 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.F1 = 2 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.F10 = 11 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.F11 = 12 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.F12 = 13 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.F2 = 3 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.F3 = 4 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.F4 = 5 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.F5 = 6 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.F6 = 7 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.F7 = 8 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.F8 = 9 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.F9 = 10 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.G = 51 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.H = 52 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Home = 86 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.I = 40 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Insert = 85 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.J = 53 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.K = 54 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.L = 55 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.LAlt = 79 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.LBracket = 43 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.LCtrl = 76 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.LeftArrow = 93 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.LowerThan = 59 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.LShift = 62 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.LWin = 78 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.M = 72 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Menu = 84 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Minus = 28 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.N = 71 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.NoName = 0 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Num0 = 109 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Num1 = 106 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Num2 = 107 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Num3 = 108 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Num4 = 103 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Num5 = 104 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Num6 = 105 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Num7 = 99 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Num8 = 100 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Num9 = 101 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.NumDivide = 96 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.NumEnter = 111 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.NumLock = 95 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.NumMinus = 98 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.NumMultiply = 97 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.NumPeriod = 110 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.NumPlus = 102 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.O = 41 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.OEM102 = 64 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.OEM5 = 65 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.P = 42 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.PageDown = 90 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.PageUp = 87 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.PauseBreak = 16 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Period = 74 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Power = 112 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.PrintScreen = 14 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Q = 33 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.R = 36 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.RAlt = 80 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.RBracket = 44 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.RCtrl = 77 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.RightArrow = 94 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.RShift = 63 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.RWin = 83 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.S = 48 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.ScrollLock = 15 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Semicolon = 56 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Slash = 75 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Sleep = 113 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Spacebar = 81 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.T = 37 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Tab = 32 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.U = 39 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.UpArrow = 91 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.V = 69 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.W = 34 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Wake = 114 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.X = 67 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Y = 38 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.Z = 66 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.KeyboardManager
+Cosmos.Kernel.System.Keyboard.KeyEvent
+Cosmos.Kernel.System.Keyboard.KeyEvent.Key.get -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.KeyEvent.Key.set -> void
+Cosmos.Kernel.System.Keyboard.KeyEvent.KeyChar.get -> char
+Cosmos.Kernel.System.Keyboard.KeyEvent.KeyChar.set -> void
+Cosmos.Kernel.System.Keyboard.KeyEvent.KeyEvent() -> void
+Cosmos.Kernel.System.Keyboard.KeyEvent.KeyEvent(char keyChar, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx key, bool shift, bool alt, bool control, Cosmos.Kernel.System.Keyboard.KeyEvent.KeyEventType type) -> void
+Cosmos.Kernel.System.Keyboard.KeyEvent.KeyEventType
+Cosmos.Kernel.System.Keyboard.KeyEvent.KeyEventType.Break = 1 -> Cosmos.Kernel.System.Keyboard.KeyEvent.KeyEventType
+Cosmos.Kernel.System.Keyboard.KeyEvent.KeyEventType.Make = 0 -> Cosmos.Kernel.System.Keyboard.KeyEvent.KeyEventType
+Cosmos.Kernel.System.Keyboard.KeyEvent.Modifiers.get -> System.ConsoleModifiers
+Cosmos.Kernel.System.Keyboard.KeyEvent.Modifiers.set -> void
+Cosmos.Kernel.System.Keyboard.KeyEvent.Type.get -> Cosmos.Kernel.System.Keyboard.KeyEvent.KeyEventType
+Cosmos.Kernel.System.Keyboard.KeyEvent.Type.set -> void
+Cosmos.Kernel.System.Keyboard.KeyMapping
+Cosmos.Kernel.System.Keyboard.KeyMapping.CapsLock -> char
+Cosmos.Kernel.System.Keyboard.KeyMapping.Control -> char
+Cosmos.Kernel.System.Keyboard.KeyMapping.ControlAlt -> char
+Cosmos.Kernel.System.Keyboard.KeyMapping.ControlAltShift -> char
+Cosmos.Kernel.System.Keyboard.KeyMapping.ControlShift -> char
+Cosmos.Kernel.System.Keyboard.KeyMapping.Key -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.KeyMapping.KeyMapping(byte scanCode, char n, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx key) -> void
+Cosmos.Kernel.System.Keyboard.KeyMapping.KeyMapping(byte scanCode, char normal, char shift, char num, char caps, char shiftCapsLock, char shiftNumLock, char ctrlAlt, char ctrlAltShift, char ctrl, char shiftCtrl, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx key, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx numKey) -> void
+Cosmos.Kernel.System.Keyboard.KeyMapping.KeyMapping(byte scanCode, char normal, char shift, char num, char capsLock, char shiftCapsLock, char shiftNumLock, char ctrlAlt, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx key) -> void
+Cosmos.Kernel.System.Keyboard.KeyMapping.KeyMapping(byte scanCode, char normal, char shift, char numLock, char capsLock, char shiftCapsLock, char shiftNumLock, char ctrlAlt, char ctrlAltShift, char ctrl, char shiftCtrl, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx key) -> void
+Cosmos.Kernel.System.Keyboard.KeyMapping.KeyMapping(byte scanCode, char normal, char shift, char numLock, char capsLock, char shiftCapsLock, char shiftNumLock, char ctrlAlt, char ctrlAltShift, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx aKey) -> void
+Cosmos.Kernel.System.Keyboard.KeyMapping.KeyMapping(byte scanCode, char normal, char shift, char numLock, char capsLock, char shiftCapsLock, char shiftNumLock, char ctrlAlt, char ctrlAltShift, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx key, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx numKey) -> void
+Cosmos.Kernel.System.Keyboard.KeyMapping.KeyMapping(byte scanCode, char normal, char shift, char numLock, char capsLock, char shiftCapsLock, char shiftNumLock, char ctrlAlt, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx key, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx numKey) -> void
+Cosmos.Kernel.System.Keyboard.KeyMapping.KeyMapping(byte scanCode, char normal, char shift, char numLock, char capsLock, char shiftCapsLock, char shiftNumLock, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx key) -> void
+Cosmos.Kernel.System.Keyboard.KeyMapping.KeyMapping(byte scanCode, char normal, char shift, char numLock, char capsLock, char shiftCapsLock, char shiftNumLock, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx key, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx numKey) -> void
+Cosmos.Kernel.System.Keyboard.KeyMapping.KeyMapping(byte scanCode, char numLock, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx key, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx numKey) -> void
+Cosmos.Kernel.System.Keyboard.KeyMapping.KeyMapping(byte scanCode, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx key) -> void
+Cosmos.Kernel.System.Keyboard.KeyMapping.NumLock -> char
+Cosmos.Kernel.System.Keyboard.KeyMapping.NumLockKey -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
+Cosmos.Kernel.System.Keyboard.KeyMapping.ScanCode -> byte
+Cosmos.Kernel.System.Keyboard.KeyMapping.Shift -> char
+Cosmos.Kernel.System.Keyboard.KeyMapping.ShiftCapsLock -> char
+Cosmos.Kernel.System.Keyboard.KeyMapping.ShiftNumLock -> char
+Cosmos.Kernel.System.Keyboard.KeyMapping.Value -> char
+Cosmos.Kernel.System.Keyboard.ScanMapBase
+Cosmos.Kernel.System.Keyboard.ScanMapBase.ConvertScanCode(byte scanKey, bool ctrl, bool shift, bool alt, bool numLock, bool capsLock, bool scrollLock) -> Cosmos.Kernel.System.Keyboard.KeyEvent?
+Cosmos.Kernel.System.Keyboard.ScanMapBase.Keys -> System.Collections.Generic.List<Cosmos.Kernel.System.Keyboard.KeyMapping!>!
+Cosmos.Kernel.System.Keyboard.ScanMapBase.ScanCodeMatchesKey(byte scanCode, Cosmos.Kernel.System.Keyboard.ConsoleKeyEx key) -> bool
+Cosmos.Kernel.System.Keyboard.ScanMapBase.ScanMapBase() -> void
+Cosmos.Kernel.System.Keyboard.ScanMaps.DEStandardLayout
+Cosmos.Kernel.System.Keyboard.ScanMaps.DEStandardLayout.DEStandardLayout() -> void
+Cosmos.Kernel.System.Keyboard.ScanMaps.ESStandardLayout
+Cosmos.Kernel.System.Keyboard.ScanMaps.ESStandardLayout.ESStandardLayout() -> void
+Cosmos.Kernel.System.Keyboard.ScanMaps.FRStandardLayout
+Cosmos.Kernel.System.Keyboard.ScanMaps.FRStandardLayout.FRStandardLayout() -> void
+Cosmos.Kernel.System.Keyboard.ScanMaps.GBStandardLayout
+Cosmos.Kernel.System.Keyboard.ScanMaps.GBStandardLayout.GBStandardLayout() -> void
+Cosmos.Kernel.System.Keyboard.ScanMaps.TRStandardLayout
+Cosmos.Kernel.System.Keyboard.ScanMaps.TRStandardLayout.TRStandardLayout() -> void
+Cosmos.Kernel.System.Keyboard.ScanMaps.USDvorakLayout
+Cosmos.Kernel.System.Keyboard.ScanMaps.USDvorakLayout.USDvorakLayout() -> void
+Cosmos.Kernel.System.Keyboard.ScanMaps.USStandardLayout
+Cosmos.Kernel.System.Keyboard.ScanMaps.USStandardLayout.USStandardLayout() -> void
+Cosmos.Kernel.System.Mouse.MouseManager
+Cosmos.Kernel.System.Network.ARP.ARPPacket
+Cosmos.Kernel.System.Network.ARP.ARPPacket.ARPPacket(byte[]! rawData) -> void
+Cosmos.Kernel.System.Network.ARP.ARPPacket.ARPPacket(Cosmos.Kernel.HAL.Devices.Network.MACAddress! dest, Cosmos.Kernel.HAL.Devices.Network.MACAddress! src, ushort hwType, ushort protoType, byte hwLen, byte protoLen, ushort operation, int packet_size) -> void
+Cosmos.Kernel.System.Network.ARP.ARPPacket.hardwareAddrLength -> byte
+Cosmos.Kernel.System.Network.ARP.ARPPacket.hardwareType -> ushort
+Cosmos.Kernel.System.Network.ARP.ARPPacket.opCode -> ushort
+Cosmos.Kernel.System.Network.ARP.ARPPacket.protocolAddrLength -> byte
+Cosmos.Kernel.System.Network.ARP.ARPPacket.protocolType -> ushort
+Cosmos.Kernel.System.Network.Config.DNSConfig
+Cosmos.Kernel.System.Network.Config.DNSConfig.DNSConfig() -> void
+Cosmos.Kernel.System.Network.Config.IPConfig
+Cosmos.Kernel.System.Network.Config.IPConfig.DefaultGateway.get -> Cosmos.Kernel.System.Network.IPv4.Address!
+Cosmos.Kernel.System.Network.Config.IPConfig.IPAddress.get -> Cosmos.Kernel.System.Network.IPv4.Address!
+Cosmos.Kernel.System.Network.Config.IPConfig.IPConfig(Cosmos.Kernel.System.Network.IPv4.Address! ip, Cosmos.Kernel.System.Network.IPv4.Address! subnet) -> void
+Cosmos.Kernel.System.Network.Config.IPConfig.IPConfig(Cosmos.Kernel.System.Network.IPv4.Address! ip, Cosmos.Kernel.System.Network.IPv4.Address! subnet, Cosmos.Kernel.System.Network.IPv4.Address! gw) -> void
+Cosmos.Kernel.System.Network.Config.IPConfig.SubnetMask.get -> Cosmos.Kernel.System.Network.IPv4.Address!
+Cosmos.Kernel.System.Network.Config.NetworkConfigEntry
+Cosmos.Kernel.System.Network.Config.NetworkConfigEntry.Device -> Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice!
+Cosmos.Kernel.System.Network.Config.NetworkConfigEntry.IPConfig -> Cosmos.Kernel.System.Network.Config.IPConfig!
+Cosmos.Kernel.System.Network.Config.NetworkConfigManager
+Cosmos.Kernel.System.Network.EthernetPacket
+Cosmos.Kernel.System.Network.EthernetPacket.destMAC -> Cosmos.Kernel.HAL.Devices.Network.MACAddress!
+Cosmos.Kernel.System.Network.EthernetPacket.EthernetPacket(byte[]! rawData) -> void
+Cosmos.Kernel.System.Network.EthernetPacket.EthernetPacket(Cosmos.Kernel.HAL.Devices.Network.MACAddress! dest, Cosmos.Kernel.HAL.Devices.Network.MACAddress! src, ushort type, int packetSize) -> void
+Cosmos.Kernel.System.Network.EthernetPacket.EthernetPacket(ushort type, int packetSize) -> void
+Cosmos.Kernel.System.Network.EthernetPacket.RawData.get -> byte[]!
+Cosmos.Kernel.System.Network.EthernetPacket.srcMAC -> Cosmos.Kernel.HAL.Devices.Network.MACAddress!
+Cosmos.Kernel.System.Network.IPv4.Address
+Cosmos.Kernel.System.Network.IPv4.Address.Address(byte aFirst, byte aSecond, byte aThird, byte aFourth) -> void
+Cosmos.Kernel.System.Network.IPv4.Address.Address(byte[]! buffer, int offset) -> void
+Cosmos.Kernel.System.Network.IPv4.Address.Address(System.ReadOnlySpan<byte> buffer) -> void
+Cosmos.Kernel.System.Network.IPv4.Address.Address(uint address) -> void
+Cosmos.Kernel.System.Network.IPv4.Address.CompareTo(Cosmos.Kernel.System.Network.IPv4.Address? other) -> int
+Cosmos.Kernel.System.Network.IPv4.Address.Id.get -> uint
+Cosmos.Kernel.System.Network.IPv4.Address.IsAPIPA() -> bool
+Cosmos.Kernel.System.Network.IPv4.Address.IsBroadcastAddress() -> bool
+Cosmos.Kernel.System.Network.IPv4.Address.IsIpv4.get -> bool
+Cosmos.Kernel.System.Network.IPv4.Address.IsIpv6.get -> bool
+Cosmos.Kernel.System.Network.IPv4.Address.IsLoopbackAddress() -> bool
+Cosmos.Kernel.System.Network.IPv4.Address.Parts.get -> System.Collections.Immutable.ImmutableArray<byte>
+Cosmos.Kernel.System.Network.IPv4.Address.ToSpan() -> System.ReadOnlySpan<byte>
+Cosmos.Kernel.System.Network.IPv4.Address.ToUInt32() -> uint
+Cosmos.Kernel.System.Network.IPv4.EndPoint
+Cosmos.Kernel.System.Network.IPv4.EndPoint.Address -> Cosmos.Kernel.System.Network.IPv4.Address!
+Cosmos.Kernel.System.Network.IPv4.EndPoint.CompareTo(object? obj) -> int
+Cosmos.Kernel.System.Network.IPv4.EndPoint.EndPoint(Cosmos.Kernel.System.Network.IPv4.Address! addr, ushort port) -> void
+Cosmos.Kernel.System.Network.IPv4.EndPoint.EndPoint(uint addr, ushort port) -> void
+Cosmos.Kernel.System.Network.IPv4.EndPoint.Port -> ushort
+Cosmos.Kernel.System.Network.IPv4.ICMPClient
+Cosmos.Kernel.System.Network.IPv4.ICMPClient.Close() -> void
+Cosmos.Kernel.System.Network.IPv4.ICMPClient.Connect(Cosmos.Kernel.System.Network.IPv4.Address! dest) -> void
+Cosmos.Kernel.System.Network.IPv4.ICMPClient.Dispose() -> void
+Cosmos.Kernel.System.Network.IPv4.ICMPClient.ICMPClient() -> void
+Cosmos.Kernel.System.Network.IPv4.ICMPClient.Receive(ref Cosmos.Kernel.System.Network.IPv4.EndPoint! source, int timeout = 5000) -> int
+Cosmos.Kernel.System.Network.IPv4.ICMPClient.SendEcho(ushort id = 1, ushort sequence = 1) -> void
+Cosmos.Kernel.System.Network.IPv4.ICMPPacket
+Cosmos.Kernel.System.Network.IPv4.IPPacket
+Cosmos.Kernel.System.Network.IPv4.IPPacket.CalcIPCRC(ushort headerLength) -> ushort
+Cosmos.Kernel.System.Network.IPv4.IPPacket.CalcOcCRC(ushort offset, ushort length) -> ushort
+Cosmos.Kernel.System.Network.IPv4.IPPacket.DestinationIP.get -> Cosmos.Kernel.System.Network.IPv4.Address!
+Cosmos.Kernel.System.Network.IPv4.IPPacket.ipHeaderLength -> byte
+Cosmos.Kernel.System.Network.IPv4.IPPacket.IPPacket(byte[]! rawData) -> void
+Cosmos.Kernel.System.Network.IPv4.IPPacket.IPPacket(Cosmos.Kernel.HAL.Devices.Network.MACAddress! srcMAC, Cosmos.Kernel.HAL.Devices.Network.MACAddress! destMAC, ushort dataLength, byte protocol, Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, byte Flags) -> void
+Cosmos.Kernel.System.Network.IPv4.IPPacket.IPPacket(ushort dataLength, byte protocol, Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, byte Flags) -> void
+Cosmos.Kernel.System.Network.IPv4.IPPacket.IPPacket(ushort dataLength, byte protocol, Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, byte Flags, Cosmos.Kernel.HAL.Devices.Network.MACAddress! destMAC) -> void
+Cosmos.Kernel.System.Network.IPv4.IPPacket.SourceIP.get -> Cosmos.Kernel.System.Network.IPv4.Address!
+Cosmos.Kernel.System.Network.IPv4.OutgoingBuffer
+Cosmos.Kernel.System.Network.IPv4.TCP.Flags
+Cosmos.Kernel.System.Network.IPv4.TCP.Flags.ACK = 16 -> Cosmos.Kernel.System.Network.IPv4.TCP.Flags
+Cosmos.Kernel.System.Network.IPv4.TCP.Flags.FIN = 1 -> Cosmos.Kernel.System.Network.IPv4.TCP.Flags
+Cosmos.Kernel.System.Network.IPv4.TCP.Flags.PSH = 8 -> Cosmos.Kernel.System.Network.IPv4.TCP.Flags
+Cosmos.Kernel.System.Network.IPv4.TCP.Flags.RST = 4 -> Cosmos.Kernel.System.Network.IPv4.TCP.Flags
+Cosmos.Kernel.System.Network.IPv4.TCP.Flags.SYN = 2 -> Cosmos.Kernel.System.Network.IPv4.TCP.Flags
+Cosmos.Kernel.System.Network.IPv4.TCP.Flags.URG = 32 -> Cosmos.Kernel.System.Network.IPv4.TCP.Flags
+Cosmos.Kernel.System.Network.IPv4.TCP.Status
+Cosmos.Kernel.System.Network.IPv4.TCP.Status.CLOSED = 10 -> Cosmos.Kernel.System.Network.IPv4.TCP.Status
+Cosmos.Kernel.System.Network.IPv4.TCP.Status.CLOSE_WAIT = 6 -> Cosmos.Kernel.System.Network.IPv4.TCP.Status
+Cosmos.Kernel.System.Network.IPv4.TCP.Status.CLOSING = 7 -> Cosmos.Kernel.System.Network.IPv4.TCP.Status
+Cosmos.Kernel.System.Network.IPv4.TCP.Status.ESTABLISHED = 3 -> Cosmos.Kernel.System.Network.IPv4.TCP.Status
+Cosmos.Kernel.System.Network.IPv4.TCP.Status.FIN_WAIT1 = 4 -> Cosmos.Kernel.System.Network.IPv4.TCP.Status
+Cosmos.Kernel.System.Network.IPv4.TCP.Status.FIN_WAIT2 = 5 -> Cosmos.Kernel.System.Network.IPv4.TCP.Status
+Cosmos.Kernel.System.Network.IPv4.TCP.Status.LAST_ACK = 8 -> Cosmos.Kernel.System.Network.IPv4.TCP.Status
+Cosmos.Kernel.System.Network.IPv4.TCP.Status.LISTEN = 0 -> Cosmos.Kernel.System.Network.IPv4.TCP.Status
+Cosmos.Kernel.System.Network.IPv4.TCP.Status.SYN_RECEIVED = 2 -> Cosmos.Kernel.System.Network.IPv4.TCP.Status
+Cosmos.Kernel.System.Network.IPv4.TCP.Status.SYN_SENT = 1 -> Cosmos.Kernel.System.Network.IPv4.TCP.Status
+Cosmos.Kernel.System.Network.IPv4.TCP.Status.TIME_WAIT = 9 -> Cosmos.Kernel.System.Network.IPv4.TCP.Status
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.AdvanceDataOffset(int offset) -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.AssignData(System.ReadOnlySpan<byte> source, int offset, int count, int length) -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.Data.get -> System.ReadOnlySpan<byte>
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.Detached.get -> bool
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.Detached.set -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.Dispose() -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.LocalEndPoint.get -> Cosmos.Kernel.System.Network.IPv4.EndPoint!
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.ProcessCloseWait(Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket! packet) -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.ProcessClosing(Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket! packet) -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.ProcessEstablished(Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket! packet) -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.ProcessFinWait1(Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket! packet) -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.ProcessFinWait2(Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket! packet) -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.ProcessListen(Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket! packet) -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.ProcessSynReceived(Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket! packet) -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.ProcessSynSent(Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket! packet) -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.RemoteEndPoint.get -> Cosmos.Kernel.System.Network.IPv4.EndPoint!
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.SendEmptyPacket(Cosmos.Kernel.System.Network.IPv4.TCP.Flags flag) -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.Status.get -> Cosmos.Kernel.System.Network.IPv4.TCP.Status
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.Status.set -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.TCB.get -> Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock!
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.WaitLeaveStatus(Cosmos.Kernel.System.Network.IPv4.TCP.Status status, int timeout) -> bool
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.WaitStatus(Cosmos.Kernel.System.Network.IPv4.TCP.Status status) -> bool
+Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.WaitStatus(Cosmos.Kernel.System.Network.IPv4.TCP.Status status, int timeout) -> bool
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPOption
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPOption.Data.get -> byte[]?
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPOption.Data.set -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPOption.Kind.get -> byte
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPOption.Kind.set -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPOption.Length.get -> byte
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPOption.Length.set -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPOption.TCPOption() -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.AckNumber.get -> uint
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.Checksum.get -> ushort
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.DestinationPort.get -> ushort
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.GetFlags() -> string!
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.Options.get -> System.Collections.Generic.List<Cosmos.Kernel.System.Network.IPv4.TCP.TCPOption!>?
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.Options.set -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.SequenceNumber.get -> uint
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.SourcePort.get -> ushort
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.TCPFlags.get -> byte
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.TCPHeaderLength.get -> byte
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.TCPPacket(byte[]! rawData) -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.TCPPacket(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, ushort srcPort, ushort destPort, ulong sequencenumber, ulong acknowledgmentnb, ushort Headerlenght, byte Flags, ushort WSValue, ushort UrgentPointer) -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.TCPPacket(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, ushort srcPort, ushort destPort, ulong sequencenumber, ulong acknowledgmentnb, ushort Headerlenght, byte Flags, ushort WSValue, ushort UrgentPointer, byte[]! data) -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.TCP_DataLength.get -> ushort
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.UrgentPointer.get -> ushort
+Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.WindowSize.get -> ushort
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.IRS.get -> uint
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.IRS.set -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.ISS.get -> uint
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.ISS.set -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.RcvNxt.get -> uint
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.RcvNxt.set -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.RcvUp.get -> uint
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.RcvUp.set -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.RcvWnd.get -> uint
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.RcvWnd.set -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.SndNxt.get -> uint
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.SndNxt.set -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.SndUna.get -> uint
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.SndUna.set -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.SndUp.get -> uint
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.SndUp.set -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.SndWl1.get -> uint
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.SndWl1.set -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.SndWl2.get -> uint
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.SndWl2.set -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.SndWnd.get -> ushort
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.SndWnd.set -> void
+Cosmos.Kernel.System.Network.IPv4.TCP.TransmissionControlBlock.TransmissionControlBlock() -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DHCPClient
+Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DHCPClient.DHCPClient() -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DHCPClient.SendDiscoverPacket() -> int
+Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DHCPClient.SendReleasePacket() -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DHCPOption
+Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DHCPOption.Data.get -> byte[]!
+Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DHCPOption.Data.init -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DHCPOption.DHCPOption() -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DHCPOption.Length.get -> byte
+Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DHCPOption.Type.get -> byte
+Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DHCPOption.Type.init -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DHCPPacket
+Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DHCPPacket.DHCPPacket(byte[]! rawData) -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer.Address.get -> byte[]?
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer.Address.set -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer.CanonicalName.get -> string?
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer.CanonicalName.set -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer.Class.get -> ushort
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer.Class.set -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer.DataLength.get -> ushort
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer.DataLength.set -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer.DNSAnswer() -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer.Name.get -> ushort
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer.Name.set -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer.ResolvedName.get -> string?
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer.ResolvedName.set -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer.TimeToLive.get -> int
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer.TimeToLive.set -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer.Type.get -> ushort
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSAnswer.Type.set -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsClient
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsClient.Connect(Cosmos.Kernel.System.Network.IPv4.Address! address) -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsClient.DnsClient() -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsClient.Receive(int timeout = 5000) -> Cosmos.Kernel.System.Network.IPv4.Address?
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsClient.ReceiveAll(int timeout = 5000) -> System.Collections.Generic.List<Cosmos.Kernel.System.Network.IPv4.Address!>?
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsClient.SendAsk(string! url) -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSPacket
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSPacket.DNSPacket(byte[]! rawData) -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSPacket.DNSPacket(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, ushort urlnb, ushort len) -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSPacket.ParseName(byte[]! rawData, ref int index) -> string!
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSPacketAnswer
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSPacketAnswer.DNSPacketAnswer(byte[]! rawData) -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSPacketAsk
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSPacketAsk.DNSPacketAsk(byte[]! rawData) -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSPacketAsk.DNSPacketAsk(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, string! url) -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSQuery
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSQuery.Class.get -> ushort
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSQuery.Class.set -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSQuery.DNSQuery() -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSQuery.Name.get -> string?
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSQuery.Name.set -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSQuery.Type.get -> ushort
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSQuery.Type.set -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSRecordType
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode.FormatError = 1 -> Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode.NameError = 11 -> Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode.NotSupported = 100 -> Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode.OK = 0 -> Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode.Refused = 101 -> Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode
+Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode.ServerFailure = 10 -> Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode
+Cosmos.Kernel.System.Network.IPv4.UDP.UdpClient
+Cosmos.Kernel.System.Network.IPv4.UDP.UdpClient.Close() -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.UdpClient.Connect(Cosmos.Kernel.System.Network.IPv4.Address! dest, int destPort) -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.UdpClient.Dispose() -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.UdpClient.NonBlockingReceive(ref Cosmos.Kernel.System.Network.IPv4.EndPoint! source) -> byte[]?
+Cosmos.Kernel.System.Network.IPv4.UDP.UdpClient.Receive(ref Cosmos.Kernel.System.Network.IPv4.EndPoint! source) -> byte[]!
+Cosmos.Kernel.System.Network.IPv4.UDP.UdpClient.rxBuffer -> System.Collections.Generic.Queue<Cosmos.Kernel.System.Network.IPv4.UDP.UDPPacket!>!
+Cosmos.Kernel.System.Network.IPv4.UDP.UdpClient.Send(byte[]! data) -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.UdpClient.Send(byte[]! data, Cosmos.Kernel.System.Network.IPv4.Address! dest, int destPort) -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.UdpClient.UdpClient() -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.UdpClient.UdpClient(Cosmos.Kernel.System.Network.IPv4.Address! dest, int destPort) -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.UdpClient.UdpClient(int _localPort) -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.UDPDataReceivedHandler
+Cosmos.Kernel.System.Network.IPv4.UDP.UDPPacket
+Cosmos.Kernel.System.Network.IPv4.UDP.UDPPacket.DestinationPort.get -> ushort
+Cosmos.Kernel.System.Network.IPv4.UDP.UDPPacket.SourcePort.get -> ushort
+Cosmos.Kernel.System.Network.IPv4.UDP.UDPPacket.UDPData.get -> byte[]!
+Cosmos.Kernel.System.Network.IPv4.UDP.UDPPacket.UDPDataLength.get -> ushort
+Cosmos.Kernel.System.Network.IPv4.UDP.UDPPacket.UDPLength.get -> ushort
+Cosmos.Kernel.System.Network.IPv4.UDP.UDPPacket.UDPPacket(byte[]! rawData) -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.UDPPacket.UDPPacket(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, ushort srcPort, ushort destPort, byte[]! data) -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.UDPPacket.UDPPacket(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, ushort srcPort, ushort destPort, byte[]! data, Cosmos.Kernel.HAL.Devices.Network.MACAddress! destmac) -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.UDPPacket.UDPPacket(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, ushort srcport, ushort destport, ushort datalength) -> void
+Cosmos.Kernel.System.Network.IPv4.UDP.UDPPacket.UDPPacket(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, ushort srcport, ushort destport, ushort datalength, Cosmos.Kernel.HAL.Devices.Network.MACAddress! destmac) -> void
+Cosmos.Kernel.System.Network.NetworkManager
+Cosmos.Kernel.System.Network.NetworkStack
+Cosmos.Kernel.System.Power
+Cosmos.Kernel.System.Storage.Ebr
+Cosmos.Kernel.System.Storage.Gpt
+Cosmos.Kernel.System.Storage.Gpt.PartitionEntry
+Cosmos.Kernel.System.Storage.Gpt.PartitionEntry.PartitionEntry(System.Guid partitionType, System.Guid partitionGuid, ulong startSector, ulong sectorCount) -> void
+Cosmos.Kernel.System.Storage.Gpt.PartitionEntry.PartitionGuid.get -> System.Guid
+Cosmos.Kernel.System.Storage.Gpt.PartitionEntry.PartitionType.get -> System.Guid
+Cosmos.Kernel.System.Storage.Gpt.PartitionEntry.SectorCount.get -> ulong
+Cosmos.Kernel.System.Storage.Gpt.PartitionEntry.StartSector.get -> ulong
+Cosmos.Kernel.System.Storage.Mbr
+Cosmos.Kernel.System.Storage.Mbr.PartitionEntry
+Cosmos.Kernel.System.Storage.Mbr.PartitionEntry.PartitionEntry(byte systemId, ulong startSector, ulong sectorCount) -> void
+Cosmos.Kernel.System.Storage.Mbr.PartitionEntry.SectorCount.get -> ulong
+Cosmos.Kernel.System.Storage.Mbr.PartitionEntry.StartSector.get -> ulong
+Cosmos.Kernel.System.Storage.Mbr.PartitionEntry.SystemId.get -> byte
+Cosmos.Kernel.System.Storage.Partition
+Cosmos.Kernel.System.Storage.Partition.Host.get -> Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice!
+Cosmos.Kernel.System.Storage.Partition.Partition(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! host, ulong startSector, ulong sectorCount, string! name) -> void
+Cosmos.Kernel.System.Storage.Partition.Partition(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! host, ulong startSector, ulong sectorCount, uint index) -> void
+Cosmos.Kernel.System.Storage.Partition.StartSector.get -> ulong
+Cosmos.Kernel.System.Storage.PartitionManager
+Cosmos.Kernel.System.Storage.PartitionManager.PartitionLocation
+Cosmos.Kernel.System.Storage.PartitionManager.PartitionLocation.PartitionLocation() -> void
+Cosmos.Kernel.System.Storage.PartitionManager.PartitionLocation.PartitionLocation(ulong startSector, ulong sectorCount) -> void
+Cosmos.Kernel.System.Storage.PartitionManager.PartitionLocation.SectorCount.get -> ulong
+Cosmos.Kernel.System.Storage.PartitionManager.PartitionLocation.StartSector.get -> ulong
+Cosmos.Kernel.System.Storage.StorageManager
+Cosmos.Kernel.System.Timer.TimerManager
+Cosmos.Kernel.System.Vfs.IVfsDirectoryHandle
+Cosmos.Kernel.System.Vfs.IVfsDirectoryHandle.TryCreateDirectory(System.ReadOnlySpan<char> name, Cosmos.Kernel.HAL.Vfs.ModeEnum mode, out Cosmos.Kernel.System.Vfs.IVfsDirectoryHandle? child) -> bool
+Cosmos.Kernel.System.Vfs.IVfsDirectoryHandle.TryCreateFile(System.ReadOnlySpan<char> name, Cosmos.Kernel.HAL.Vfs.ModeEnum mode, out Cosmos.Kernel.System.Vfs.IVfsNodeHandle? child) -> bool
+Cosmos.Kernel.System.Vfs.IVfsDirectoryHandle.TryLookup(System.ReadOnlySpan<char> name, out Cosmos.Kernel.System.Vfs.IVfsNodeHandle? child) -> bool
+Cosmos.Kernel.System.Vfs.IVfsDirectoryHandle.TryReadDir(out System.Collections.Generic.IReadOnlyList<Cosmos.Kernel.HAL.Vfs.IVfsInode!>! entries) -> bool
+Cosmos.Kernel.System.Vfs.IVfsDirectoryHandle.TryRemoveDirectory(System.ReadOnlySpan<char> name) -> bool
+Cosmos.Kernel.System.Vfs.IVfsDirectoryHandle.TryRename(System.ReadOnlySpan<char> oldName, Cosmos.Kernel.System.Vfs.IVfsDirectoryHandle! newParent, System.ReadOnlySpan<char> newName) -> bool
+Cosmos.Kernel.System.Vfs.IVfsDirectoryHandle.TrySetAttr(Cosmos.Kernel.HAL.Vfs.SetAttrFlags flags, in Cosmos.Kernel.HAL.Vfs.VfsStat attributes) -> bool
+Cosmos.Kernel.System.Vfs.IVfsDirectoryHandle.TrySymlink(System.ReadOnlySpan<char> name, System.ReadOnlySpan<char> target, out Cosmos.Kernel.System.Vfs.IVfsNodeHandle? child) -> bool
+Cosmos.Kernel.System.Vfs.IVfsDirectoryHandle.TryUnlink(System.ReadOnlySpan<char> name) -> bool
+Cosmos.Kernel.System.Vfs.IVfsFileHandle
+Cosmos.Kernel.System.Vfs.IVfsFileHandle.Flush() -> bool
+Cosmos.Kernel.System.Vfs.IVfsFileHandle.Position.get -> long
+Cosmos.Kernel.System.Vfs.IVfsFileHandle.Read(System.Span<byte> buffer) -> long
+Cosmos.Kernel.System.Vfs.IVfsFileHandle.TrySeek(long offset, Cosmos.Kernel.HAL.Vfs.SeekWhence whence) -> bool
+Cosmos.Kernel.System.Vfs.IVfsFileHandle.Write(System.ReadOnlySpan<byte> buffer) -> long
+Cosmos.Kernel.System.Vfs.IVfsNodeHandle
+Cosmos.Kernel.System.Vfs.IVfsNodeHandle.Inode.get -> Cosmos.Kernel.HAL.Vfs.IVfsInode!
+Cosmos.Kernel.System.Vfs.IVfsNodeHandle.Name.get -> string!
+Cosmos.Kernel.System.Vfs.IVfsNodeHandle.TryStat(out Cosmos.Kernel.HAL.Vfs.VfsStat stat) -> bool
+Cosmos.Kernel.System.Vfs.VfsManager
+Cosmos.Kernel.System.Vfs.VfsManager.VfsMount
+Cosmos.Kernel.System.Vfs.VfsManager.VfsMount.FilesystemType.get -> Cosmos.Kernel.HAL.Vfs.IVfsFilesystemType!
+Cosmos.Kernel.System.Vfs.VfsManager.VfsMount.MountPoint.get -> string!
+Cosmos.Kernel.System.Vfs.VfsManager.VfsMount.Name.get -> string!
+Cosmos.Kernel.System.Vfs.VfsManager.VfsMount.Source.get -> string!
+Cosmos.Kernel.System.Vfs.VfsManager.VfsMount.Superblock.get -> Cosmos.Kernel.HAL.Vfs.IVfsSuperblock!
+Cosmos.Kernel.System.Vfs.VfsManager.VfsMount.VfsMount(string! name, string! source, string! mountPoint, Cosmos.Kernel.HAL.Vfs.IVfsFilesystemType! filesystemType, Cosmos.Kernel.HAL.Vfs.IVfsSuperblock! superblock) -> void
+Internal.Runtime.CompilerHelpers.LibraryInitializer
+Internal.Runtime.CompilerHelpers.LibraryInitializer.LibraryInitializer() -> void
+override Cosmos.Kernel.System.Graphics.Mode.Equals(object? obj) -> bool
+override Cosmos.Kernel.System.Graphics.Mode.GetHashCode() -> int
+override Cosmos.Kernel.System.Graphics.Mode.ToString() -> string!
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.AvailableModes.get -> System.Collections.Generic.List<Cosmos.Kernel.System.Graphics.Mode>!
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.Clear(int color) -> void
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.Clear(System.Drawing.Color color) -> void
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.CroppedDrawImage(Cosmos.Kernel.System.Graphics.Image! image, int x, int y, int width, int height, bool preventOffBoundPixels = true) -> void
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.DefaultGraphicsMode.get -> Cosmos.Kernel.System.Graphics.Mode
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.Disable() -> void
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.Display() -> void
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.DrawArray(int[]! colors, int x, int y, int width, int height) -> void
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.DrawArray(int[]! colors, int x, int y, int width, int height, int startIndex) -> void
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.DrawArray(System.Drawing.Color[]! colors, int x, int y, int width, int height) -> void
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.DrawFilledRectangle(System.Drawing.Color color, int xStart, int yStart, int width, int height, bool preventOffBoundPixels = true) -> void
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.DrawImage(Cosmos.Kernel.System.Graphics.Image! image, int x, int y, bool preventOffBoundPixels = true) -> void
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.DrawPoint(int color, int x, int y) -> void
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.DrawPoint(System.Drawing.Color color, int x, int y) -> void
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.DrawPoint(uint color, int x, int y) -> void
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.DrawRectangle(System.Drawing.Color color, int x, int y, int width, int height) -> void
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.GetImage(int x, int y, int width, int height) -> Cosmos.Kernel.System.Graphics.Bitmap!
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.GetPointColor(int x, int y) -> System.Drawing.Color
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.GetRawPointColor(int x, int y) -> int
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.Mode.get -> Cosmos.Kernel.System.Graphics.Mode
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.Mode.set -> void
+override Cosmos.Kernel.System.Graphics.SVGAII3DCanvas.Name() -> string!
+override Cosmos.Kernel.System.IO.ConsoleStream.Flush() -> void
+override Cosmos.Kernel.System.IO.ConsoleStream.Read(byte[]! buffer, int offset, int count) -> int
+override Cosmos.Kernel.System.IO.ConsoleStream.Read(System.Span<byte> buffer) -> int
+override Cosmos.Kernel.System.IO.ConsoleStream.ReadByte() -> int
+override Cosmos.Kernel.System.IO.ConsoleStream.Write(byte[]! buffer, int offset, int count) -> void
+override Cosmos.Kernel.System.IO.ConsoleStream.Write(System.ReadOnlySpan<byte> buffer) -> void
+override Cosmos.Kernel.System.IO.ConsoleStream.WriteByte(byte value) -> void
+override Cosmos.Kernel.System.IO.ConsoleTextWriter.Encoding.get -> System.Text.Encoding!
+override Cosmos.Kernel.System.IO.ConsoleTextWriter.Write(char value) -> void
+override Cosmos.Kernel.System.IO.ConsoleTextWriter.Write(string? value) -> void
+override Cosmos.Kernel.System.IO.ConsoleTextWriter.Write(System.ReadOnlySpan<char> buffer) -> void
+override Cosmos.Kernel.System.IO.KeyboardTextReader.Peek() -> int
+override Cosmos.Kernel.System.IO.KeyboardTextReader.Read() -> int
+override Cosmos.Kernel.System.IO.KeyboardTextReader.ReadLine() -> string?
+override Cosmos.Kernel.System.Keyboard.ScanMaps.DEStandardLayout.InitKeys() -> void
+override Cosmos.Kernel.System.Keyboard.ScanMaps.ESStandardLayout.InitKeys() -> void
+override Cosmos.Kernel.System.Keyboard.ScanMaps.FRStandardLayout.InitKeys() -> void
+override Cosmos.Kernel.System.Keyboard.ScanMaps.GBStandardLayout.InitKeys() -> void
+override Cosmos.Kernel.System.Keyboard.ScanMaps.TRStandardLayout.InitKeys() -> void
+override Cosmos.Kernel.System.Keyboard.ScanMaps.USDvorakLayout.InitKeys() -> void
+override Cosmos.Kernel.System.Keyboard.ScanMaps.USStandardLayout.InitKeys() -> void
+override Cosmos.Kernel.System.Network.ARP.ARPPacket.InitializeFields() -> void
+override Cosmos.Kernel.System.Network.ARP.ARPPacket.ToString() -> string!
+override Cosmos.Kernel.System.Network.EthernetPacket.ToString() -> string!
+override Cosmos.Kernel.System.Network.IPv4.Address.Equals(object? obj) -> bool
+override Cosmos.Kernel.System.Network.IPv4.Address.GetHashCode() -> int
+override Cosmos.Kernel.System.Network.IPv4.Address.ToString() -> string!
+override Cosmos.Kernel.System.Network.IPv4.EndPoint.ToString() -> string!
+override Cosmos.Kernel.System.Network.IPv4.ICMPPacket.ToString() -> string!
+override Cosmos.Kernel.System.Network.IPv4.IPPacket.InitializeFields() -> void
+override Cosmos.Kernel.System.Network.IPv4.IPPacket.ToString() -> string!
+override Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.InitializeFields() -> void
+override Cosmos.Kernel.System.Network.IPv4.TCP.TCPPacket.ToString() -> string!
+override Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DHCPPacket.InitializeFields() -> void
+override Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSPacket.InitializeFields() -> void
+override Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSPacket.ToString() -> string!
+override Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSPacketAnswer.InitializeFields() -> void
+override Cosmos.Kernel.System.Network.IPv4.UDP.UDPPacket.InitializeFields() -> void
+override Cosmos.Kernel.System.Network.IPv4.UDP.UDPPacket.ToString() -> string!
+override Cosmos.Kernel.System.Storage.Partition.Flush() -> void
+override Cosmos.Kernel.System.Storage.Partition.Name.get -> string!
+override Cosmos.Kernel.System.Storage.Partition.ReadBlock(ulong blockNo, ulong blockCount, System.Span<byte> data) -> void
+override Cosmos.Kernel.System.Storage.Partition.WriteBlock(ulong blockNo, ulong blockCount, System.ReadOnlySpan<byte> data) -> void
+override sealed Cosmos.Kernel.System.IO.ConsoleStream.CanRead.get -> bool
+override sealed Cosmos.Kernel.System.IO.ConsoleStream.CanSeek.get -> bool
+override sealed Cosmos.Kernel.System.IO.ConsoleStream.CanWrite.get -> bool
+override sealed Cosmos.Kernel.System.IO.ConsoleStream.Length.get -> long
+override sealed Cosmos.Kernel.System.IO.ConsoleStream.Position.get -> long
+override sealed Cosmos.Kernel.System.IO.ConsoleStream.Position.set -> void
+override sealed Cosmos.Kernel.System.IO.ConsoleStream.Seek(long offset, System.IO.SeekOrigin origin) -> long
+override sealed Cosmos.Kernel.System.IO.ConsoleStream.SetLength(long value) -> void
+static Cosmos.Kernel.System.Conversion.Base64.Decode(char* Encoded, uint Length) -> byte*
+static Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.TryParse(System.ReadOnlySpan<byte> bpb, out Cosmos.Kernel.System.Filesystems.Fat.FatBootSector? bootSector) -> bool
+static Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.BuildShortName(string! longName, System.Span<char> dest11, System.ReadOnlySpan<byte> directoryData) -> void
+static Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.ComputeShortChecksum(System.ReadOnlySpan<byte> raw11) -> byte
+static Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.ComputeShortChecksum(System.ReadOnlySpan<char> shortName11) -> byte
+static Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.FindFreeRun(System.ReadOnlySpan<byte> buffer, int entriesNeeded, out bool consumedTerminator) -> int
+static Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.FitsInShortName(System.ReadOnlySpan<char> name) -> bool
+static Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.LfnEntryCountFor(System.ReadOnlySpan<char> name) -> int
+static Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.MarkDeleted(System.Span<byte> dest, int offset, int entryCount) -> void
+static Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.NameEqualsIgnoreCase(string! a, string! b) -> bool
+static Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.Parse(System.ReadOnlySpan<byte> buffer, bool fat32) -> System.Collections.Generic.List<Cosmos.Kernel.System.Filesystems.Fat.FatDirEntry!>!
+static Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.WriteLfnEntries(System.Span<byte> dest, int offset, System.ReadOnlySpan<char> longName, System.ReadOnlySpan<char> shortName11) -> void
+static Cosmos.Kernel.System.Filesystems.Fat.FatDirectory.WriteShortEntry(System.Span<byte> dest, int offset, System.ReadOnlySpan<char> shortName11, Cosmos.Kernel.System.Filesystems.Fat.FatAttr attributes, uint firstCluster, uint size) -> void
+static Cosmos.Kernel.System.Global.CurrentKernel.get -> Cosmos.Kernel.System.Kernel?
+static Cosmos.Kernel.System.Global.CurrentKernel.set -> void
+static Cosmos.Kernel.System.Global.Init() -> void
+static Cosmos.Kernel.System.Global.RegisterKernel(Cosmos.Kernel.System.Kernel! kernel) -> void
+static Cosmos.Kernel.System.Global.StartKernel() -> void
+static Cosmos.Kernel.System.Graphics.Canvas.AlphaBlend(System.Drawing.Color to, System.Drawing.Color from, byte alpha) -> System.Drawing.Color
+static Cosmos.Kernel.System.Graphics.Canvas.GetFullScreen() -> Cosmos.Kernel.System.Graphics.Canvas!
+static Cosmos.Kernel.System.Graphics.Canvas.GetFullScreen(Cosmos.Kernel.System.Graphics.Mode mode) -> Cosmos.Kernel.System.Graphics.Canvas!
+static Cosmos.Kernel.System.Graphics.Cell.Empty(uint foreground, uint background) -> Cosmos.Kernel.System.Graphics.Cell
+static Cosmos.Kernel.System.Graphics.Fonts.PCScreenFont.DefaultFont.get -> Cosmos.Kernel.System.Graphics.Fonts.PCScreenFont!
+static Cosmos.Kernel.System.Graphics.Fonts.PCScreenFont.LoadFont(byte[]! fontData) -> Cosmos.Kernel.System.Graphics.Fonts.PCScreenFont!
+static Cosmos.Kernel.System.Graphics.FullScreenCanvas.Disable() -> void
+static Cosmos.Kernel.System.Graphics.FullScreenCanvas.GetCurrentFullScreenCanvas() -> Cosmos.Kernel.System.Graphics.Canvas?
+static Cosmos.Kernel.System.Graphics.FullScreenCanvas.GetFullScreenCanvas() -> Cosmos.Kernel.System.Graphics.Canvas!
+static Cosmos.Kernel.System.Graphics.FullScreenCanvas.GetFullScreenCanvas(Cosmos.Kernel.System.Graphics.Mode mode) -> Cosmos.Kernel.System.Graphics.Canvas!
+static Cosmos.Kernel.System.Graphics.FullScreenCanvas.IsInUse.get -> bool
+static Cosmos.Kernel.System.Graphics.FullScreenCanvas.TryGetFullScreenCanvas(Cosmos.Kernel.System.Graphics.Mode mode, out Cosmos.Kernel.System.Graphics.Canvas? canvas) -> bool
+static Cosmos.Kernel.System.Graphics.KernelConsole.ConsoleColorToUint(System.ConsoleColor color) -> uint
+static Cosmos.Kernel.System.Graphics.KernelConsole.Default.get -> Cosmos.Kernel.System.Graphics.KernelConsole?
+static Cosmos.Kernel.System.Graphics.KernelConsole.Initialize() -> bool
+static Cosmos.Kernel.System.Graphics.KernelConsole.IsInitialized.get -> bool
+static Cosmos.Kernel.System.Graphics.KernelConsole.ThrowIfKernelConsoleNotInitialized() -> void
+static Cosmos.Kernel.System.Graphics.Mode.operator !=(Cosmos.Kernel.System.Graphics.Mode a, Cosmos.Kernel.System.Graphics.Mode b) -> bool
+static Cosmos.Kernel.System.Graphics.Mode.operator <(Cosmos.Kernel.System.Graphics.Mode a, Cosmos.Kernel.System.Graphics.Mode b) -> bool
+static Cosmos.Kernel.System.Graphics.Mode.operator <=(Cosmos.Kernel.System.Graphics.Mode a, Cosmos.Kernel.System.Graphics.Mode b) -> bool
+static Cosmos.Kernel.System.Graphics.Mode.operator ==(Cosmos.Kernel.System.Graphics.Mode a, Cosmos.Kernel.System.Graphics.Mode b) -> bool
+static Cosmos.Kernel.System.Graphics.Mode.operator >(Cosmos.Kernel.System.Graphics.Mode a, Cosmos.Kernel.System.Graphics.Mode b) -> bool
+static Cosmos.Kernel.System.Graphics.Mode.operator >=(Cosmos.Kernel.System.Graphics.Mode a, Cosmos.Kernel.System.Graphics.Mode b) -> bool
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.AltPressed.get -> bool
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.AltPressed.set -> void
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.CapsLock.get -> bool
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.CapsLock.set -> void
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.ControlPressed.get -> bool
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.ControlPressed.set -> void
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.GetKey(byte scanCode, out Cosmos.Kernel.System.Keyboard.KeyEvent? keyInfo) -> bool
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.GetKeyLayout() -> Cosmos.Kernel.System.Keyboard.ScanMapBase?
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.HandleScanCode(byte scanCode, bool released) -> void
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.Initialize() -> void
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.IsEnabled.get -> bool
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.KeyAvailable.get -> bool
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.NumLock.get -> bool
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.NumLock.set -> void
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.Peek() -> Cosmos.Kernel.System.Keyboard.KeyEvent!
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.ReadKey() -> Cosmos.Kernel.System.Keyboard.KeyEvent!
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.RegisterKeyboard(Cosmos.Kernel.HAL.Interfaces.Devices.IKeyboardDevice! keyboard) -> void
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.ScrollLock.get -> bool
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.ScrollLock.set -> void
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.SetKeyLayout(Cosmos.Kernel.System.Keyboard.ScanMapBase! scanMap) -> void
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.ShiftPressed.get -> bool
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.ShiftPressed.set -> void
+static Cosmos.Kernel.System.Keyboard.KeyboardManager.TryReadKey(out Cosmos.Kernel.System.Keyboard.KeyEvent? key) -> bool
+static Cosmos.Kernel.System.Mouse.MouseManager.Initialize() -> void
+static Cosmos.Kernel.System.Mouse.MouseManager.IsEnabled.get -> bool
+static Cosmos.Kernel.System.Mouse.MouseManager.LeftButton.get -> bool
+static Cosmos.Kernel.System.Mouse.MouseManager.MiddleButton.get -> bool
+static Cosmos.Kernel.System.Mouse.MouseManager.Poll() -> void
+static Cosmos.Kernel.System.Mouse.MouseManager.RegisterMouse(Cosmos.Kernel.HAL.Interfaces.Devices.IMouseDevice! mouse) -> void
+static Cosmos.Kernel.System.Mouse.MouseManager.ResetScrollDelta() -> void
+static Cosmos.Kernel.System.Mouse.MouseManager.RightButton.get -> bool
+static Cosmos.Kernel.System.Mouse.MouseManager.ScreenHeight.get -> int
+static Cosmos.Kernel.System.Mouse.MouseManager.ScreenHeight.set -> void
+static Cosmos.Kernel.System.Mouse.MouseManager.ScreenWidth.get -> int
+static Cosmos.Kernel.System.Mouse.MouseManager.ScreenWidth.set -> void
+static Cosmos.Kernel.System.Mouse.MouseManager.ScrollDelta.get -> int
+static Cosmos.Kernel.System.Mouse.MouseManager.Sensitivity.get -> float
+static Cosmos.Kernel.System.Mouse.MouseManager.Sensitivity.set -> void
+static Cosmos.Kernel.System.Mouse.MouseManager.SetPosition(int x, int y) -> void
+static Cosmos.Kernel.System.Mouse.MouseManager.SetScreenSize(int width, int height) -> void
+static Cosmos.Kernel.System.Mouse.MouseManager.X.get -> int
+static Cosmos.Kernel.System.Mouse.MouseManager.Y.get -> int
+static Cosmos.Kernel.System.Network.Config.DNSConfig.Add(Cosmos.Kernel.System.Network.IPv4.Address! nameserver) -> void
+static Cosmos.Kernel.System.Network.Config.DNSConfig.Remove(Cosmos.Kernel.System.Network.IPv4.Address! nameserver) -> void
+static Cosmos.Kernel.System.Network.Config.IPConfig.Enable(Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice! device, Cosmos.Kernel.System.Network.IPv4.Address! ip, Cosmos.Kernel.System.Network.IPv4.Address! subnet, Cosmos.Kernel.System.Network.IPv4.Address! gw) -> bool
+static Cosmos.Kernel.System.Network.Config.IPConfig.FindNetwork(Cosmos.Kernel.System.Network.IPv4.Address! destIP) -> Cosmos.Kernel.System.Network.IPv4.Address?
+static Cosmos.Kernel.System.Network.Config.NetworkConfigManager.AddConfig(Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice! device, Cosmos.Kernel.System.Network.Config.IPConfig! config) -> void
+static Cosmos.Kernel.System.Network.Config.NetworkConfigManager.ClearConfigs() -> void
+static Cosmos.Kernel.System.Network.Config.NetworkConfigManager.ConfigsContainsDevice(Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice! targetDevice) -> bool
+static Cosmos.Kernel.System.Network.Config.NetworkConfigManager.Count.get -> int
+static Cosmos.Kernel.System.Network.Config.NetworkConfigManager.CurrentAddress.get -> Cosmos.Kernel.System.Network.IPv4.Address?
+static Cosmos.Kernel.System.Network.Config.NetworkConfigManager.CurrentNetworkConfig.get -> Cosmos.Kernel.System.Network.Config.NetworkConfigEntry?
+static Cosmos.Kernel.System.Network.Config.NetworkConfigManager.CurrentNetworkConfig.set -> void
+static Cosmos.Kernel.System.Network.Config.NetworkConfigManager.Get(Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice! device) -> Cosmos.Kernel.System.Network.Config.IPConfig?
+static Cosmos.Kernel.System.Network.Config.NetworkConfigManager.Remove(Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice! key) -> void
+static Cosmos.Kernel.System.Network.Config.NetworkConfigManager.SetCurrentConfig(Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice! device, Cosmos.Kernel.System.Network.Config.IPConfig! config) -> void
+static Cosmos.Kernel.System.Network.IPv4.Address.CIDRToAddress(int cidr) -> Cosmos.Kernel.System.Network.IPv4.Address?
+static Cosmos.Kernel.System.Network.IPv4.Address.Parse(System.ReadOnlySpan<char> addr) -> Cosmos.Kernel.System.Network.IPv4.Address?
+static Cosmos.Kernel.System.Network.IPv4.ICMPPacket.EchoRequestsReplied.get -> int
+static Cosmos.Kernel.System.Network.IPv4.ICMPPacket.LastEchoRequestData.get -> byte[]?
+static Cosmos.Kernel.System.Network.IPv4.IPPacket.CalcOcCRC(byte[]! buffer, ushort offset, int length) -> ushort
+static Cosmos.Kernel.System.Network.IPv4.IPPacket.NextIPFragmentID.get -> ushort
+static Cosmos.Kernel.System.Network.IPv4.IPPacket.SumShortValues(byte[]! buffer, int offset, int length) -> ushort
+static Cosmos.Kernel.System.Network.IPv4.OutgoingBuffer.AddPacket(Cosmos.Kernel.System.Network.IPv4.IPPacket! packet) -> void
+static Cosmos.Kernel.System.Network.IPv4.OutgoingBuffer.AddPacket(Cosmos.Kernel.System.Network.IPv4.IPPacket! packet, Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice! device) -> void
+static Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.CreateConnection(ushort localPort, ushort remotePort, Cosmos.Kernel.System.Network.IPv4.Address! localIp, Cosmos.Kernel.System.Network.IPv4.Address! remoteIp) -> Cosmos.Kernel.System.Network.IPv4.TCP.Tcp!
+static Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.GetDynamicPort(int tries = 10) -> ushort
+static Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.RemoveConnection(Cosmos.Kernel.System.Network.IPv4.TCP.Tcp! connection) -> bool
+static Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.RemoveConnection(ushort localPort, ushort remotePort, Cosmos.Kernel.System.Network.IPv4.Address! localIp, Cosmos.Kernel.System.Network.IPv4.Address! remoteIp) -> bool
+static Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DHCPClient.DHCPServerAddress(Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice! networkDevice) -> Cosmos.Kernel.System.Network.IPv4.Address?
+static Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DHCPPacket.DHCPHandler(byte[]! packetData) -> void
+static Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSPacket.ParseNameAt(byte[]! rawData, int startIndex, int messageBase) -> string!
+static Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DNSPacket.ResolveRRName(ushort nameField, byte[]! rawData, int messageBase) -> string?
+static Cosmos.Kernel.System.Network.IPv4.UDP.UdpClient.DynamicPortStart -> ushort
+static Cosmos.Kernel.System.Network.IPv4.UDP.UdpClient.GetDynamicPort(int tries = 10) -> ushort
+static Cosmos.Kernel.System.Network.IPv4.UDP.UDPPacket.OnUDPDataReceived.get -> Cosmos.Kernel.System.Network.IPv4.UDP.UDPDataReceivedHandler?
+static Cosmos.Kernel.System.Network.IPv4.UDP.UDPPacket.OnUDPDataReceived.set -> void
+static Cosmos.Kernel.System.Network.NetworkManager.DeviceCount.get -> int
+static Cosmos.Kernel.System.Network.NetworkManager.GetDevice(int index) -> Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice?
+static Cosmos.Kernel.System.Network.NetworkManager.Initialize() -> void
+static Cosmos.Kernel.System.Network.NetworkManager.IsEnabled.get -> bool
+static Cosmos.Kernel.System.Network.NetworkManager.IsInitialized.get -> bool
+static Cosmos.Kernel.System.Network.NetworkManager.LinkUp.get -> bool
+static Cosmos.Kernel.System.Network.NetworkManager.PrimaryDevice.get -> Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice?
+static Cosmos.Kernel.System.Network.NetworkManager.RegisterDevice(Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice! device) -> void
+static Cosmos.Kernel.System.Network.NetworkManager.Send(byte[]! data, int length) -> bool
+static Cosmos.Kernel.System.Network.NetworkStack.ConfigIP(Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice! device, Cosmos.Kernel.System.Network.Config.IPConfig! config) -> void
+static Cosmos.Kernel.System.Network.NetworkStack.ConfigIP(Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice! device, Cosmos.Kernel.System.Network.IPv4.Address! ipAddress) -> void
+static Cosmos.Kernel.System.Network.NetworkStack.HandlePacket(byte[]! packetData, int length) -> void
+static Cosmos.Kernel.System.Network.NetworkStack.Initialize() -> void
+static Cosmos.Kernel.System.Network.NetworkStack.RemoveAllConfigIP() -> void
+static Cosmos.Kernel.System.Network.NetworkStack.Update() -> void
+static Cosmos.Kernel.System.Power.Halt() -> void
+static Cosmos.Kernel.System.Power.Reboot() -> void
+static Cosmos.Kernel.System.Power.Shutdown() -> void
+static Cosmos.Kernel.System.Storage.Ebr.AddLogical(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, ulong extendedStartLba, ulong extendedSectorCount, byte systemId, ulong sectorCount) -> ulong
+static Cosmos.Kernel.System.Storage.Ebr.MoveLogical(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, ulong extendedStartLba, int logicalIndex, ulong newAbsoluteStart) -> bool
+static Cosmos.Kernel.System.Storage.Ebr.Parse(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, ulong extendedStartLba) -> System.Collections.Generic.List<Cosmos.Kernel.System.Storage.Mbr.PartitionEntry!>!
+static Cosmos.Kernel.System.Storage.Ebr.RemoveLogical(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, ulong extendedStartLba, int logicalIndex) -> bool
+static Cosmos.Kernel.System.Storage.Ebr.ResizeLogical(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, ulong extendedStartLba, int logicalIndex, ulong newSectorCount) -> bool
+static Cosmos.Kernel.System.Storage.Gpt.AddPartition(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, ulong startSector, ulong sectorCount, System.Guid partitionType) -> bool
+static Cosmos.Kernel.System.Storage.Gpt.Create(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device) -> void
+static Cosmos.Kernel.System.Storage.Gpt.IsGpt(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device) -> bool
+static Cosmos.Kernel.System.Storage.Gpt.MovePartition(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, int partitionIndex, ulong newStartSector) -> bool
+static Cosmos.Kernel.System.Storage.Gpt.Parse(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device) -> System.Collections.Generic.List<Cosmos.Kernel.System.Storage.Gpt.PartitionEntry!>!
+static Cosmos.Kernel.System.Storage.Gpt.RemovePartition(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, int partitionIndex) -> bool
+static Cosmos.Kernel.System.Storage.Gpt.ResizePartition(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, int partitionIndex, ulong newSectorCount) -> bool
+static Cosmos.Kernel.System.Storage.Mbr.Create(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device) -> void
+static Cosmos.Kernel.System.Storage.Mbr.DeletePartition(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, int index) -> void
+static Cosmos.Kernel.System.Storage.Mbr.IsMbr(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device) -> bool
+static Cosmos.Kernel.System.Storage.Mbr.MovePartition(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, int index, uint newStartSector) -> void
+static Cosmos.Kernel.System.Storage.Mbr.Parse(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device) -> System.Collections.Generic.List<Cosmos.Kernel.System.Storage.Mbr.PartitionEntry!>!
+static Cosmos.Kernel.System.Storage.Mbr.ResizePartition(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, int index, uint newSectorCount) -> void
+static Cosmos.Kernel.System.Storage.Mbr.TryGetExtendedPartition(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, out ulong startSector) -> bool
+static Cosmos.Kernel.System.Storage.Mbr.TryGetExtendedPartition(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, out ulong startSector, out ulong sectorCount) -> bool
+static Cosmos.Kernel.System.Storage.Mbr.WritePartition(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, int index, byte systemId, uint startSector, uint sectorCount) -> void
+static Cosmos.Kernel.System.Storage.PartitionManager.Create(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, ulong startSector, ulong sectorCount, byte mbrSystemId, System.Guid gptType) -> bool
+static Cosmos.Kernel.System.Storage.PartitionManager.CreateLogical(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, byte systemId, ulong sectorCount) -> ulong
+static Cosmos.Kernel.System.Storage.PartitionManager.Delete(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, Cosmos.Kernel.System.Storage.PartitionManager.PartitionLocation location) -> bool
+static Cosmos.Kernel.System.Storage.PartitionManager.MoveWithData(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, Cosmos.Kernel.System.Storage.PartitionManager.PartitionLocation location, ulong newStartSector) -> bool
+static Cosmos.Kernel.System.Storage.PartitionManager.Resize(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device, Cosmos.Kernel.System.Storage.PartitionManager.PartitionLocation location, ulong newSectorCount) -> bool
+static Cosmos.Kernel.System.Storage.StorageManager.DeviceCount.get -> int
+static Cosmos.Kernel.System.Storage.StorageManager.GetDevice(int index) -> Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice?
+static Cosmos.Kernel.System.Storage.StorageManager.Initialize() -> void
+static Cosmos.Kernel.System.Storage.StorageManager.IsEnabled.get -> bool
+static Cosmos.Kernel.System.Storage.StorageManager.IsInitialized.get -> bool
+static Cosmos.Kernel.System.Storage.StorageManager.Partitions.get -> System.Collections.Generic.IReadOnlyList<Cosmos.Kernel.System.Storage.Partition!>!
+static Cosmos.Kernel.System.Storage.StorageManager.PrimaryDevice.get -> Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice?
+static Cosmos.Kernel.System.Storage.StorageManager.RegisterDevice(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device) -> void
+static Cosmos.Kernel.System.Storage.StorageManager.RegisterHalDevices() -> void
+static Cosmos.Kernel.System.Storage.StorageManager.RescanPartitions(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! device) -> void
+static Cosmos.Kernel.System.Timer.TimerManager.Cancel(Cosmos.Kernel.HAL.Interfaces.Devices.SoftwareTimer? timer) -> void
+static Cosmos.Kernel.System.Timer.TimerManager.Frequency.get -> uint
+static Cosmos.Kernel.System.Timer.TimerManager.Initialize() -> void
+static Cosmos.Kernel.System.Timer.TimerManager.IsInitialized.get -> bool
+static Cosmos.Kernel.System.Timer.TimerManager.RegisterTimer(Cosmos.Kernel.HAL.Interfaces.Devices.ITimerDevice! timer) -> void
+static Cosmos.Kernel.System.Timer.TimerManager.Schedule(System.Action! callback, uint delayMs) -> Cosmos.Kernel.HAL.Interfaces.Devices.SoftwareTimer?
+static Cosmos.Kernel.System.Timer.TimerManager.ScheduleRecurring(System.Action! callback, uint periodMs) -> Cosmos.Kernel.HAL.Interfaces.Devices.SoftwareTimer?
+static Cosmos.Kernel.System.Timer.TimerManager.SetFrequency(uint frequency) -> void
+static Cosmos.Kernel.System.Timer.TimerManager.Timer.get -> Cosmos.Kernel.HAL.Interfaces.Devices.ITimerDevice?
+static Cosmos.Kernel.System.Timer.TimerManager.Wait(uint ms) -> void
+static Cosmos.Kernel.System.Vfs.VfsManager.CurrentDirectory.get -> string!
+static Cosmos.Kernel.System.Vfs.VfsManager.GetVirtualRootEntries() -> string![]!
+static Cosmos.Kernel.System.Vfs.VfsManager.IsMountPoint(string! fullPath) -> bool
+static Cosmos.Kernel.System.Vfs.VfsManager.MakeAbsolute(string? path) -> string?
+static Cosmos.Kernel.System.Vfs.VfsManager.MountCovers(string! mountPoint, string! path) -> bool
+static Cosmos.Kernel.System.Vfs.VfsManager.Mounts.get -> System.Collections.Generic.IReadOnlyList<Cosmos.Kernel.System.Vfs.VfsManager.VfsMount!>!
+static Cosmos.Kernel.System.Vfs.VfsManager.RegisterFilesystem(string! name, Cosmos.Kernel.HAL.Vfs.IVfsFilesystemType! filesystemType) -> bool
+static Cosmos.Kernel.System.Vfs.VfsManager.SplitParentLeaf(string! fullPath, out string! parentPath, out string! leaf) -> void
+static Cosmos.Kernel.System.Vfs.VfsManager.TryCreateDirectory(string! fullPath, Cosmos.Kernel.HAL.Vfs.ModeEnum permissions) -> bool
+static Cosmos.Kernel.System.Vfs.VfsManager.TryCreateFile(string! fullPath, Cosmos.Kernel.HAL.Vfs.ModeEnum permissions) -> bool
+static Cosmos.Kernel.System.Vfs.VfsManager.TryDestroy(string! name, System.ReadOnlySpan<char> source) -> bool
+static Cosmos.Kernel.System.Vfs.VfsManager.TryFormat(string! name, System.ReadOnlySpan<char> source, Cosmos.Kernel.HAL.Vfs.IVfsFormatOptions? options) -> bool
+static Cosmos.Kernel.System.Vfs.VfsManager.TryGetMount(string! mountPoint, out Cosmos.Kernel.System.Vfs.VfsManager.VfsMount? mount) -> bool
+static Cosmos.Kernel.System.Vfs.VfsManager.TryMount(string! name, System.ReadOnlySpan<char> source, Cosmos.Kernel.HAL.Vfs.MountFlags flags, string! mountPoint, out Cosmos.Kernel.System.Vfs.VfsManager.VfsMount? mount) -> bool
+static Cosmos.Kernel.System.Vfs.VfsManager.TryOpenDirectory(string! path, out Cosmos.Kernel.System.Vfs.IVfsDirectoryHandle? directory) -> bool
+static Cosmos.Kernel.System.Vfs.VfsManager.TryOpenFile(string! path, out Cosmos.Kernel.System.Vfs.IVfsFileHandle? file) -> bool
+static Cosmos.Kernel.System.Vfs.VfsManager.TryRemoveDirectory(string! fullPath) -> bool
+static Cosmos.Kernel.System.Vfs.VfsManager.TryRename(string! oldFullPath, string! newFullPath) -> bool
+static Cosmos.Kernel.System.Vfs.VfsManager.TrySetCurrentDirectory(string! path) -> bool
+static Cosmos.Kernel.System.Vfs.VfsManager.TryStat(string! fullPath, out Cosmos.Kernel.HAL.Vfs.VfsStat stat) -> bool
+static Cosmos.Kernel.System.Vfs.VfsManager.TryUnlink(string! fullPath) -> bool
+static Cosmos.Kernel.System.Vfs.VfsManager.TryUnmount(string! mountPoint) -> bool
+static Internal.Runtime.CompilerHelpers.LibraryInitializer.InitializeLibrary() -> void
+static readonly Cosmos.Kernel.System.Network.Config.DNSConfig.DNSNameservers -> System.Collections.Generic.List<Cosmos.Kernel.System.Network.IPv4.Address!>!
+static readonly Cosmos.Kernel.System.Network.Config.NetworkConfigManager.NetworkConfigs -> System.Collections.Generic.List<Cosmos.Kernel.System.Network.Config.NetworkConfigEntry!>!
+static readonly Cosmos.Kernel.System.Network.IPv4.Address.Broadcast -> Cosmos.Kernel.System.Network.IPv4.Address!
+static readonly Cosmos.Kernel.System.Network.IPv4.Address.Zero -> Cosmos.Kernel.System.Network.IPv4.Address!
+static readonly Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.DynamicPortStart -> ushort
+static readonly Cosmos.Kernel.System.Network.IPv4.TCP.Tcp.Table -> string![]!
+static readonly Cosmos.Kernel.System.Storage.Gpt.BasicDataPartitionType -> System.Guid
+virtual Cosmos.Kernel.System.Graphics.Canvas.AvailableModes.get -> System.Collections.Generic.List<Cosmos.Kernel.System.Graphics.Mode>!
+virtual Cosmos.Kernel.System.Graphics.Canvas.Clear(int color) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.Clear(System.Drawing.Color color) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.CroppedDrawImage(Cosmos.Kernel.System.Graphics.Image! image, int x, int y, int maxWidth, int maxHeight, bool preventOffBoundPixels = true) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DefaultGraphicsMode.get -> Cosmos.Kernel.System.Graphics.Mode
+virtual Cosmos.Kernel.System.Graphics.Canvas.Disable() -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.Display() -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawArc(int x, int y, int width, int height, System.Drawing.Color color, int startAngle = 0, int endAngle = 360) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawArray(int[]! colors, int x, int y, int width, int height) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawArray(int[]! colors, int x, int y, int width, int height, int startIndex) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawArray(System.Drawing.Color[]! colors, int x, int y, int width, int height) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawCanvas(Cosmos.Kernel.System.Graphics.Canvas! canvas, int x, int y) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawChar(char c, Cosmos.Kernel.System.Graphics.Fonts.Font! font, System.Drawing.Color color, int x, int y) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawCircle(System.Drawing.Color color, int xCenter, int yCenter, int radius) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawEllipse(System.Drawing.Color color, int xCenter, int yCenter, int xR, int yR) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawFilledCircle(System.Drawing.Color color, int x0, int y0, int radius) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawFilledEllipse(System.Drawing.Color color, int xCenter, int yCenter, int yR, int xR) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawFilledRectangle(System.Drawing.Color color, int xStart, int yStart, int width, int height, bool preventOffBoundPixels = true) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawImage(Cosmos.Kernel.System.Graphics.Image! image, int x, int y, bool preventOffBoundPixels = true) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawImage(Cosmos.Kernel.System.Graphics.Image! image, int x, int y, int w, int h, bool preventOffBoundPixels = true) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawLine(System.Drawing.Color color, int x1, int y1, int x2, int y2) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawPoint(int color, int x, int y) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawPoint(System.Drawing.Color color, int x, int y) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawPoint(uint color, int x, int y) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawPolygon(System.Drawing.Color color, params System.Drawing.Point[]! points) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawRectangle(System.Drawing.Color color, int x, int y, int width, int height) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawSquare(System.Drawing.Color color, int x, int y, int size) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawString(string! str, Cosmos.Kernel.System.Graphics.Fonts.Font! font, System.Drawing.Color color, int x, int y) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawString(string! str, Cosmos.Kernel.System.Graphics.Fonts.TrueTypeFont! font, int sizePx, System.Drawing.Color color, int x, int y) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.DrawTriangle(System.Drawing.Color color, int v1x, int v1y, int v2x, int v2y, int v3x, int v3y) -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.GetImage(int x, int y, int width, int height) -> Cosmos.Kernel.System.Graphics.Bitmap!
+virtual Cosmos.Kernel.System.Graphics.Canvas.GetPointColor(int x, int y) -> System.Drawing.Color
+virtual Cosmos.Kernel.System.Graphics.Canvas.GetRawPointColor(int x, int y) -> int
+virtual Cosmos.Kernel.System.Graphics.Canvas.Mode.get -> Cosmos.Kernel.System.Graphics.Mode
+virtual Cosmos.Kernel.System.Graphics.Canvas.Mode.set -> void
+virtual Cosmos.Kernel.System.Graphics.Canvas.Name() -> string!
+virtual Cosmos.Kernel.System.Graphics.Canvas.RefreshRate.get -> int
+virtual Cosmos.Kernel.System.Kernel.AfterRun() -> void
+virtual Cosmos.Kernel.System.Kernel.BeforeRun() -> void
+virtual Cosmos.Kernel.System.Kernel.OnBoot() -> void
+virtual Cosmos.Kernel.System.Kernel.Start() -> void
+virtual Cosmos.Kernel.System.Network.EthernetPacket.InitializeFields() -> void
+virtual Cosmos.Kernel.System.Network.IPv4.UDP.UDPDataReceivedHandler.Invoke(Cosmos.Kernel.System.Network.IPv4.UDP.UDPPacket! packet) -> void


### PR DESCRIPTION
### Problem

Nothing guards the public surface of the kernel packages ahead of the Gen3 release:

- `Cosmos.Kernel.System` exposes its whole surface with no inventory: a PR that adds, changes, or deletes public API shows nothing reviewable.
- No breaking-change detection exists between releases, so the first NuGet consumers would get silent binary breaks.
- The docs site follows main only: once a release ships, the docs of that release are overwritten by the next merge.

Tool evaluation behind this stack: [Outillage API Gen3](https://claude.ai/code/artifact/3bb536be-96bc-480c-a0c1-19896d15adc2) (PublicApiAnalyzers + SDK Package Validation + one frozen docfx build per release in gh-pages subfolders, the Stride pattern).

### Fix

Three pillars, wired so the release-time parts activate on their own:

1. **Declared surface.** `Cosmos.Kernel.System` opts in with `CosmosTrackPublicApi` (wiring in `Directory.Build.props`, extensible to Core and HAL after their audit). Microsoft.CodeAnalysis.PublicApiAnalyzers requires every public symbol to be listed in `PublicAPI.Shipped.txt` (empty until the Gen3 release) or `PublicAPI.Unshipped.txt` (seeded here with the current 1078-symbol surface). `RS0016`/`RS0017` are errors, so any surface change must land in the PR as a txt diff; `make api` reseeds the files. The vendored directories (SharpZipLib, PNG decoder, TrueType fonts) are excluded by path: they go internal in the pre-release surface cleanup, and keeping them unlisted means that cleanup will not churn the declared surface.
2. **Package validation.** The same flag sets `EnablePackageValidation`. `CosmosApiBaselineVersion` in `Directory.Build.props` stays empty until the first Gen3 release is on NuGet.org; once pinned, it activates both `PackageValidationBaselineVersion` at pack time and the new `API compatibility guard` step in `release.yml` (Microsoft.DotNet.ApiCompat.Tool against the baseline nupkg downloaded from NuGet.org).
3. **Versioned docs.** A `publish-docs` job in `release.yml` freezes the docs of a `v*` tag under `gh-pages/vX.Y.Z/`, refreshes the `latest/` alias, and rewrites `versions.json`. `build-docs.yml` gains `keep_files: true` so dev deploys stop wiping those folders. The custom docfx template gains a version dropdown (reads `versions.json`, keeps the reader on the same page across versions when it exists there); it only appears after the first tagged release, until then the site is unchanged.

`docs/articles/dev/public-api.md` documents the contributor workflow and the release checklist (promote Unshipped to Shipped, pin the baseline).

### Verification

| Check | Result |
|-------|--------|
| `make api` seeding | 1078 symbols, stable across 3 passes |
| `make setup` with analyzers and pack validation active | pass, all packages built |
| Version-stamped `Kernel.VersionString` in the API file | excluded via `.editorconfig`, no churn per version bump |
| Dropdown on the dev root | renders, `dev` selected |
| Dropdown on a page under `v9.9.9/` | renders, `v9.9.9 (latest)` selected |
| Dropdown on a page under `latest/` | maps to the `v9.9.9` entry |
| No `versions.json` (state before the first release) | no dropdown, site unchanged |
| `versions.json` composition | newest-first ordering verified locally |
| Workflow YAML | parses |

The dropdown checks ran on a locally simulated gh-pages tree (dev root + `v9.9.9/` + `latest/` + `versions.json`) built with docfx, served over HTTP, and inspected with headless Chromium.

### Notes

- The versioned publish is conditioned on this repo; when #427 moves the release pipeline to CosmosOS/Cosmos, `publish-docs` needs the same move (deploy-key mechanism as `build-docs.yml`).
- The rollout order from the evaluation stands: the surface cleanup (SharpZipLib internal, public fields, `Conversion.Base64`, naming) is breaking and must precede the first `Shipped.txt` promotion. Each cleanup PR now shows up as a shrinking `PublicAPI.Unshipped.txt` diff.
