### PR TITLE
Document the Cosmos.Kernel.System public API and enforce CS1591

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -18,6 +18,11 @@
          trample the per-file severity=none exclusions (LibraryInitializer,
          KernelVersion.g.cs); its editorconfig error severity already works. -->
     <WarningsAsErrors>$(WarningsAsErrors);RS0017</WarningsAsErrors>
+    <!-- A tracked public surface must be documented: lift the repo-wide CS1591
+         suppression (props set NoWarn to ";1591;CS1998;..." so the delimited
+         token is always ";1591;") and make missing XML docs a build error. -->
+    <NoWarn>$(NoWarn.Replace(';1591;', ';'))</NoWarn>
+    <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
   </PropertyGroup>
 
   <Target Name="EnforceKernelReferenceRules" BeforeTargets="BeforeBuild">

--- a/src/Cosmos.Build.Common/Cosmos.Build.Common.csproj
+++ b/src/Cosmos.Build.Common/Cosmos.Build.Common.csproj
@@ -5,7 +5,7 @@
 
     <!-- Pack compiled tasks DLL to tasks/ folder (MSBuild convention) -->
     <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
-    <NoWarn>NU5100</NoWarn>
+    <NoWarn>$(NoWarn);NU5100</NoWarn>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 

--- a/src/Cosmos.Kernel.System/Cosmos.Kernel.System.csproj
+++ b/src/Cosmos.Kernel.System/Cosmos.Kernel.System.csproj
@@ -44,6 +44,7 @@
       <_KernelVersionCsLine Include="namespace Cosmos.Kernel.System%3B" />
       <_KernelVersionCsLine Include="public abstract partial class Kernel" />
       <_KernelVersionCsLine Include="{" />
+      <_KernelVersionCsLine Include="    /// &lt;summary&gt;The version of the Cosmos packages this kernel was built against.&lt;/summary&gt;" />
       <_KernelVersionCsLine Include="    public const string VersionString = &quot;$(VersionPrefix)&quot;%3B" />
       <_KernelVersionCsLine Include="}" />
     </ItemGroup>

--- a/src/Cosmos.Kernel.System/Filesystems/Fat/FatBootSector.cs
+++ b/src/Cosmos.Kernel.System/Filesystems/Fat/FatBootSector.cs
@@ -9,9 +9,13 @@ namespace Cosmos.Kernel.System.Filesystems.Fat;
 /// </summary>
 public enum FatType
 {
+    /// <summary>The volume is not a recognized FAT variant.</summary>
     Unknown,
+    /// <summary>FAT12: fewer than 4085 clusters.</summary>
     Fat12,
+    /// <summary>FAT16: 4085 to 65524 clusters.</summary>
     Fat16,
+    /// <summary>FAT32: 65525 clusters or more.</summary>
     Fat32,
 }
 
@@ -177,24 +181,59 @@ public sealed class FatBootSector
     /// <summary>Highest cluster count of the FAT16 band — the Max encoding of the same §3.5 boundary as <see cref="Fat32MinClusters"/> (Max = Min - 1).</summary>
     internal const uint Fat16MaxClusters = Fat32MinClusters - 1;
 
+    /// <summary>The FAT variant, derived from <see cref="ClusterCount"/>.</summary>
     public FatType Type { get; private set; }
+
+    /// <summary>Bytes per sector (BPB_BytsPerSec): 512, 1024, 2048 or 4096.</summary>
     public uint BytesPerSector { get; private set; }
+
+    /// <summary>Sectors per cluster (BPB_SecPerClus): a power of two up to 128.</summary>
     public uint SectorsPerCluster { get; private set; }
+
+    /// <summary>Cluster size in bytes: <see cref="BytesPerSector"/> times <see cref="SectorsPerCluster"/>.</summary>
     public uint BytesPerCluster { get; private set; }
+
+    /// <summary>Sectors reserved before the first FAT (BPB_RsvdSecCnt).</summary>
     public uint ReservedSectorCount { get; private set; }
+
+    /// <summary>Number of FAT copies (BPB_NumFATs), usually 2.</summary>
     public uint NumberOfFats { get; private set; }
+
+    /// <summary>Number of fixed root directory entries (BPB_RootEntCnt); 0 on FAT32.</summary>
     public uint RootEntryCount { get; private set; }
+
+    /// <summary>Total sectors of the volume (BPB_TotSec16 or BPB_TotSec32).</summary>
     public uint TotalSectorCount { get; private set; }
+
+    /// <summary>Sectors per FAT copy (BPB_FATSz16 or BPB_FATSz32).</summary>
     public uint FatSectorCount { get; private set; }
+
+    /// <summary>First cluster of the root directory (BPB_RootClus); 0 on FAT12/16.</summary>
     public uint RootCluster { get; private set; }
+
+    /// <summary>LBA of the fixed root directory region on FAT12/16; 0 on FAT32.</summary>
     public uint RootStartLba { get; private set; }
+
+    /// <summary>Sectors occupied by the fixed root directory on FAT12/16; 0 on FAT32.</summary>
     public uint RootSectorCount { get; private set; }
+
+    /// <summary>LBA of the first data cluster (cluster 2).</summary>
     public uint DataStartLba { get; private set; }
+
+    /// <summary>Number of data clusters on the volume.</summary>
     public uint ClusterCount { get; private set; }
+
+    /// <summary>LBA of the first FAT copy.</summary>
     public uint FatStartLba { get; private set; }
 
     private FatBootSector() { }
 
+    /// <summary>
+    /// Parses and validates a boot sector, deriving the volume geometry.
+    /// </summary>
+    /// <param name="bpb">The raw boot sector, at least 512 bytes.</param>
+    /// <param name="bootSector">The parsed boot sector, or <see langword="null"/> when parsing fails.</param>
+    /// <returns><see langword="true"/> when the sector carries a valid, spec-legal BPB.</returns>
     public static bool TryParse(ReadOnlySpan<byte> bpb, out FatBootSector? bootSector)
     {
         bootSector = null;

--- a/src/Cosmos.Kernel.System/Filesystems/Fat/FatFilesystemType.cs
+++ b/src/Cosmos.Kernel.System/Filesystems/Fat/FatFilesystemType.cs
@@ -25,15 +25,24 @@ public sealed class FatFilesystemType : IVfsFilesystemType
 
     private readonly IBlockDevice? _injectedDevice;
 
+    /// <summary>
+    /// Creates a driver that resolves its device from the mount source string.
+    /// </summary>
     public FatFilesystemType()
     {
     }
 
+    /// <summary>
+    /// Creates a driver bound to a fixed device, used when the mount source is
+    /// empty (test seam).
+    /// </summary>
+    /// <param name="device">The block device holding the FAT volume.</param>
     public FatFilesystemType(IBlockDevice device)
     {
         _injectedDevice = device;
     }
 
+    /// <inheritdoc />
     public bool TryMount(ReadOnlySpan<char> source, MountFlags flags, [NotNullWhen(true)] out IVfsSuperblock? superblock)
     {
         superblock = null;
@@ -75,6 +84,7 @@ public sealed class FatFilesystemType : IVfsFilesystemType
         return true;
     }
 
+    /// <inheritdoc />
     public bool TryFormat(ReadOnlySpan<char> source, IVfsFormatOptions? options)
     {
         IBlockDevice? device = ResolveDevice(source);
@@ -92,6 +102,7 @@ public sealed class FatFilesystemType : IVfsFilesystemType
         return FatFormatter.Format(device, fatOptions);
     }
 
+    /// <inheritdoc />
     public bool TryDestroy(ReadOnlySpan<char> source)
     {
         IBlockDevice? device = ResolveDevice(source);

--- a/src/Cosmos.Kernel.System/Graphics/Canvas.cs
+++ b/src/Cosmos.Kernel.System/Graphics/Canvas.cs
@@ -1160,6 +1160,14 @@ public unsafe class Canvas
         }
     }
 
+    /// <summary>
+    /// Clamps the line's two endpoints so the segment fits inside the canvas
+    /// boundaries, preserving its slope.
+    /// </summary>
+    /// <param name="x1">The start point X coordinate.</param>
+    /// <param name="y1">The start point Y coordinate.</param>
+    /// <param name="x2">The end point X coordinate.</param>
+    /// <param name="y2">The end point Y coordinate.</param>
     protected void TrimLine(ref int x1, ref int y1, ref int x2, ref int y2)
     {
         // in case of vertical lines, no need to perform complex operations

--- a/src/Cosmos.Kernel.System/Graphics/Fonts/PCScreenFont.cs
+++ b/src/Cosmos.Kernel.System/Graphics/Fonts/PCScreenFont.cs
@@ -41,13 +41,29 @@ public class PCScreenFont : Font
     // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
     // POSSIBILITY OF SUCH DAMAGE.
 
+    /// <summary>
+    /// Names identifying the default font resource.
+    /// </summary>
     public static class Default
     {
+        /// <summary>
+        /// The <see cref="AppContext"/> data key checked for an overriding
+        /// embedded-resource name before falling back to <see cref="DefaultFontName"/>.
+        /// </summary>
         public const string DefaultFontKey = "Cosmos.Kernel.System.Graphics.Fonts.DefaultFont";
+
+        /// <summary>
+        /// The embedded-resource name of the default PSF font.
+        /// </summary>
         public const string DefaultFontName = $"{DefaultFontKey}.psf";
     }
 
     static PCScreenFont? s_default = null;
+
+    /// <summary>
+    /// The default console font, loaded lazily from the embedded PSF resource,
+    /// or from a built-in fallback font when the resource is absent.
+    /// </summary>
     public static PCScreenFont DefaultFont
     {
         get

--- a/src/Cosmos.Kernel.System/Graphics/Images/Image.cs
+++ b/src/Cosmos.Kernel.System/Graphics/Images/Image.cs
@@ -51,5 +51,6 @@ public abstract class Image
 /// </summary>
 public enum ImageFormat
 {
+    /// <summary>The Windows bitmap (.bmp) format.</summary>
     BMP
 }

--- a/src/Cosmos.Kernel.System/Graphics/KernelConsole.cs
+++ b/src/Cosmos.Kernel.System/Graphics/KernelConsole.cs
@@ -88,6 +88,11 @@ public class KernelConsole
         ClearCells();
     }
 
+    /// <summary>
+    /// Throws when <see cref="Initialize"/> has not run yet, guaranteeing
+    /// <see cref="Default"/> is non-null to callers that return normally.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The kernel console is not initialized.</exception>
     [MemberNotNull(nameof(Default))]
     public static void ThrowIfKernelConsoleNotInitialized()
     {

--- a/src/Cosmos.Kernel.System/Graphics/Mode.cs
+++ b/src/Cosmos.Kernel.System/Graphics/Mode.cs
@@ -40,13 +40,20 @@ public readonly struct Mode
         ColorDepth = colorDepth;
     }
 
+    /// <summary>
+    /// Checks whether this mode has the same width, height and color depth as
+    /// <paramref name="other"/>.
+    /// </summary>
+    /// <param name="other">The mode to compare with.</param>
     public bool Equals(Mode other)
     {
         return Width == other.Width && Height == other.Height && ColorDepth == other.ColorDepth;
     }
 
+    /// <inheritdoc />
     public override bool Equals(object? obj) => obj is Mode mode && Equals(mode);
 
+    /// <inheritdoc />
     public override int GetHashCode()
     {
         // overflow is acceptable in this case
@@ -59,6 +66,12 @@ public readonly struct Mode
         }
     }
 
+    /// <summary>
+    /// Orders modes by resolution: negative when both dimensions are smaller
+    /// than <paramref name="other"/>'s, positive when both are larger, zero
+    /// otherwise. Color depth does not participate in the ordering.
+    /// </summary>
+    /// <param name="other">The mode to compare with.</param>
     public int CompareTo(Mode other)
     {
         // color_depth has no effect on the orderiring
@@ -76,13 +89,39 @@ public readonly struct Mode
         return 0;
     }
 
+    /// <summary>Checks whether the two modes are equal.</summary>
+    /// <param name="a">The first mode.</param>
+    /// <param name="b">The second mode.</param>
     public static bool operator ==(Mode a, Mode b) => a.Equals(b);
+
+    /// <summary>Checks whether the two modes differ.</summary>
+    /// <param name="a">The first mode.</param>
+    /// <param name="b">The second mode.</param>
     public static bool operator !=(Mode a, Mode b) => !(a == b);
+
+    /// <summary>Checks whether <paramref name="a"/> has a higher resolution than <paramref name="b"/>, per <see cref="CompareTo"/>.</summary>
+    /// <param name="a">The first mode.</param>
+    /// <param name="b">The second mode.</param>
     public static bool operator >(Mode a, Mode b) => a.CompareTo(b) > 0;
+
+    /// <summary>Checks whether <paramref name="a"/> has a lower resolution than <paramref name="b"/>, per <see cref="CompareTo"/>.</summary>
+    /// <param name="a">The first mode.</param>
+    /// <param name="b">The second mode.</param>
     public static bool operator <(Mode a, Mode b) => a.CompareTo(b) < 0;
+
+    /// <summary>Checks whether <paramref name="a"/> compares greater than or equal to <paramref name="b"/>, per <see cref="CompareTo"/>.</summary>
+    /// <param name="a">The first mode.</param>
+    /// <param name="b">The second mode.</param>
     public static bool operator >=(Mode a, Mode b) => a.CompareTo(b) >= 0;
+
+    /// <summary>Checks whether <paramref name="a"/> compares less than or equal to <paramref name="b"/>, per <see cref="CompareTo"/>.</summary>
+    /// <param name="a">The first mode.</param>
+    /// <param name="b">The second mode.</param>
     public static bool operator <=(Mode a, Mode b) => a.CompareTo(b) <= 0;
 
+    /// <summary>
+    /// Formats the mode as <c>width x height @ depth</c>, e.g. <c>1024x768@32</c>.
+    /// </summary>
     public override string ToString()
     {
         return Width + "x" + Height + "@" + (int)ColorDepth;

--- a/src/Cosmos.Kernel.System/Graphics/SVGAII3DCanvas.cs
+++ b/src/Cosmos.Kernel.System/Graphics/SVGAII3DCanvas.cs
@@ -33,11 +33,22 @@ public class SVGAII3DCanvas : Canvas
     /// </summary>
     public VMWareSVGAII3D? Driver3D { get; }
 
+    /// <summary>
+    /// Creates a canvas on the given SVGA II PCI device in the default
+    /// 1024x768x32 mode.
+    /// </summary>
+    /// <param name="device">The VMware SVGA II PCI device.</param>
     public SVGAII3DCanvas(PciDevice device)
         : this(device, s_defaultMode)
     {
     }
 
+    /// <summary>
+    /// Creates a canvas on the given SVGA II PCI device in the given mode.
+    /// </summary>
+    /// <param name="device">The VMware SVGA II PCI device.</param>
+    /// <param name="aMode">The graphics mode to set; must be one of <see cref="AvailableModes"/>.</param>
+    /// <exception cref="ArgumentOutOfRangeException">The mode is not supported by this driver.</exception>
     public SVGAII3DCanvas(PciDevice device, Mode aMode)
         : base(aMode)
     {
@@ -48,6 +59,7 @@ public class SVGAII3DCanvas : Canvas
         Driver3D = Driver.Is3DEnabled ? new VMWareSVGAII3D(Driver) : null;
     }
 
+    /// <inheritdoc />
     public override string Name() => "VMWareSVGAII";
 
     /// <summary>
@@ -67,13 +79,16 @@ public class SVGAII3DCanvas : Canvas
         }
     }
 
+    /// <inheritdoc />
     public override Mode DefaultGraphicsMode => s_defaultMode;
 
+    /// <inheritdoc />
     public override void Disable()
     {
         Driver.Disable();
     }
 
+    /// <inheritdoc />
     public override void DrawPoint(Color color, int x, int y)
     {
         if (color.A < 255)
@@ -89,16 +104,19 @@ public class SVGAII3DCanvas : Canvas
         Driver.DrawPixel((uint)color.ToArgb(), x, y);
     }
 
+    /// <inheritdoc />
     public override void DrawPoint(uint color, int x, int y)
     {
         Driver.DrawPixel(color, x, y);
     }
 
+    /// <inheritdoc />
     public override void DrawPoint(int color, int x, int y)
     {
         Driver.DrawPixel((uint)color, x, y);
     }
 
+    /// <inheritdoc />
     public override void DrawArray(Color[] colors, int x, int y, int width, int height)
     {
         ThrowIfCoordNotValid(x, y);
@@ -118,16 +136,19 @@ public class SVGAII3DCanvas : Canvas
         return (x * _stride) + (y * _pitch);
     }
 
+    /// <inheritdoc />
     public override void DrawArray(int[] colors, int x, int y, int width, int height)
     {
         Driver.CopyBuffer(colors.AsMemory(), x, y, width, height);
     }
 
+    /// <inheritdoc />
     public override void DrawArray(int[] colors, int x, int y, int width, int height, int startIndex)
     {
         Driver.CopyBuffer(colors.AsMemory(startIndex), x, y, width, height);
     }
 
+    /// <inheritdoc />
     public override void DrawFilledRectangle(Color color, int xStart, int yStart, int width, int height, bool preventOffBoundPixels = true)
     {
         int argb = color.ToArgb();
@@ -144,6 +165,7 @@ public class SVGAII3DCanvas : Canvas
         }
     }
 
+    /// <inheritdoc />
     public override void DrawRectangle(Color color, int x, int y, int width, int height)
     {
         if (color.A < 255)
@@ -172,6 +194,7 @@ public class SVGAII3DCanvas : Canvas
         }
     }
 
+    /// <inheritdoc />
     public override List<Mode> AvailableModes { get; } = new List<Mode>
     {
         /* VmWare may support 16-bit resolutions but CGS does not yet.
@@ -215,16 +238,23 @@ public class SVGAII3DCanvas : Canvas
         Driver.SetMode(width, height, colorDepth);
     }
 
+    /// <inheritdoc />
     public override void Clear(int color)
     {
         Driver.ClearScreen((uint)color);
     }
 
+    /// <inheritdoc />
     public override void Clear(Color color)
     {
         Driver.ClearScreen((uint)color.ToArgb());
     }
 
+    /// <summary>
+    /// Reads the color of the pixel at the given coordinates from video memory.
+    /// </summary>
+    /// <param name="x">The X coordinate.</param>
+    /// <param name="y">The Y coordinate.</param>
     public Color GetPixel(int x, int y)
     {
         uint argb = Driver.GetPixel(x, y);
@@ -239,6 +269,12 @@ public class SVGAII3DCanvas : Canvas
     /// </summary>
     public bool HasHardwareCursor => Driver.HasAlphaCursor;
 
+    /// <summary>
+    /// Moves the hardware cursor and toggles its visibility.
+    /// </summary>
+    /// <param name="visible">Whether the cursor is shown.</param>
+    /// <param name="x">The X coordinate of the cursor.</param>
+    /// <param name="y">The Y coordinate of the cursor.</param>
     public void SetCursor(bool visible, int x, int y)
     {
         Driver.SetCursor(visible, (uint)x, (uint)y);
@@ -253,32 +289,56 @@ public class SVGAII3DCanvas : Canvas
         Driver.DefineAlphaCursor((uint)hotspotX, (uint)hotspotY, (uint)width, (uint)height, data);
     }
 
+    /// <summary>
+    /// Defines the default hardware cursor shape on the device.
+    /// </summary>
     public void CreateCursor()
     {
         Driver.DefineCursor();
     }
 
+    /// <summary>
+    /// Copies a rectangle of pixels from one screen position to another using
+    /// the device's accelerated copy operation.
+    /// </summary>
+    /// <param name="srcX">The X coordinate of the source rectangle.</param>
+    /// <param name="srcY">The Y coordinate of the source rectangle.</param>
+    /// <param name="dstX">The X coordinate of the destination rectangle.</param>
+    /// <param name="dstY">The Y coordinate of the destination rectangle.</param>
+    /// <param name="width">The width of the rectangle in pixels.</param>
+    /// <param name="height">The height of the rectangle in pixels.</param>
     public void CopyPixels(int srcX, int srcY, int dstX, int dstY, int width = 1, int height = 1)
     {
         Driver.Copy((uint)srcX, (uint)srcY, (uint)dstX, (uint)dstY, (uint)width, (uint)height);
     }
 
+    /// <summary>
+    /// Moves a single pixel to a new position and clears its old position to
+    /// black.
+    /// </summary>
+    /// <param name="x">The X coordinate of the pixel.</param>
+    /// <param name="y">The Y coordinate of the pixel.</param>
+    /// <param name="newX">The X coordinate to move the pixel to.</param>
+    /// <param name="newY">The Y coordinate to move the pixel to.</param>
     public void MovePixel(int x, int y, int newX, int newY)
     {
         Driver.Copy((uint)x, (uint)y, (uint)newX, (uint)newY, 1, 1);
         Driver.DrawPixel(0, x, y);
     }
 
+    /// <inheritdoc />
     public override Color GetPointColor(int x, int y)
     {
         return Color.FromArgb((int)Driver.GetPixel(x, y));
     }
 
+    /// <inheritdoc />
     public override int GetRawPointColor(int x, int y)
     {
         return (int)Driver.GetPixel(x, y);
     }
 
+    /// <inheritdoc />
     public override Bitmap GetImage(int x, int y, int width, int height)
     {
         int[] all = new int[width * height];
@@ -296,11 +356,13 @@ public class SVGAII3DCanvas : Canvas
         return bitmap;
     }
 
+    /// <inheritdoc />
     public override void Display()
     {
         Driver.Swap();
     }
 
+    /// <inheritdoc />
     public override void DrawImage(Image image, int x, int y, bool preventOffBoundPixels = true)
     {
         int width = (int)image.Width;
@@ -344,6 +406,7 @@ public class SVGAII3DCanvas : Canvas
         }
     }
 
+    /// <inheritdoc />
     public override void CroppedDrawImage(Image image, int x, int y, int width, int height, bool preventOffBoundPixels = true)
     {
         int[] data = image.RawData;

--- a/src/Cosmos.Kernel.System/Keyboard/ConsoleKeyEx.cs
+++ b/src/Cosmos.Kernel.System/Keyboard/ConsoleKeyEx.cs
@@ -14,132 +14,252 @@ namespace Cosmos.Kernel.System.Keyboard
         /// </summary>
         NoName,
 
+        /// <summary>The Esc key.</summary>
         Escape,
 
+        /// <summary>The F1 function key.</summary>
         F1,
+        /// <summary>The F2 function key.</summary>
         F2,
+        /// <summary>The F3 function key.</summary>
         F3,
+        /// <summary>The F4 function key.</summary>
         F4,
+        /// <summary>The F5 function key.</summary>
         F5,
+        /// <summary>The F6 function key.</summary>
         F6,
+        /// <summary>The F7 function key.</summary>
         F7,
+        /// <summary>The F8 function key.</summary>
         F8,
+        /// <summary>The F9 function key.</summary>
         F9,
+        /// <summary>The F10 function key.</summary>
         F10,
+        /// <summary>The F11 function key.</summary>
         F11,
+        /// <summary>The F12 function key.</summary>
         F12,
 
+        /// <summary>The Print Screen key.</summary>
         PrintScreen,
+        /// <summary>The Scroll Lock key.</summary>
         ScrollLock,
+        /// <summary>The Pause/Break key.</summary>
         PauseBreak,
 
+        /// <summary>The backquote (`) key.</summary>
         Backquote,
+        /// <summary>The 1 key on the top row.</summary>
         D1,
+        /// <summary>The 2 key on the top row.</summary>
         D2,
+        /// <summary>The 3 key on the top row.</summary>
         D3,
+        /// <summary>The 4 key on the top row.</summary>
         D4,
+        /// <summary>The 5 key on the top row.</summary>
         D5,
+        /// <summary>The 6 key on the top row.</summary>
         D6,
+        /// <summary>The 7 key on the top row.</summary>
         D7,
+        /// <summary>The 8 key on the top row.</summary>
         D8,
+        /// <summary>The 9 key on the top row.</summary>
         D9,
+        /// <summary>The 0 key on the top row.</summary>
         D0,
+        /// <summary>The minus (-) key.</summary>
         Minus,
+        /// <summary>The equals (=) key.</summary>
         Equal,
+        /// <summary>The backslash (\) key.</summary>
         Backslash,
+        /// <summary>The Backspace key.</summary>
         Backspace,
 
+        /// <summary>The Tab key.</summary>
         Tab,
+        /// <summary>The Q key.</summary>
         Q,
+        /// <summary>The W key.</summary>
         W,
+        /// <summary>The E key.</summary>
         E,
+        /// <summary>The R key.</summary>
         R,
+        /// <summary>The T key.</summary>
         T,
+        /// <summary>The Y key.</summary>
         Y,
+        /// <summary>The U key.</summary>
         U,
+        /// <summary>The I key.</summary>
         I,
+        /// <summary>The O key.</summary>
         O,
+        /// <summary>The P key.</summary>
         P,
+        /// <summary>The left bracket ([) key.</summary>
         LBracket,
+        /// <summary>The right bracket (]) key.</summary>
         RBracket,
+        /// <summary>The Enter key.</summary>
         Enter,
 
+        /// <summary>The Caps Lock key.</summary>
         CapsLock,
+        /// <summary>The A key.</summary>
         A,
+        /// <summary>The S key.</summary>
         S,
+        /// <summary>The D key.</summary>
         D,
+        /// <summary>The F key.</summary>
         F,
+        /// <summary>The G key.</summary>
         G,
+        /// <summary>The H key.</summary>
         H,
+        /// <summary>The J key.</summary>
         J,
+        /// <summary>The K key.</summary>
         K,
+        /// <summary>The L key.</summary>
         L,
+        /// <summary>The semicolon (;) key.</summary>
         Semicolon,
+        /// <summary>The colon (:) key.</summary>
         Colon,
+        /// <summary>The apostrophe (') key.</summary>
         Apostrophe,
 
+        /// <summary>The less-than (&lt;) key.</summary>
         LowerThan,
+        /// <summary>The greater-than (&gt;) key.</summary>
         BiggerThan,
 
+        /// <summary>The exclamation point (!) key.</summary>
         ExclamationPoint,
 
+        /// <summary>The left Shift key.</summary>
         LShift,
+        /// <summary>The right Shift key.</summary>
         RShift,
-        OEM102, // <<=== This key does not exist on a US keyboard, but on the german one. It contains the characters `|`, `<` and `>`
-        OEM5, // This one is registered as \ and | on a British keyboard. however US use the one registered as # and ~ to us.
+        /// <summary>
+        /// The extra key next to the left Shift on ISO layouts (absent on a US
+        /// keyboard); on the German layout it carries |, &lt; and &gt;.
+        /// </summary>
+        OEM102,
+        /// <summary>
+        /// The key registered as \ and | on a British keyboard, and as # and ~
+        /// on a US one.
+        /// </summary>
+        OEM5,
+        /// <summary>The Z key.</summary>
         Z,
+        /// <summary>The X key.</summary>
         X,
+        /// <summary>The C key.</summary>
         C,
+        /// <summary>The V key.</summary>
         V,
+        /// <summary>The B key.</summary>
         B,
+        /// <summary>The N key.</summary>
         N,
+        /// <summary>The M key.</summary>
         M,
+        /// <summary>The comma (,) key.</summary>
         Comma,
+        /// <summary>The period (.) key.</summary>
         Period,
+        /// <summary>The slash (/) key.</summary>
         Slash,
 
+        /// <summary>The left Ctrl key.</summary>
         LCtrl,
+        /// <summary>The right Ctrl key.</summary>
         RCtrl,
+        /// <summary>The left Windows key.</summary>
         LWin,
+        /// <summary>The left Alt key.</summary>
         LAlt,
+        /// <summary>The right Alt key.</summary>
         RAlt,
+        /// <summary>The Spacebar key.</summary>
         Spacebar,
+        /// <summary>The AltGr key.</summary>
         AltGr,
+        /// <summary>The right Windows key.</summary>
         RWin,
+        /// <summary>The Menu (context menu) key.</summary>
         Menu,
 
+        /// <summary>The Insert key.</summary>
         Insert,
+        /// <summary>The Home key.</summary>
         Home,
+        /// <summary>The Page Up key.</summary>
         PageUp,
+        /// <summary>The Delete key.</summary>
         Delete,
+        /// <summary>The End key.</summary>
         End,
+        /// <summary>The Page Down key.</summary>
         PageDown,
 
+        /// <summary>The up arrow key.</summary>
         UpArrow,
+        /// <summary>The down arrow key.</summary>
         DownArrow,
+        /// <summary>The left arrow key.</summary>
         LeftArrow,
+        /// <summary>The right arrow key.</summary>
         RightArrow,
 
+        /// <summary>The Num Lock key.</summary>
         NumLock,
+        /// <summary>The divide (/) key on the numeric keypad.</summary>
         NumDivide,
+        /// <summary>The multiply (*) key on the numeric keypad.</summary>
         NumMultiply,
+        /// <summary>The minus (-) key on the numeric keypad.</summary>
         NumMinus,
+        /// <summary>The 7 key on the numeric keypad.</summary>
         Num7,
+        /// <summary>The 8 key on the numeric keypad.</summary>
         Num8,
+        /// <summary>The 9 key on the numeric keypad.</summary>
         Num9,
+        /// <summary>The plus (+) key on the numeric keypad.</summary>
         NumPlus,
+        /// <summary>The 4 key on the numeric keypad.</summary>
         Num4,
+        /// <summary>The 5 key on the numeric keypad.</summary>
         Num5,
+        /// <summary>The 6 key on the numeric keypad.</summary>
         Num6,
+        /// <summary>The 1 key on the numeric keypad.</summary>
         Num1,
+        /// <summary>The 2 key on the numeric keypad.</summary>
         Num2,
+        /// <summary>The 3 key on the numeric keypad.</summary>
         Num3,
+        /// <summary>The 0 key on the numeric keypad.</summary>
         Num0,
+        /// <summary>The period (.) key on the numeric keypad.</summary>
         NumPeriod,
+        /// <summary>The Enter key on the numeric keypad.</summary>
         NumEnter,
 
+        /// <summary>The Power key.</summary>
         Power,
+        /// <summary>The Sleep key.</summary>
         Sleep,
+        /// <summary>The Wake key.</summary>
         Wake
     }
 }

--- a/src/Cosmos.Kernel.System/Keyboard/KeyEvent.cs
+++ b/src/Cosmos.Kernel.System/Keyboard/KeyEvent.cs
@@ -13,7 +13,9 @@ namespace Cosmos.Kernel.System.Keyboard
         /// </summary>
         public enum KeyEventType
         {
+            /// <summary>The key was pressed.</summary>
             Make,
+            /// <summary>The key was released.</summary>
             Break
         }
 

--- a/src/Cosmos.Kernel.System/Keyboard/ScanMaps/DEStandardLayout.cs
+++ b/src/Cosmos.Kernel.System/Keyboard/ScanMaps/DEStandardLayout.cs
@@ -15,6 +15,7 @@ public class DEStandardLayout : ScanMapBase
     {
     }
 
+    /// <inheritdoc />
     protected override void InitKeys()
     {
         Keys = new List<KeyMapping>(101);

--- a/src/Cosmos.Kernel.System/Keyboard/ScanMaps/ESStandardLayout.cs
+++ b/src/Cosmos.Kernel.System/Keyboard/ScanMaps/ESStandardLayout.cs
@@ -15,6 +15,7 @@ public class ESStandardLayout : ScanMapBase
     {
     }
 
+    /// <inheritdoc />
     protected override void InitKeys()
     {
         Keys = new List<KeyMapping>(105);

--- a/src/Cosmos.Kernel.System/Keyboard/ScanMaps/FRStandardLayout.cs
+++ b/src/Cosmos.Kernel.System/Keyboard/ScanMaps/FRStandardLayout.cs
@@ -8,6 +8,7 @@ namespace Cosmos.Kernel.System.Keyboard.ScanMaps;
 /// </summary>
 public class FRStandardLayout : ScanMapBase
 {
+    /// <inheritdoc />
     protected override void InitKeys()
     {
         Keys = new List<KeyMapping>();

--- a/src/Cosmos.Kernel.System/Keyboard/ScanMaps/TRStandardLayout.cs
+++ b/src/Cosmos.Kernel.System/Keyboard/ScanMaps/TRStandardLayout.cs
@@ -15,6 +15,7 @@ public class TRStandardLayout : ScanMapBase
     {
     }
 
+    /// <inheritdoc />
     protected override void InitKeys()
     {
         Keys = new List<KeyMapping>(100);

--- a/src/Cosmos.Kernel.System/Keyboard/ScanMaps/USStandardLayout.cs
+++ b/src/Cosmos.Kernel.System/Keyboard/ScanMaps/USStandardLayout.cs
@@ -15,6 +15,7 @@ public class USStandardLayout : ScanMapBase
     {
     }
 
+    /// <inheritdoc />
     protected override void InitKeys()
     {
         Keys = new List<KeyMapping>(100);

--- a/src/Cosmos.Kernel.System/Network/IPv4/Address.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/Address.cs
@@ -21,7 +21,10 @@ public sealed class Address : IComparable<Address>
     /// </summary>
     public ImmutableArray<byte> Parts { get; }
 
+    /// <summary>Whether this is a 4-byte IPv4 address.</summary>
     public bool IsIpv4 => Parts.Length == 4;
+
+    /// <summary>Whether this is an IPv6 address (not 4 bytes long).</summary>
     public bool IsIpv6 => !IsIpv4;
 
     /// <summary>
@@ -149,11 +152,17 @@ public sealed class Address : IComparable<Address>
     /// </summary>
     public bool IsAPIPA() => Parts[0] == 169 && Parts[1] == 254;
 
+    /// <summary>
+    /// Formats the address in dotted-decimal notation (e.g. <c>192.168.1.1</c>).
+    /// </summary>
     public override string ToString()
     {
         return $"{Parts[0]}.{Parts[1]}.{Parts[2]}.{Parts[3]}";
     }
 
+    /// <summary>
+    /// The address bytes in network order, as a span over <see cref="Parts"/>.
+    /// </summary>
     public ReadOnlySpan<byte> ToSpan() => Parts.AsSpan();
 
     /// <summary>
@@ -180,6 +189,12 @@ public sealed class Address : IComparable<Address>
         }
     }
 
+    /// <summary>
+    /// Orders addresses by their numeric value (<see cref="Id"/>); a
+    /// <see langword="null"/> address sorts first.
+    /// </summary>
+    /// <param name="other">The address to compare with.</param>
+    /// <exception cref="Exception">The two addresses are not the same family.</exception>
     public int CompareTo(Address? other)
     {
         if (other is null)
@@ -194,6 +209,7 @@ public sealed class Address : IComparable<Address>
         return Id.CompareTo(other.Id);
     }
 
+    /// <inheritdoc />
     public override bool Equals(object? obj)
     {
         if (obj is Address other)
@@ -205,6 +221,7 @@ public sealed class Address : IComparable<Address>
 
     }
 
+    /// <inheritdoc />
     public override int GetHashCode()
     {
         return HashCode.Combine(Id);

--- a/src/Cosmos.Kernel.System/Network/IPv4/EndPoint.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/EndPoint.cs
@@ -37,11 +37,19 @@ public class EndPoint : IComparable
         Port = port;
     }
 
+    /// <summary>
+    /// Formats the end point as <c>address:port</c>.
+    /// </summary>
     public override string ToString()
     {
         return Address.ToString() + ":" + Port.ToString();
     }
 
+    /// <summary>
+    /// Compares this end point with another: 0 when address and port both
+    /// match, -1 otherwise; non-<see cref="EndPoint"/> arguments sort after.
+    /// </summary>
+    /// <param name="obj">The object to compare with.</param>
     public int CompareTo(object? obj)
     {
         if (obj is EndPoint other)

--- a/src/Cosmos.Kernel.System/Network/IPv4/IcmpClient.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/IcmpClient.cs
@@ -116,6 +116,9 @@ public class IcmpClient : IDisposable
         _rxBuffer.Enqueue(packet);
     }
 
+    /// <summary>
+    /// Closes the client, like <see cref="Close"/>.
+    /// </summary>
     public void Dispose()
     {
         Close();

--- a/src/Cosmos.Kernel.System/Network/IPv4/UDP/UdpClient.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/UDP/UdpClient.cs
@@ -212,6 +212,9 @@ public class UdpClient : IDisposable
         _rxBuffer.Enqueue(packet);
     }
 
+    /// <summary>
+    /// Closes the client, like <see cref="Close"/>.
+    /// </summary>
     public void Dispose()
     {
         Close();

--- a/src/Cosmos.Kernel.System/Storage/Partition.cs
+++ b/src/Cosmos.Kernel.System/Storage/Partition.cs
@@ -23,21 +23,25 @@ public sealed class Partition : BlockDevice
     /// <inheritdoc />
     public override string Name => _name;
 
-    /// <summary>Creates a block-device view of a partition on a host disk.</summary>
-    /// <param name="host">The disk this partition lives on.</param>
-    /// <param name="startSector">Absolute LBA on the host where the partition begins.</param>
-    /// <param name="sectorCount">Length of the partition in sectors.</param>
-    /// <param name="name">Display name for the partition.</param>
     /// <summary>
     /// Index-based naming ctor: builds "&lt;host&gt;p&lt;index&gt;" digit by
     /// digit so partition naming matches the device-naming convention and
     /// stays safe if registration ever moves earlier in boot.
     /// </summary>
+    /// <param name="host">The disk this partition lives on.</param>
+    /// <param name="startSector">Absolute LBA on the host where the partition begins.</param>
+    /// <param name="sectorCount">Length of the partition in sectors.</param>
+    /// <param name="index">Zero-based partition index on the host disk.</param>
     public Partition(IBlockDevice host, ulong startSector, ulong sectorCount, uint index)
         : this(host, startSector, sectorCount, BuildDeviceName(host.Name, "p", index))
     {
     }
 
+    /// <summary>Creates a block-device view of a partition on a host disk.</summary>
+    /// <param name="host">The disk this partition lives on.</param>
+    /// <param name="startSector">Absolute LBA on the host where the partition begins.</param>
+    /// <param name="sectorCount">Length of the partition in sectors.</param>
+    /// <param name="name">Display name for the partition.</param>
     public Partition(IBlockDevice host, ulong startSector, ulong sectorCount, string name)
     {
         _host = host;

--- a/src/Cosmos.Kernel.System/Storage/PartitionManager.cs
+++ b/src/Cosmos.Kernel.System/Storage/PartitionManager.cs
@@ -18,9 +18,17 @@ public static class PartitionManager
     /// <summary>Identifies a partition by its absolute LBA range on the host disk.</summary>
     public readonly struct PartitionLocation
     {
+        /// <summary>Absolute LBA on the host disk where the partition begins.</summary>
         public ulong StartSector { get; }
+
+        /// <summary>Length of the partition in sectors.</summary>
         public ulong SectorCount { get; }
 
+        /// <summary>
+        /// Creates a location from an absolute LBA range.
+        /// </summary>
+        /// <param name="startSector">Absolute LBA on the host disk where the partition begins.</param>
+        /// <param name="sectorCount">Length of the partition in sectors.</param>
         public PartitionLocation(ulong startSector, ulong sectorCount)
         {
             StartSector = startSector;

--- a/src/Cosmos.Kernel.System/Storage/StorageManager.cs
+++ b/src/Cosmos.Kernel.System/Storage/StorageManager.cs
@@ -102,14 +102,14 @@ public static class StorageManager
         }
     }
 
+    private static SchedSpinLock s_mutationLock;
+
     /// <summary>
     /// Registers a block device with the manager and scans it for a GPT or
     /// MBR partition table. Discovered partitions are appended to
     /// <see cref="Partitions"/>.
     /// </summary>
     /// <param name="device">The block device to register.</param>
-    private static SchedSpinLock s_mutationLock;
-
     public static void RegisterDevice(IBlockDevice device)
     {
         if (device == null || s_devices == null || s_deviceCount >= s_devices.Length)

--- a/src/Cosmos.Kernel.System/Vfs/VfsDirectory.cs
+++ b/src/Cosmos.Kernel.System/Vfs/VfsDirectory.cs
@@ -10,22 +10,77 @@ namespace Cosmos.Kernel.System.Vfs;
 /// </summary>
 public interface IVfsDirectoryHandle : IVfsNodeHandle, IDisposable
 {
+    /// <summary>
+    /// Lists the directory's entries.
+    /// </summary>
+    /// <param name="entries">The child inodes when the call succeeds.</param>
+    /// <returns><see langword="true"/> when the driver produced the listing.</returns>
     bool TryReadDir(out IReadOnlyList<IVfsInode> entries);
 
+    /// <summary>
+    /// Resolves a child entry by name.
+    /// </summary>
+    /// <param name="name">The child's name.</param>
+    /// <param name="child">A handle on the child when it exists.</param>
+    /// <returns><see langword="true"/> when the entry exists.</returns>
     bool TryLookup(ReadOnlySpan<char> name, [NotNullWhen(true)] out IVfsNodeHandle? child);
 
+    /// <summary>
+    /// Creates a file entry in this directory.
+    /// </summary>
+    /// <param name="name">The new file's name.</param>
+    /// <param name="mode">The mode bits of the new file.</param>
+    /// <param name="child">A handle on the created file.</param>
+    /// <returns><see langword="true"/> when the file was created.</returns>
     bool TryCreateFile(ReadOnlySpan<char> name, ModeEnum mode, [NotNullWhen(true)] out IVfsNodeHandle? child);
 
+    /// <summary>
+    /// Creates a subdirectory in this directory.
+    /// </summary>
+    /// <param name="name">The new directory's name.</param>
+    /// <param name="mode">The mode bits of the new directory.</param>
+    /// <param name="child">A handle on the created directory.</param>
+    /// <returns><see langword="true"/> when the directory was created.</returns>
     bool TryCreateDirectory(ReadOnlySpan<char> name, ModeEnum mode, [NotNullWhen(true)] out IVfsDirectoryHandle? child);
 
+    /// <summary>
+    /// Creates a symbolic link in this directory.
+    /// </summary>
+    /// <param name="name">The link's name.</param>
+    /// <param name="target">The path the link points to.</param>
+    /// <param name="child">A handle on the created link.</param>
+    /// <returns><see langword="true"/> when the link was created.</returns>
     bool TrySymlink(ReadOnlySpan<char> name, ReadOnlySpan<char> target, [NotNullWhen(true)] out IVfsNodeHandle? child);
 
+    /// <summary>
+    /// Removes a file entry from this directory.
+    /// </summary>
+    /// <param name="name">The entry's name.</param>
+    /// <returns><see langword="true"/> when the entry was removed.</returns>
     bool TryUnlink(ReadOnlySpan<char> name);
 
+    /// <summary>
+    /// Removes an empty subdirectory from this directory.
+    /// </summary>
+    /// <param name="name">The subdirectory's name.</param>
+    /// <returns><see langword="true"/> when the directory was removed.</returns>
     bool TryRemoveDirectory(ReadOnlySpan<char> name);
 
+    /// <summary>
+    /// Moves or renames an entry of this directory into <paramref name="newParent"/>.
+    /// </summary>
+    /// <param name="oldName">The entry's current name in this directory.</param>
+    /// <param name="newParent">The directory receiving the entry; may be this handle.</param>
+    /// <param name="newName">The entry's new name.</param>
+    /// <returns><see langword="true"/> when the entry was moved.</returns>
     bool TryRename(ReadOnlySpan<char> oldName, IVfsDirectoryHandle newParent, ReadOnlySpan<char> newName);
 
+    /// <summary>
+    /// Updates this directory's metadata.
+    /// </summary>
+    /// <param name="flags">Which fields of <paramref name="attributes"/> to apply.</param>
+    /// <param name="attributes">The new attribute values.</param>
+    /// <returns><see langword="true"/> when the driver applied the change.</returns>
     bool TrySetAttr(SetAttrFlags flags, in VfsStat attributes);
 }
 

--- a/src/Cosmos.Kernel.System/Vfs/VfsFile.cs
+++ b/src/Cosmos.Kernel.System/Vfs/VfsFile.cs
@@ -9,10 +9,17 @@ namespace Cosmos.Kernel.System.Vfs;
 /// </summary>
 public interface IVfsNodeHandle
 {
+    /// <summary>The name of the node inside its parent directory.</summary>
     string Name { get; }
 
+    /// <summary>The underlying HAL VFS inode.</summary>
     IVfsInode Inode { get; }
 
+    /// <summary>
+    /// Reads the node's metadata (size, timestamps, mode).
+    /// </summary>
+    /// <param name="stat">The node's metadata when the call succeeds.</param>
+    /// <returns><see langword="true"/> when the driver produced the metadata.</returns>
     bool TryStat(out VfsStat stat);
 }
 
@@ -21,14 +28,35 @@ public interface IVfsNodeHandle
 /// </summary>
 public interface IVfsFileHandle : IVfsNodeHandle, IDisposable
 {
+    /// <summary>The current byte offset of the file cursor.</summary>
     long Position { get; }
 
+    /// <summary>
+    /// Reads bytes at the current position, advancing it by the amount read.
+    /// </summary>
+    /// <param name="buffer">The destination buffer.</param>
+    /// <returns>The number of bytes read; 0 at end of file.</returns>
     long Read(Span<byte> buffer);
 
+    /// <summary>
+    /// Writes bytes at the current position, advancing it by the amount written.
+    /// </summary>
+    /// <param name="buffer">The bytes to write.</param>
+    /// <returns>The number of bytes written.</returns>
     long Write(ReadOnlySpan<byte> buffer);
 
+    /// <summary>
+    /// Moves the file cursor.
+    /// </summary>
+    /// <param name="offset">The offset relative to <paramref name="whence"/>.</param>
+    /// <param name="whence">The origin the offset is applied from.</param>
+    /// <returns><see langword="true"/> when the resulting position is valid.</returns>
     bool TrySeek(long offset, SeekWhence whence);
 
+    /// <summary>
+    /// Flushes buffered writes to the underlying device.
+    /// </summary>
+    /// <returns><see langword="true"/> when the driver flushed successfully.</returns>
     bool Flush();
 }
 

--- a/src/Cosmos.Kernel.System/Vfs/VfsManager.cs
+++ b/src/Cosmos.Kernel.System/Vfs/VfsManager.cs
@@ -36,6 +36,14 @@ public static partial class VfsManager
     /// </summary>
     public sealed class VfsMount
     {
+        /// <summary>
+        /// Creates a mount record.
+        /// </summary>
+        /// <param name="name">The registered driver name.</param>
+        /// <param name="source">The driver-specific backing-store identifier.</param>
+        /// <param name="mountPoint">The absolute path the filesystem is mounted at.</param>
+        /// <param name="filesystemType">The filesystem driver.</param>
+        /// <param name="superblock">The mounted filesystem instance.</param>
         public VfsMount(string name, string source, string mountPoint, IVfsFilesystemType filesystemType, IVfsSuperblock superblock)
         {
             Name = name;
@@ -51,10 +59,13 @@ public static partial class VfsManager
         /// <summary>Driver-specific backing-store identifier passed to <see cref="TryMount"/> — for the FAT driver, this is the global partition index in <c>StorageManager.Partitions</c> as a decimal string.</summary>
         public string Source { get; }
 
+        /// <summary>Absolute path the filesystem is mounted at (e.g. "/").</summary>
         public string MountPoint { get; }
 
+        /// <summary>The filesystem driver that produced this mount.</summary>
         public IVfsFilesystemType FilesystemType { get; }
 
+        /// <summary>The mounted filesystem instance.</summary>
         public IVfsSuperblock Superblock { get; }
     }
 


### PR DESCRIPTION
Last work stream of the pre-release API audit (after #451): the reference documentation. Stacked on `refactor/api-surface`.

## Problem

The repo-wide `NoWarn 1591` hides every missing XML doc comment. Of the 750 tracked public symbols of `Cosmos.Kernel.System`, 229 had no documentation at all, so the docfx API reference renders empty pages for them:

| Area | Missing docs |
|---|---|
| `ConsoleKeyEx` | all 114 enum members |
| `SVGAII3DCanvas` | 27 members (constructors, `Canvas` overrides, cursor/copy helpers) |
| `FatBootSector` + `FatType` | the 15 geometry properties, `TryParse`, the 4 enum members |
| `Mode` | equality/comparison operators, `Equals`, `GetHashCode`, `CompareTo`, `ToString` |
| VFS handles | all members of `IVfsNodeHandle`, `IVfsFileHandle`, `IVfsDirectoryHandle`, `VfsManager.VfsMount` |
| Network | `Address` (7), `EndPoint` (2), the two `Dispose` methods |
| Storage, keyboard, fonts | `PartitionLocation`, `Partition`/`StorageManager` stragglers, `KeyEventType`, the 5 layout `InitKeys`, `PCScreenFont` defaults, generated `Kernel.VersionString` |

Two adjacent defects surfaced while wiring the guard:

- `Partition`'s index ctor carried two `<summary>` blocks (the string ctor's docs had been stranded on it), and `StorageManager.RegisterDevice`'s docs were attached to the `s_mutationLock` field declaration instead of the method.
- `Cosmos.Build.Common.csproj` sets `<NoWarn>NU5100</NoWarn>` without `$(NoWarn)`, discarding every inherited suppression (its builds emitted 10 CS1591 warnings among others).

## Fix

- Every missing symbol documented: factual one-liners in the house style; `<inheritdoc />` on `Canvas`/interface overrides so docfx pulls the base docs; the `KernelVersion.g.cs` generator now emits a `<summary>` for `VersionString`.
- The stranded doc blocks in `Partition` and `StorageManager` reattached to their members.
- The guard: in the `CosmosTrackPublicApi` block of `Directory.Build.targets`, the repo-wide 1591 suppression is lifted and CS1591 is promoted through `WarningsAsErrors`. A tracked surface now fails the build when a new public symbol lands undocumented; untracked projects keep the suppression.
- `Cosmos.Build.Common` NoWarn made additive (`$(NoWarn);NU5100`).

## Verification

| Check | Result |
|---|---|
| `dotnet build Cosmos.Kernel.System -t:Rebuild` with the guard active | 0 errors, 0 CS1591 |
| Planted undocumented public member | fails the build with error CS1591 |
| `dotnet format ./nativeaot-patcher.slnx --exclude dotnet --verify-no-changes --severity error` (CI command) | exit 0 |
| `make setup` (all packages) | green |
| `make test KERNEL=HelloWorld` | 3/3 |
