### PR TITLE
Define the ring policy and internalize everything outside it

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -274,13 +274,6 @@ dotnet_diagnostic.RS0017.severity = none
 [**/KernelVersion.g.cs]
 dotnet_diagnostic.RS0016.severity = none
 dotnet_diagnostic.RS0017.severity = none
-# LibraryInitializer is public only because NativeAOT startup calls it by
-# convention (reserved Internal.Runtime.CompilerHelpers namespace); it is not
-# part of the surface offered to kernels.
-[src/Cosmos.Kernel.System/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs]
-dotnet_diagnostic.RS0016.severity = none
-dotnet_diagnostic.RS0017.severity = none
-
 # IRQContext's register fields differ per architecture (x64 vs ARM64 layouts
 # behind #if), and one declared-surface file cannot hold both: whichever arch
 # seeded it, the other arch's build reports the counterpart fields as missing

--- a/.editorconfig
+++ b/.editorconfig
@@ -254,6 +254,14 @@ dotnet_diagnostic.RS0017.severity = error
 dotnet_diagnostic.RS0026.severity = none
 dotnet_diagnostic.RS0027.severity = none
 
+# A tracked public surface must be documented. The error severity is scoped to
+# the tracked projects' own paths (editorconfig severity outranks NoWarn, so a
+# repo-wide [*.cs] entry would fire in every project) and never reaches the
+# sources linked from the dotnet/runtime submodule, which sit under the
+# submodule's own root .editorconfig.
+[src/Cosmos.Kernel.{System,Core,HAL,HAL.Interfaces}/**.cs]
+dotnet_diagnostic.CS1591.severity = error
+
 # Vendored code stays out of the declared surface: the tracking files list the
 # repo's own API only, and these types go internal in the pre-release surface
 # cleanup. Must come after the [*.cs] section above (later sections win).
@@ -266,10 +274,18 @@ dotnet_diagnostic.RS0017.severity = none
 [**/KernelVersion.g.cs]
 dotnet_diagnostic.RS0016.severity = none
 dotnet_diagnostic.RS0017.severity = none
-
 # LibraryInitializer is public only because NativeAOT startup calls it by
 # convention (reserved Internal.Runtime.CompilerHelpers namespace); it is not
 # part of the surface offered to kernels.
 [src/Cosmos.Kernel.System/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs]
+dotnet_diagnostic.RS0016.severity = none
+dotnet_diagnostic.RS0017.severity = none
+
+# IRQContext's register fields differ per architecture (x64 vs ARM64 layouts
+# behind #if), and one declared-surface file cannot hold both: whichever arch
+# seeded it, the other arch's build reports the counterpart fields as missing
+# and stale. The type stays public (IInterruptController.Dispatch pins it) and
+# documented; only its layout stays out of the txt files.
+[src/Cosmos.Kernel.Core/CPU/IRQContext.cs]
 dotnet_diagnostic.RS0016.severity = none
 dotnet_diagnostic.RS0017.severity = none

--- a/.github/workflows/kernel-coverage.yml
+++ b/.github/workflows/kernel-coverage.yml
@@ -115,9 +115,11 @@ jobs:
       suite_name: Threading
       suite_id: threading
       kernel_path: tests/Kernels/Cosmos.Kernel.Tests.Threading
-      timeout_x64: 120
-      timeout_arm64: 180
-      step_timeout_minutes: 10
+      # Matches kernel-tests.yml: the scheduling-policy cells add three fixed
+      # CPU-share measurement windows.
+      timeout_x64: 150
+      timeout_arm64: 240
+      step_timeout_minutes: 12
       coverage: true
 
   # ── Graphic ───────────────────────────────────────────────────────────────────

--- a/.github/workflows/kernel-tests.yml
+++ b/.github/workflows/kernel-tests.yml
@@ -190,9 +190,11 @@ jobs:
       suite_name: Threading
       suite_id: threading
       kernel_path: tests/Kernels/Cosmos.Kernel.Tests.Threading
-      timeout_x64: 120
-      timeout_arm64: 180
-      step_timeout_minutes: 10
+      # The scheduling-policy cells run three fixed CPU-share measurement
+      # windows on top of the lock/mutex waits, which TCG stretches further.
+      timeout_x64: 150
+      timeout_arm64: 240
+      step_timeout_minutes: 12
 
   threading-results:
     needs: threading-tests

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -20,9 +20,11 @@
     <WarningsAsErrors>$(WarningsAsErrors);RS0017</WarningsAsErrors>
     <!-- A tracked public surface must be documented: lift the repo-wide CS1591
          suppression (props set NoWarn to ";1591;CS1998;..." so the delimited
-         token is always ";1591;") and make missing XML docs a build error. -->
+         token is always ";1591;"). The error severity comes from the
+         .editorconfig [*.cs] section, not WarningsAsErrors, so it only reaches
+         files this repo's .editorconfig governs; sources linked from the
+         dotnet/runtime submodule keep their default severity. -->
     <NoWarn>$(NoWarn.Replace(';1591;', ';'))</NoWarn>
-    <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
   </PropertyGroup>
 
   <Target Name="EnforceKernelReferenceRules" BeforeTargets="BeforeBuild">

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,12 @@ setup:
 api:
 	dotnet format analyzers src/Cosmos.Kernel.System/Cosmos.Kernel.System.csproj \
 		--diagnostics RS0016 RS0017 --severity info
+	dotnet format analyzers src/Cosmos.Kernel.Core/Cosmos.Kernel.Core.csproj \
+		--diagnostics RS0016 RS0017 --severity info
+	dotnet format analyzers src/Cosmos.Kernel.HAL/Cosmos.Kernel.HAL.csproj \
+		--diagnostics RS0016 RS0017 --severity info
+	dotnet format analyzers src/Cosmos.Kernel.HAL.Interfaces/Cosmos.Kernel.HAL.Interfaces.csproj \
+		--diagnostics RS0016 RS0017 --severity info
 
 build:
 	dotnet publish -c Debug -r $(RID) \

--- a/docs/articles/dev/accessing-internals.md
+++ b/docs/articles/dev/accessing-internals.md
@@ -1,0 +1,55 @@
+# Accessing internals
+
+Everything outside the supported surface described in [Public API Tracking](public-api.md) is `internal` by design: visibility is not the extension mechanism, seams are. When no seam covers a need, `[UnsafeAccessor]` and `[UnsafeAccessorType]` reach internal state directly, without an `InternalsVisibleTo` grant. That hatch is deliberately available and deliberately unsupported: internals change in any release without notice, and code using them is expected to break.
+
+---
+
+## The mechanism
+
+`[UnsafeAccessor]` (`System.Runtime.CompilerServices`) declares an `extern` method that the runtime binds to an otherwise inaccessible member; `[UnsafeAccessorType]` extends it to types that are themselves inaccessible, addressed by assembly-qualified name. Both are resolved statically by ILC, so they are AOT-safe, unlike reflection, which the kernel cannot use.
+
+Accessing an internal static member of an internal type:
+
+```csharp
+using System.Runtime.CompilerServices;
+
+internal static class CoreAccessors
+{
+    // Binds to Cosmos.Kernel.Core.Memory.Heap.Heap.Collect(). The first
+    // parameter carries the target type by name and is passed as null for
+    // static members.
+    [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "Collect")]
+    internal static extern int HeapCollect(
+        [UnsafeAccessorType("Cosmos.Kernel.Core.Memory.Heap.Heap, Cosmos.Kernel.Core")] object? heap);
+}
+
+int freed = CoreAccessors.HeapCollect(null);
+```
+
+Accessing a private instance field of an accessible type:
+
+```csharp
+[UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_name")]
+private static extern ref string GetName(Partition partition);
+```
+
+`UnsafeAccessorKind` covers methods, static methods, constructors, and fields; property accessors are addressed as methods named `get_X`/`set_X`.
+
+---
+
+## Limits
+
+- **Byref returns of inaccessible types throw.** An accessor cannot `ref`-return a field whose own type is inaccessible to the declaring assembly; the runtime rejects it by spec. This is why `ThreadPlug` does not plug `Thread.CreateThread`: the upstream body reads the private `StartHelper`, whose type cannot be byref-returned, so the seam runs below it instead (see the comment in [ThreadPlug.cs](../../../src/Cosmos.Kernel.Plugs/System/Threading/ThreadPlug.cs)).
+- **Resolution failures surface at the call site**, not as a compile error: a renamed or removed target member turns the accessor into a throwing stub.
+- **Signatures must match exactly**, including custom modifiers on the rare members that carry them.
+
+---
+
+## When to use it
+
+In order of preference:
+
+1. The supported surface (`Cosmos.Kernel.System` plus the contract interfaces). If it is missing something a kernel legitimately needs, open an issue: extending the ring is the intended fix.
+2. An `[Experimental]` seam where one exists (the scheduler seam, [Scheduler - Writing a Scheduler](scheduler-plugging.md)).
+3. A [plug](plugs.md), when the goal is replacing behavior rather than reaching state.
+4. `[UnsafeAccessor]`/`[UnsafeAccessorType]`, accepting that any release may break it.

--- a/docs/articles/dev/coding-guidelines.md
+++ b/docs/articles/dev/coding-guidelines.md
@@ -20,6 +20,7 @@ This document establishes the coding style and architecture patterns for Cosmos 
 - [14. AOT Constraints](#14-aot-constraints)
 - [15. Documentation](#15-documentation)
 - [16. Testing](#16-testing)
+- [17. Public API Surface](#17-public-api-surface)
 
 ---
 
@@ -385,7 +386,7 @@ PlatformHAL.Initialize(new X64PlatformInitializer());
 
 ## 7. Plug System
 
-Plugs replace BCL methods at the IL level. The patcher rewires calls at build time. For full documentation on plug attributes (`[Plug]`, `[PlugMember]`, `[Expose]`, `[FieldAccess]`) and the plug template, see [Plugs](plugs.md).
+Plugs replace BCL methods at the IL level. The patcher rewires calls at build time. For full documentation on plug attributes (`[Plug]`, `[PlugMember]`, `[PlatformSpecific]`) and the plug template, see [Plugs](plugs.md).
 
 ### When to Use Plugs vs. Other Approaches
 
@@ -858,5 +859,30 @@ contextAddr = (contextAddr + 0xF) & ~(nuint)0xF;
 For the full testing guide (unit tests, kernel integration tests, UART protocol, CI, writing test kernels), see [Testing](testing.md).
 
 **Code coverage:** Add the `run-coverage` label to a PR to trigger the coverage CI. It runs the kernel test suites and outputs which code paths are covered by the integration tests.
+
+---
+
+## 17. Public API Surface
+
+Three rules decide what is `public` (the full policy and its mechanisms live in [Public API Tracking](public-api.md)):
+
+1. **One supported ring.** `Cosmos.Kernel.System` is the API kernels program against, plus the contract types its signatures expose (the `HAL.Interfaces` device interfaces, the `HAL.Vfs` contracts, Core's platform interfaces). Only that surface is tracked, documented, and covered by deprecation cycles.
+2. **Chosen experimental seams.** An extension point outside the ring is opened deliberately and marked `[Experimental("COSMOSxxxx")]`: usable now, no compatibility promise, promoted by removing the attribute. Never open a seam by just making something public.
+3. **Everything else is `internal`.** Visibility is not the extension mechanism. First-party assemblies and white-box test kernels use `InternalsVisibleTo`; external code uses `[UnsafeAccessor]` ([Accessing internals](accessing-internals.md)) at its own risk.
+
+Practical rules that follow:
+
+```csharp
+// Good: new user-facing capability lands as a Cosmos.Kernel.System facade
+public static class MemoryInfo { public static ulong FreePages => PageAllocator.FreePageCount; }
+
+// Bad: making the Core type public so a kernel can reach it
+public static class PageAllocator { ... }
+```
+
+- **New types default to `internal`.** Making a symbol `public` in a tracked project is a reviewed decision: the build fails (`RS0016`) until `make api` records it in `PublicAPI.Unshipped.txt`, and the txt diff belongs in the same commit.
+- **The enforcement test is DevKernel.** `examples/DevKernel` compiles with no `InternalsVisibleTo` grant; anything it needs must come from the supported ring.
+- **Tracked surface must be documented.** Enabling `CosmosTrackPublicApi` turns missing XML docs (`CS1591`) into build errors for the project's public symbols.
+- **A white-box test kernel gets an `InternalsVisibleTo` grant**, with a comment in the granting `.csproj` saying what it observes; it never forces a symbol public.
 
 ---

--- a/docs/articles/dev/plugs.md
+++ b/docs/articles/dev/plugs.md
@@ -1,115 +1,84 @@
-A **plug** is a mechanism that replaces existing methods, variables, or types with custom implementations to enable platform-specific functionality ([what is a plug?](https://cosmosos.github.io/articles/Kernel/Plugs.html)).
+# Plugs
 
-## Plug-related attributes
+A plug replaces members of an existing type at IL level: the patcher (`cosmos-patcher`, built on Mono.Cecil) rewrites the target assembly before ILC compiles it, so BCL and runtime code acquire kernel-specific implementations without source changes. The mechanism, the patcher pipeline, and where plugs run in the build are covered by the build pipeline docs; this page covers writing one.
+
+---
+
+## Attributes
+
+Gen3 implements three plug-related attributes, all defined in [Cosmos.Build.API](../../../src/Cosmos.Build.API/Attributes/):
+
+| Attribute | Applied to | Effect |
+|-----------|------------|--------|
+| `[Plug]` | class | Marks the class as the replacement source for one target type |
+| `[PlugMember]` | method, property, field | Replaces the matching member of the target type |
+| `[PlatformSpecific]` | class or member | Keeps the element only when patching for the named architectures |
 
 ### `[Plug]`
 
-Marks a class as the replacement for a target type. The attribute accepts the fully qualified name of the type to replace and optional flags to skip missing targets or substitute base implementations. See the definition in [PlugAttribute.cs](../../../src/Cosmos.Build.API/Attributes/PlugAttribute.cs) for details.
-
-**Use when:** creating a plug class that substitutes an existing type.
-
-**Pitfalls:** mismatched `TargetName` can break builds.
+Names the target type, either as `typeof(...)` when the type is publicly reachable or as a fully qualified name string for internal types (`[Plug("Internal.Runtime.CompilerHelpers.StartupCodeHelpers")]`). `IsOptional = true` skips the plug silently when the target type does not exist in the compilation; a mistyped `TargetName` on a non-optional plug fails the build. See [PlugAttribute.cs](../../../src/Cosmos.Build.API/Attributes/PlugAttribute.cs).
 
 ### `[PlugMember]`
 
-Indicates that a member should replace a member on the target type. The attribute can be applied to fields, properties, or methods. Its implementation is available in [PlugMemberAttribute.cs](../../../src/Cosmos.Build.API/Attributes/PlugMemberAttribute.cs).
+Replaces the target member that matches the plug member's name and signature. A string argument overrides the name matching, which is how constructors and property accessors are addressed: `[PlugMember(".ctor")]`, `[PlugMember("get_Address")]`. Signatures must match the target member exactly, with one addition for instance members described below; a mismatch means the patcher cannot wire the member up. See [PlugMemberAttribute.cs](../../../src/Cosmos.Build.API/Attributes/PlugMemberAttribute.cs).
 
-**Use when:** you need fine‑grained control over which members of the target type are replaced.
+### `[PlatformSpecific]`
 
-**Pitfalls:** ensure signatures match the target member; otherwise the patcher cannot wire them up correctly.
+Filters a plug class or member to specific architectures at patch time: `[PlatformSpecific(PlatformArchitecture.X64)]`. See [PlatformSpecificAttribute.cs](../../../src/Cosmos.Build.API/Attributes/PlatformSpecificAttribute.cs).
 
-### `[Expose]`
+---
 
-Adds new private members to the target type so that plugs can use them. The attribute is useful for introducing fields or methods that are not part of the original type.
+## The `aThis` convention
 
-**Use when:** a plug requires additional private storage or logic.
-
-**Pitfalls:** exposing members that conflict with existing names can cause unpredictable behavior.
-
-### `[FieldAccess]`
-
-Allows a plug method to access private fields of the target type by mapping a parameter to a specific field name. The patcher rewrites the method's IL to reference the requested field (see `ReplaceFieldAccess` in [PlugPatcher.cs](../../../src/Cosmos.Patcher/PlugPatcher.cs)).
-
-**Use when:** accessing or modifying an object field inside a plugged method.
-
-**Pitfalls:** incorrect field names or mismatched parameter types result in runtime failures when the patcher attempts to rewrite field accesses.
-
-## Cosmos gen3 plug template
-
-_Feel free to propose changes_
+Plug classes are static, so an instance member is plugged by a static method whose first parameter is the target instance, conventionally named `aThis`. The patcher rewires `this` references onto that parameter:
 
 ```csharp
-using System.IO;
+using System.Net;
+using Cosmos.Build.API.Attributes;
 
-namespace Cosmos.Plugs;
+namespace Cosmos.Kernel.Plugs.System.Net;
 
-[Plug(typeof(System.IO.FileStream))]
-public class FileStream
+[Plug(typeof(IPEndPoint))]
+public static class IPEndPointPlug
 {
-    /* Plug static fields from System.IO.FileStream */
+    [PlugMember(".ctor")]
+    public static void Ctor(IPEndPoint aThis, IPAddress address, int port)
+    {
+        // runs in place of the target constructor
+    }
+
+    [PlugMember("get_Address")]
+    public static IPAddress? get_Address(IPEndPoint aThis)
+    {
+        // runs in place of the property getter
+        return null;
+    }
+
     [PlugMember]
-    public static ulong StaticField
+    public static long Seek(IPEndPoint aThis, long offset)
     {
-         get; set;
+        // instance method: name and remaining signature match the target
+        return 0;
     }
 
-    /* Plug instance fields from System.IO.FileStream */
     [PlugMember]
-    public static ulong classInstanceField
-    {
-         get; set;
-    }
-
-    /* Add private static fields to plugged class */
-    [Expose]
-    private static ulong _privateStaticField;
-
-    /* Add private fields to plugged class */
-    [Expose]
-    private static ulong _privateInstanceField;
-
-    /* Add private static methods to plugged class */
-    [Expose]
-    private static void PrivateStaticMethod()
-    {
-    }
-
-    /* Add private objects methods to plugged class */
-    [Expose]
-    private static void PrivateInstanceMethod(FileStream aThis)
-    {
-        aThis.WriteByte('a');
-    }
-
-    /* Plug non static method with aThis to access fields */
-    [PlugMember]
-    public static long Seek(FileStream aThis, long offset, SeekOrigin origin)
-    {
-        PrivateMethod();
-        _privateInstanceField = 0;
-        aThis.WriteByte('a');
-        classStaticField = 0;
-        aThis.classInstanceField = 0; //or classInstanceField = 0;
-        // ...
-    }
-
-    /* Plug static method */
-    [PlugMember]
-    public static long StaticMethod()
-    {
-
-    }
-
-    /* Access private fields from plugged class */
-    [PlugMember]
-    public static long AccessFieldsMethod(FileStream aThis, [FieldAccess(Name = "InstanceField2")] ulong InstanceField2)
-    {
-        InstanceField2 = 0;
-    }
-
-    /* Assembly plug for System.IO.FileStream.WriteByte */
-    [PlugMember, RuntimeImport("asm_writebyte")]
-    public static void WriteByte(FileStream aThis, byte b);
-
+    public static bool StaticMethod() => true;   // static member: no aThis
 }
 ```
+
+---
+
+## Accessing private and internal state
+
+Gen2's `[Expose]` (inject new private members into the target type) and `[FieldAccess]` (bind a plug-method parameter to a private field of the target) are not implemented in the gen3 patcher; porting them is tracked in [#458](https://github.com/valentinbreiz/nativeaot-patcher/issues/458). Until then a plug has two options:
+
+- **Side storage.** Keep per-instance state in the plug class itself, keyed by the instance ([IPEndPointPlug.cs](../../../src/Cosmos.Kernel.Plugs/System/Net/IPEndPointPlug.cs) does this with dictionaries). This replaces the target's state entirely rather than reading it, so every member that touches the state must be plugged.
+- **`[UnsafeAccessor]` / `[UnsafeAccessorType]`.** The runtime's accessor mechanism reaches private and internal members directly. It is the unsupported escape hatch of the [public API policy](public-api.md); see [Accessing internals](accessing-internals.md) for what it can and cannot do (notably: it cannot byref-return a field whose type is itself inaccessible).
+
+---
+
+## Pitfalls
+
+- A plug whose `TargetName` does not resolve fails the build unless `IsOptional` is set; an optional plug that silently stops matching keeps compiling while the target runs unpatched, so prefer non-optional plugs for anything correctness-critical.
+- A `[Plug]` class whose members lack `[PlugMember]` patches nothing, and no error is raised: the class compiles, the target runs unpatched. This has produced real silent failures (an unplugged `NativeMemory` recursed into a triple fault), so check the attribute is on every member meant to replace something.
+- Signature mismatches (including a missing or mistyped `aThis` parameter) mean the member is not wired up.

--- a/docs/articles/dev/public-api.md
+++ b/docs/articles/dev/public-api.md
@@ -9,7 +9,7 @@ The public surface of the kernel packages is declared in text files checked into
 Three rules decide what is public:
 
 1. **One supported ring.** `Cosmos.Kernel.System` is the API kernels program against: tracked, documented, frozen at release, with deprecation cycles applying there and only there. Contract types that the ring's own signatures expose ride along as public: the device interfaces in `Cosmos.Kernel.HAL.Interfaces`, the VFS contracts in `Cosmos.Kernel.HAL.Vfs`, and the platform interfaces in `Cosmos.Kernel.Core` (`IPortIO`, `ICpuOps`, `IPowerOps`, `IInterruptController`).
-2. **Chosen experimental seams.** Extension points are opened deliberately and marked `[Experimental]`: public and usable now, no compatibility promise, promoted to stable by removing the attribute once proven. Referencing one is a build error until the consuming project suppresses its diagnostic ID, which is the consumer's acknowledgement of that contract. The scheduler policy seam in Core is the first; a driver kit in the HAL is the planned second.
+2. **Chosen experimental seams.** Extension points are opened deliberately and marked `[Experimental]`: public and usable now, no compatibility promise, promoted to stable by removing the attribute once proven. Referencing one is a build error until the consuming project suppresses its diagnostic ID, which is the consumer's acknowledgement of that contract. The scheduler policy seam in Core is the first, the packet seam in System is the second; a driver kit in the HAL is the planned third.
 3. **Everything else is internal.** Visibility is never the extension mechanism; seams are. First-party assemblies and the white-box test kernels reach internals through `InternalsVisibleTo`; anyone else goes through `[UnsafeAccessor]`/`[UnsafeAccessorType]` ([Accessing internals](accessing-internals.md)) and accepts that internals change without notice.
 
 The enforcement test is mechanical: `examples/DevKernel` must compile with no `InternalsVisibleTo` grant. If DevKernel needs a symbol, the symbol becomes public or gets a `Cosmos.Kernel.System` facade; if it does not, the symbol stays internal.
@@ -29,6 +29,7 @@ Experimental seams carry diagnostic IDs:
 | ID | Seam |
 |----|------|
 | `COSMOS0001` | The scheduler policy seam: `IScheduler`, `SchedulerManager`, `Thread`, `PerCpuState`, `SchedulerExtensible`, `ThreadState`, `ThreadFlags` ([Scheduler - Writing a Scheduler](scheduler-plugging.md)) |
+| `COSMOS0002` | The packet seam: the protocol packet types (`EthernetPacket`, ARP, `IPPacket`, ICMP, `UdpPacket`, DHCP, DNS, `TcpPacket`), `NetworkStack.Send`/`HandlePacket`, and the client members that take or return packets ([Network - Crafting packets](../user/network.md#crafting-packets)) |
 
 ---
 

--- a/docs/articles/dev/public-api.md
+++ b/docs/articles/dev/public-api.md
@@ -1,12 +1,40 @@
 # Public API Tracking
 
-The public surface of the kernel packages is declared in text files checked into the repository, enforced by Roslyn analyzers at build time, guarded against breaking changes at release time, and published as one frozen documentation site per release. This page describes the three mechanisms and the contributor workflow they impose.
+The public surface of the kernel packages is declared in text files checked into the repository, enforced by Roslyn analyzers at build time, guarded against breaking changes at release time, and published as one frozen documentation site per release. This page states the policy that decides what is public, then the three mechanisms and the contributor workflow they impose.
+
+---
+
+## The policy
+
+Three rules decide what is public:
+
+1. **One supported ring.** `Cosmos.Kernel.System` is the API kernels program against: tracked, documented, frozen at release, with deprecation cycles applying there and only there. Contract types that the ring's own signatures expose ride along as public: the device interfaces in `Cosmos.Kernel.HAL.Interfaces`, the VFS contracts in `Cosmos.Kernel.HAL.Vfs`, and the platform interfaces in `Cosmos.Kernel.Core` (`IPortIO`, `ICpuOps`, `IPowerOps`, `IInterruptController`).
+2. **Chosen experimental seams.** Extension points are opened deliberately and marked `[Experimental]`: public and usable now, no compatibility promise, promoted to stable by removing the attribute once proven. Referencing one is a build error until the consuming project suppresses its diagnostic ID, which is the consumer's acknowledgement of that contract. The scheduler policy seam in Core is the first; a driver kit in the HAL is the planned second.
+3. **Everything else is internal.** Visibility is never the extension mechanism; seams are. First-party assemblies and the white-box test kernels reach internals through `InternalsVisibleTo`; anyone else goes through `[UnsafeAccessor]`/`[UnsafeAccessorType]` ([Accessing internals](accessing-internals.md)) and accepts that internals change without notice.
+
+The enforcement test is mechanical: `examples/DevKernel` must compile with no `InternalsVisibleTo` grant. If DevKernel needs a symbol, the symbol becomes public or gets a `Cosmos.Kernel.System` facade; if it does not, the symbol stays internal.
+
+| Assembly | Surface |
+|----------|---------|
+| `Cosmos.Kernel.System` | The supported ring |
+| `Cosmos.Kernel.HAL.Interfaces` | Device and platform contracts, tracked |
+| `Cosmos.Kernel.HAL` | VFS contracts only, tracked; drivers, PCI, ports internal |
+| `Cosmos.Kernel.Core` | The scheduler seam (`[Experimental]`) plus the platform contract interfaces, tracked |
+| Arch assemblies, Native, Plugs, Debug, Boot.Limine | Internal, `InternalsVisibleTo` for first-party |
+
+The last row is policy rather than tracked enforcement: those assemblies are untracked, and their remaining public types shrink as they are touched.
+
+Experimental seams carry diagnostic IDs:
+
+| ID | Seam |
+|----|------|
+| `COSMOS0001` | The scheduler policy seam: `IScheduler`, `SchedulerManager`, `Thread`, `PerCpuState`, `SchedulerExtensible`, `ThreadState`, `ThreadFlags` ([Scheduler - Writing a Scheduler](scheduler-plugging.md)) |
 
 ---
 
 ## The declared surface
 
-Projects opt in with `<CosmosTrackPublicApi>true</CosmosTrackPublicApi>` in their `.csproj` (wired in `Directory.Build.props`). Today that covers `Cosmos.Kernel.System`; `Cosmos.Kernel.Core` and the HAL packages follow once their surfaces are audited.
+Projects opt in with `<CosmosTrackPublicApi>true</CosmosTrackPublicApi>` in their `.csproj` (wired in `Directory.Build.props`). That covers `Cosmos.Kernel.System`, `Cosmos.Kernel.Core`, `Cosmos.Kernel.HAL`, and `Cosmos.Kernel.HAL.Interfaces`.
 
 An opted-in project references [Microsoft.CodeAnalysis.PublicApiAnalyzers](https://github.com/dotnet/roslyn-analyzers/blob/main/src/PublicApiAnalyzers/PublicApiAnalyzers.Help.md), which requires every `public` symbol to appear in one of two files next to the `.csproj`:
 

--- a/docs/articles/dev/scheduler-plugging.md
+++ b/docs/articles/dev/scheduler-plugging.md
@@ -107,6 +107,10 @@ A FIFO queue with fixed-quantum preemption.
 
 FIFO order already bounds latency at `quantum * queue depth`, so Round-Robin needs no wakeup placement logic at all.
 
+This sketch exists in-tree as a working policy: [`RoundRobinScheduler`](../../../tests/Kernels/Cosmos.Kernel.Tests.Threading/RoundRobinScheduler.cs) lives in the Threading suite exactly as a user policy would, over the public seam only. The suite validates it two ways, and the split is worth copying. The run-structure invariants — tail enqueue, head pick, quantum accounting, block/yield/exit — are asserted by driving the hooks directly on a throwaway `PerCpuState` and `Thread`, which needs no timer and no dispatch and so cannot flake; the policy keeps all its state in the data slots, so a throwaway instance exercises the real logic. Only what genuinely needs a running kernel — that threads get dispatched, that a spinner is preempted at quantum expiry, that shares come out equal whatever priority is requested, that the run queue tracks blocking and waking — is measured live, after swapping the policy in at a quiescent point. Note what the live half deliberately does *not* assert: the order threads reach their delegate is not the order they became ready, because a thread preempted inside its dispatch preamble is re-queued at the tail.
+
+Two swap hazards are worth copying as well. `GetSchedulerData<T>` is a cast, so a policy installable after boot reads the slots with `as` instead — bookkeeping left by the previous policy (the boot thread keeps its Stride record across the swap) then degrades to `null`, which every hook already tolerates, rather than throwing in interrupt context. And the reverse direction has no such tolerance: the stock Stride policy hard-casts, so restoring it is only safe while no thread created under the outgoing policy is still alive, which the suite asserts before swapping back.
+
 ### Multi-Level Feedback Queue (MLFQ)
 
 Several priority levels; threads demote when they burn a full quantum and promote when they block early.

--- a/docs/articles/dev/scheduler-plugging.md
+++ b/docs/articles/dev/scheduler-plugging.md
@@ -4,9 +4,23 @@ This guide shows how to replace the kernel's scheduling policy. The mechanism si
 
 Replacing the policy takes three steps:
 
-1. Implement `IScheduler`, using the per-thread and per-CPU data slots for the algorithm's bookkeeping. The slots' setter is `internal`, so today a policy lives inside `Cosmos.Kernel.Core`, next to `Stride/`.
+1. Implement `IScheduler`, using the per-thread and per-CPU data slots for the algorithm's bookkeeping. The seam is public: a policy lives in your own kernel project, with no access to `Cosmos.Kernel.Core` internals.
 2. Respect the [kernel constraints](#kernel-constraints): the hooks run in interrupt context or under disabled interrupts, on live scheduler state.
 3. Install it with `SchedulerManager.SetScheduler(new MyScheduler())`. The manager calls `ShutdownCpu` on the outgoing policy and `InitializeCpu` on the incoming one for every CPU. Install at boot, before threads exist (as `LibraryInitializer` does): nothing migrates queued threads or their attached bookkeeping into the new policy, so a mid-flight swap strands them.
+
+---
+
+## Experimental status
+
+The seam types (`IScheduler`, `SchedulerManager`, `Thread`, `PerCpuState`, `SchedulerExtensible`, `ThreadState`, `ThreadFlags`) carry `[Experimental("COSMOS0001")]`: they are usable today but make no compatibility promise, and they are promoted to the stable surface by removing the attribute once proven. Referencing them is a build error until the project acknowledges that contract:
+
+```xml
+<PropertyGroup>
+  <NoWarn>$(NoWarn);COSMOS0001</NoWarn>
+</PropertyGroup>
+```
+
+See [Public API Tracking](public-api.md) for how experimental seams fit the surface policy.
 
 ---
 
@@ -30,8 +44,8 @@ Most hooks receive the `PerCpuState` they operate on, and run either under the m
 | `SelectCpu(thread, currentCpu, cpuCount)` | nothing yet | Choose a starting CPU for a thread; honor `ThreadFlags.Pinned` |
 | `OnThreadMigrate(thread, fromState, toState)` | `Balance` implementations | Move the thread's bookkeeping (and any virtual-time base) between CPUs |
 | `Balance(state, allCpuStates)` | nothing yet | Rebalance load across CPUs; honor `Pinned` |
-| `SetPriority(state, thread, priority)` / `GetPriority(thread)` | nothing in-tree today (a DevKernel diagnostic reads `GetPriority`) | Priority is policy-defined: Stride reads it as tickets, a real-time policy would read it as a priority level. Called under a spinlock, not with interrupts masked |
-| `GetRunQueueCount(state)` / `GetRunQueueThread(state, index)` | diagnostics | Read-only introspection of the run structure |
+| `SetPriority(state, thread, priority)` / `GetPriority(thread)` | nothing in-tree today (the `SchedulerInfo` facade reads `GetPriority`) | Priority is policy-defined: Stride reads it as tickets, a real-time policy would read it as a priority level. Called under a spinlock, not with interrupts masked |
+| `GetRunQueueCount(state)` / `GetRunQueueThread(state, index)` | `SchedulerInfo` diagnostics | Read-only introspection of the run structure; guard it yourself (see [kernel constraints](#kernel-constraints)) |
 
 `SelectCpu`, `Balance`, `OnPickFailed`, and `SetPriority` have no mechanism-side caller today (the kernel runs on one CPU, and nothing sets priorities yet). Implement them for completeness, but do not rely on them being exercised. Note also that `Name`, `SelectCpu`, and `GetPriority` receive no `PerCpuState`, and that `InitializeCpu`/`ShutdownCpu` run from `SetScheduler` under a plain spinlock, in thread context with interrupts enabled.
 
@@ -39,7 +53,7 @@ Most hooks receive the `PerCpuState` they operate on, and run either under the m
 
 ## Attaching state
 
-`Thread` and `PerCpuState` both inherit `SchedulerExtensible`, which carries exactly one `object?` slot, `SchedulerData`, reserved for the active policy. Its setter is `internal` to `Cosmos.Kernel.Core`, which is why a policy currently has to live in that assembly. Allocate in the creation hooks, read with the typed accessor, and tolerate `null` (a thread can exit between a tick and the hook that observes it):
+`Thread` and `PerCpuState` both inherit `SchedulerExtensible`, which carries exactly one `object?` slot, `SchedulerData`, reserved for the active policy. Allocate in the creation hooks, read with the typed accessor, and tolerate `null` (a thread can exit between a tick and the hook that observes it):
 
 ```csharp
 public sealed class MyThreadData { public ulong Deadline; }
@@ -67,7 +81,7 @@ The hooks run inside the kernel's most sensitive window, so four rules are not o
 - **You are in interrupt context.** `OnTick` and `PickNext` run inside the timer interrupt; the lifecycle hooks run under `DisableInterruptsScope` from whatever thread called the manager. Nothing may block, park, or wait in a hook.
 - **Do not allocate on the tick path.** Allocation is technically interrupt-safe in this kernel, but an allocation in `OnTick` or `PickNext` can trigger a collection inside the tick. Allocate in `OnThreadCreate` and `InitializeCpu`, where creation already pays for it, and pre-size collections there.
 - **No `List<T>.Remove`, `Contains`, or `IndexOf` on scheduler paths.** They route through `EqualityComparer<T>.Default`, which needs runtime helpers the kernel does not provide. Scan with `ReferenceEquals` and use `RemoveAt`, as `StrideScheduler.RemoveThreadFromQueue` does.
-- **Guard structure mutations against the tick.** A hook mutating the run structure can itself be interrupted by the timer unless interrupts are masked. The lifecycle hooks and the tick hooks get that masking from the manager, but `InitializeCpu`/`ShutdownCpu` and `SetPriority` do not (spinlocks only), and any *additional* entry point a policy exposes (a diagnostics read, a tuning setter) must take `InternalCpu.DisableInterruptsScope()` itself.
+- **Guard structure mutations against the tick.** A hook mutating the run structure can itself be interrupted by the timer unless interrupts are masked. The lifecycle hooks and the tick hooks get that masking from the manager, but `InitializeCpu`/`ShutdownCpu` and `SetPriority` do not (spinlocks only), and neither do the diagnostics hooks (`GetRunQueueCount`, `GetRunQueueThread`), which the `SchedulerInfo` facade calls from thread context. Those, and any *additional* entry point a policy exposes (a tuning setter, a stats read), must take `SchedulerManager.MaskInterrupts()` themselves.
 
 Bookkeeping the mechanism already does, so a policy does not have to: `Thread.State` transitions, the thread registry, `_needReschedule` on wakes, TLAB return on exit, and the idle-thread fallback when `PickNext` returns `null`.
 
@@ -159,5 +173,5 @@ The policy/mechanism split makes the framework a plausible base for a real-time 
 2. Pick the run structure (queue, sorted list, heap, multi-level). The mechanism only ever asks `PickNext`.
 3. Put the preemption decision, and nothing slow, in `OnTick`'s return value.
 4. Decide what survives a park: whatever `OnThreadBlocked` saves is what wakeup placement in `OnThreadReady` has to work with.
-5. Use `ReferenceEquals` scans, pre-sized collections, and `DisableInterruptsScope` on any entry the manager does not already guard.
+5. Use `ReferenceEquals` scans, pre-sized collections, and `SchedulerManager.MaskInterrupts()` on any entry the manager does not already guard.
 6. Implement `SelectCpu`, `OnThreadMigrate`, and `Balance` honoring `Pinned`, and treat them as dormant until SMP lands.

--- a/docs/articles/dev/toc.yml
+++ b/docs/articles/dev/toc.yml
@@ -10,6 +10,8 @@
   href: testing.md
 - name: Public API Tracking
   href: public-api.md
+- name: Public API - Accessing Internals
+  href: accessing-internals.md
 - name: Garbage Collector
   href: garbage-collector.md
 - name: Garbage Collector - Precise Stack Scan

--- a/docs/articles/user/network.md
+++ b/docs/articles/user/network.md
@@ -242,9 +242,55 @@ dnsClient.Close();
 <!-- screenshot: console showing github.com resolved to an IP address -->
 ![DNS](images/network-dns.png)
 
+## Crafting packets
+
+The packet types behind the clients are public as an experimental seam: a kernel can build protocol packets itself, transmit them through the stack, and receive the parsed packet objects instead of payload bytes. The seam carries the `COSMOS0002` diagnostic ([Public API Tracking](../dev/public-api.md)); referencing it is a build error until the kernel project acknowledges the missing compatibility promise:
+
+```xml
+<PropertyGroup>
+  <NoWarn>$(NoWarn);COSMOS0002</NoWarn>
+</PropertyGroup>
+```
+
+The seam has three parts:
+
+| Part | Members |
+|------|---------|
+| Packet types | `EthernetPacket`, `ArpRequestEthernet`/`ArpReplyEthernet`, `IPPacket`, `IcmpEchoRequest`/`IcmpEchoReply`, `UdpPacket`, `DhcpDiscover`/`DhcpRequest`/`DhcpRelease`, `DnsPacketAsk`/`DnsPacketAnswer`, `TcpPacket` |
+| Transmit and inject | `NetworkStack.Send(IPPacket)` queues a built packet with ARP resolution; `NetworkStack.HandlePacket` injects a raw frame into the receive path |
+| Packet-level client I/O | `UdpClient.Send(UdpPacket)` / `UdpClient.ReceivePacket(timeout)`, `IcmpClient.Send(IcmpPacket)` / `IcmpClient.ReceivePacket(timeout)` |
+
+A crafted echo request, correlated with its reply by the identifier and sequence number the caller chose:
+
+```csharp
+using Cosmos.Kernel.System.Network;
+using Cosmos.Kernel.System.Network.IPv4;
+
+IcmpClient icmp = new IcmpClient();
+icmp.Connect(gateway);
+
+IcmpEchoRequest request = new IcmpEchoRequest(localIp, gateway, id: 0x1234, sequence: 7);
+NetworkStack.Send(request);
+
+if (icmp.ReceivePacket(5000) is IcmpEchoReply reply
+    && reply.ICMPID == 0x1234 && reply.ICMPSequence == 7)
+{
+    Console.WriteLine("reply from " + reply.SourceIP.ToString());
+}
+
+icmp.Close();
+```
+
+The contract the packet types actually implement:
+
+- A build constructor writes the complete frame, including lengths and checksums, at construction time; nothing is recomputed later, so header bytes must not be modified after construction.
+- Header properties are snapshots parsed from `RawData` at construction; writing to `RawData` does not refresh them.
+- A parse constructor (`new XxxPacket(byte[])`) aliases the caller's array without copying.
+- `NetworkStack.Send` resolves the sending device from the packet's source IP and returns `false` when no configured interface matches it; the destination MAC is resolved by ARP unless the destination is a broadcast.
+- A custom IP protocol is a subclass of `IPPacket`: pass the protocol number and payload length to a build constructor and write the payload at `DataOffset`.
+
 ## Current limitations
 
-- ICMP is not implemented yet: no ping, in either direction.
 - `System.Net.Dns` is not plugged; use the Cosmos `DnsClient` shown above.
 - No TLS, so no `HttpClient`/HTTPS: raw TCP only.
 - One NIC: the stack talks to `NetworkManager.PrimaryDevice`.

--- a/examples/DevKernel/Commands/GraphicsCommands.cs
+++ b/examples/DevKernel/Commands/GraphicsCommands.cs
@@ -1,5 +1,5 @@
 using System;
-using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.System.Diagnostics;
 using DevKernel.Diagnostics;
 using DevKernel.Graphics;
 using DevKernel.Shell;
@@ -25,7 +25,7 @@ internal static class GraphicsCommands
                 Description = "Start graphics thread (draws color-cycling square)",
                 Execute = static (context, args) =>
                 {
-                    Serial.WriteString("[GfxThread] Starting graphics thread\n");
+                    Log.WriteString("[GfxThread] Starting graphics thread\n");
                     Terminal.Info("Starting graphics thread (draws color-cycling square)...");
 
                     ColorSquareWorker.Start();

--- a/examples/DevKernel/Commands/MemoryCommands.cs
+++ b/examples/DevKernel/Commands/MemoryCommands.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Collections.Generic;
-using Cosmos.Kernel.Core.Memory;
+using Cosmos.Kernel.System.Diagnostics;
 using DevKernel.Diagnostics;
 using DevKernel.Shell;
-using KernelHeap = Cosmos.Kernel.Core.Memory.Heap.Heap;
 
 namespace DevKernel.Commands;
 
@@ -40,7 +39,7 @@ internal static class MemoryCommands
                 Name = "free",
                 Usage = "free",
                 Description = "Force a heap collection and report freed objects",
-                Execute = static (context, args) => Terminal.Info(KernelHeap.Collect() + " objects collected."),
+                Execute = static (context, args) => Terminal.Info(MemoryInfo.Collect() + " objects collected."),
             },
             new ShellCommand
             {
@@ -68,10 +67,10 @@ internal static class MemoryCommands
     {
         Terminal.Header("Memory Information:");
 
-        ulong totalPages = PageAllocator.TotalPageCount;
-        ulong freePages = PageAllocator.FreePageCount;
+        ulong totalPages = MemoryInfo.TotalPages;
+        ulong freePages = MemoryInfo.FreePages;
         ulong usedPages = totalPages - freePages;
-        ulong pageSize = PageAllocator.PageSize;
+        ulong pageSize = MemoryInfo.PageSizeBytes;
 
         Terminal.InfoLine("Page Size", Units.ToKiB(pageSize).ToString() + " KB");
         Terminal.InfoLine("Total Pages", totalPages.ToString());

--- a/examples/DevKernel/Commands/NetworkCommands.cs
+++ b/examples/DevKernel/Commands/NetworkCommands.cs
@@ -1,6 +1,6 @@
 using System;
-using Cosmos.Kernel.Core.IO;
 using Cosmos.Kernel.HAL.Interfaces.Devices;
+using Cosmos.Kernel.System.Diagnostics;
 using Cosmos.Kernel.System.Network;
 using Cosmos.Kernel.System.Network.Config;
 using Cosmos.Kernel.System.Network.IPv4;
@@ -210,28 +210,28 @@ internal static class NetworkCommands
     /// <summary>Logs the full payload to serial, and a printable preview to the console.</summary>
     private static void PrintDatagram(EndPoint source, byte[] data)
     {
-        Serial.Write("[UDP] Received datagram from ");
-        Serial.WriteString(source.Address.ToString());
-        Serial.Write(":");
-        Serial.WriteNumber((ulong)source.Port);
-        Serial.Write(" -> port ");
-        Serial.WriteNumber((ulong)TestUdpPort);
-        Serial.Write("\n");
+        Log.Write("[UDP] Received datagram from ");
+        Log.WriteString(source.Address.ToString());
+        Log.Write(":");
+        Log.WriteNumber((ulong)source.Port);
+        Log.Write(" -> port ");
+        Log.WriteNumber((ulong)TestUdpPort);
+        Log.Write("\n");
 
-        Serial.Write("[UDP] Payload (");
-        Serial.WriteNumber((ulong)data.Length);
-        Serial.Write(" bytes): ");
+        Log.Write("[UDP] Payload (");
+        Log.WriteNumber((ulong)data.Length);
+        Log.Write(" bytes): ");
 
         for (int i = 0; i < data.Length; i++)
         {
             char c = (char)data[i];
             if (Ascii.IsPrintable(c))
             {
-                Serial.Write(c.ToString());
+                Log.Write(c.ToString());
             }
         }
 
-        Serial.Write("\n");
+        Log.Write("\n");
 
         Console.ForegroundColor = ConsoleColor.Magenta;
         Console.Write("[UDP] ");

--- a/examples/DevKernel/Commands/SchedulerCommands.cs
+++ b/examples/DevKernel/Commands/SchedulerCommands.cs
@@ -1,11 +1,8 @@
 using System;
-using Cosmos.Kernel.Core.IO;
-using Cosmos.Kernel.Core.Scheduler;
+using Cosmos.Kernel.System.Diagnostics;
 using Cosmos.Kernel.System.Timer;
 using DevKernel.Diagnostics;
 using DevKernel.Shell;
-using SchedThread = Cosmos.Kernel.Core.Scheduler.Thread;
-using SchedThreadState = Cosmos.Kernel.Core.Scheduler.ThreadState;
 using SysThread = System.Threading.Thread;
 
 namespace DevKernel.Commands;
@@ -73,8 +70,7 @@ internal static class SchedulerCommands
     {
         Terminal.Header("Scheduler Information:");
 
-        IScheduler? scheduler = SchedulerManager.Current;
-        if (scheduler == null)
+        if (!SchedulerInfo.IsInitialized)
         {
             Terminal.InfoLine("Status", "Not initialized");
             return;
@@ -82,35 +78,31 @@ internal static class SchedulerCommands
 
         Terminal.StatusLine(
             "Status",
-            SchedulerManager.Enabled ? "ENABLED" : "DISABLED",
-            SchedulerManager.Enabled ? ConsoleColor.Green : ConsoleColor.Red);
+            SchedulerInfo.IsRunning ? "ENABLED" : "DISABLED",
+            SchedulerInfo.IsRunning ? ConsoleColor.Green : ConsoleColor.Red);
 
-        Terminal.InfoLine("Scheduler", scheduler.Name);
-        Terminal.InfoLine("CPU Count", SchedulerManager.CpuCount.ToString());
-        Terminal.InfoLine("Quantum", (SchedulerManager.DefaultQuantumNs / Units.NsPerMs).ToString() + " ms");
+        Terminal.InfoLine("Scheduler", SchedulerInfo.SchedulerName!);
+        Terminal.InfoLine("CPU Count", SchedulerInfo.CpuCount.ToString());
+        Terminal.InfoLine("Quantum", (SchedulerInfo.QuantumNs / Units.NsPerMs).ToString() + " ms");
         Console.WriteLine();
 
-        for (uint cpuId = 0; cpuId < SchedulerManager.CpuCount; cpuId++)
+        for (uint cpuId = 0; cpuId < SchedulerInfo.CpuCount; cpuId++)
         {
-            PerCpuState cpuState = SchedulerManager.GetCpuState(cpuId);
-
             Console.ForegroundColor = ConsoleColor.Cyan;
             Console.WriteLine("  CPU " + cpuId + ":");
             Console.ResetColor();
 
-            SchedThread? currentThread = cpuState.CurrentThread;
-            if (currentThread != null)
+            if (SchedulerInfo.TryGetCurrentThread(cpuId, out KernelThreadInfo currentThread))
             {
-                PrintThreadInfo(scheduler, currentThread);
+                PrintThreadInfo(currentThread);
             }
 
-            int runQueueCount = scheduler.GetRunQueueCount(cpuState);
+            int runQueueCount = SchedulerInfo.GetRunQueueCount(cpuId);
             for (int i = 0; i < runQueueCount; i++)
             {
-                SchedThread? thread = scheduler.GetRunQueueThread(cpuState, i);
-                if (thread != null)
+                if (SchedulerInfo.TryGetRunQueueThread(cpuId, i, out KernelThreadInfo thread))
                 {
-                    PrintThreadInfo(scheduler, thread);
+                    PrintThreadInfo(thread);
                 }
             }
         }
@@ -118,29 +110,29 @@ internal static class SchedulerCommands
         Console.WriteLine();
     }
 
-    private static void PrintThreadInfo(IScheduler scheduler, SchedThread thread)
+    private static void PrintThreadInfo(KernelThreadInfo info)
     {
         Console.Write("    ");
         Console.ForegroundColor = ConsoleColor.White;
-        Console.Write("Thread " + thread.Id);
+        Console.Write("Thread " + info.Id);
 
         Console.Write(" ");
-        switch (thread.State)
+        switch (info.State)
         {
-            case SchedThreadState.Running:
+            case KernelThreadState.Running:
                 Console.ForegroundColor = ConsoleColor.Green;
                 Console.Write("Running");
                 break;
-            case SchedThreadState.Ready:
+            case KernelThreadState.Ready:
                 Console.ForegroundColor = ConsoleColor.Cyan;
                 Console.Write("Ready");
                 break;
-            case SchedThreadState.Blocked:
-            case SchedThreadState.Sleeping:
+            case KernelThreadState.Blocked:
+            case KernelThreadState.Sleeping:
                 Console.ForegroundColor = ConsoleColor.Yellow;
-                Console.Write(thread.State == SchedThreadState.Blocked ? "Blocked" : "Sleeping");
+                Console.Write(info.State == KernelThreadState.Blocked ? "Blocked" : "Sleeping");
                 break;
-            case SchedThreadState.Dead:
+            case KernelThreadState.Dead:
                 Console.ForegroundColor = ConsoleColor.Red;
                 Console.Write("Dead");
                 break;
@@ -150,14 +142,13 @@ internal static class SchedulerCommands
                 break;
         }
 
-        if (thread.SchedulerData != null)
+        if (info.HasPriority)
         {
-            long priority = scheduler.GetPriority(thread);
             Console.ForegroundColor = ConsoleColor.DarkGray;
-            Console.Write(" Pri=" + priority);
+            Console.Write(" Pri=" + info.Priority);
         }
 
-        ulong runtimeMs = thread.TotalRuntime / Units.NsPerMs;
+        ulong runtimeMs = info.TotalRuntimeNs / Units.NsPerMs;
         Console.ForegroundColor = ConsoleColor.DarkGray;
         Console.Write(" Run=" + runtimeMs + "ms");
 
@@ -167,12 +158,12 @@ internal static class SchedulerCommands
 
     private static void TestThread()
     {
-        Serial.WriteString("[Thread] Testing System.Threading.Thread API\n");
+        Log.WriteString("[Thread] Testing System.Threading.Thread API\n");
         Terminal.Info("Creating and starting a thread...");
 
         SysThread thread = new(static () =>
         {
-            Serial.WriteString("[Thread] Hello from thread delegate!\n");
+            Log.WriteString("[Thread] Hello from thread delegate!\n");
             Console.WriteLine("Hello from thread!");
         });
 
@@ -185,8 +176,7 @@ internal static class SchedulerCommands
 
     private static void KillThread(uint threadId)
     {
-        IScheduler? scheduler = SchedulerManager.Current;
-        if (scheduler == null)
+        if (!SchedulerInfo.IsInitialized)
         {
             Terminal.Error("Scheduler not initialized");
             return;
@@ -198,31 +188,23 @@ internal static class SchedulerCommands
             return;
         }
 
-        for (uint cpuId = 0; cpuId < SchedulerManager.CpuCount; cpuId++)
+        switch (SchedulerInfo.RequestKill(threadId))
         {
-            PerCpuState cpuState = SchedulerManager.GetCpuState(cpuId);
-
-            if (cpuState.CurrentThread?.Id == threadId)
-            {
+            case ThreadKillResult.Killed:
+                Terminal.Success("Thread " + threadId + " killed");
+                Console.WriteLine();
+                break;
+            case ThreadKillResult.MarkedForExit:
+                // The thread is already marked dead; the scheduler reaps it
+                // on its next reschedule.
                 Terminal.Warning("Cannot kill currently running thread");
-                cpuState.CurrentThread.State = SchedThreadState.Dead;
-                return;
-            }
-
-            int count = scheduler.GetRunQueueCount(cpuState);
-            for (int i = 0; i < count; i++)
-            {
-                SchedThread? thread = scheduler.GetRunQueueThread(cpuState, i);
-                if (thread?.Id == threadId)
-                {
-                    SchedulerManager.ExitThread(cpuId, thread);
-                    Terminal.Success("Thread " + threadId + " killed");
-                    Console.WriteLine();
-                    return;
-                }
-            }
+                break;
+            case ThreadKillResult.RefusedIdle:
+                Terminal.Error("Cannot kill idle thread (ID " + IdleThreadId + ")");
+                break;
+            default:
+                Terminal.Error("Thread " + threadId + " not found");
+                break;
         }
-
-        Terminal.Error("Thread " + threadId + " not found");
     }
 }

--- a/examples/DevKernel/Commands/SystemCommands.cs
+++ b/examples/DevKernel/Commands/SystemCommands.cs
@@ -1,5 +1,4 @@
 using System;
-using Cosmos.Kernel.Core.IO;
 using Cosmos.Kernel.System.Graphics;
 using Cosmos.Kernel.System.Timer;
 using DevKernel.Shell;

--- a/examples/DevKernel/Diagnostics/CpuStat.cs
+++ b/examples/DevKernel/Diagnostics/CpuStat.cs
@@ -2,10 +2,9 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.Threading;
-using Cosmos.Kernel.Core.Scheduler;
+using Cosmos.Kernel.System.Diagnostics;
 using Cosmos.Kernel.System.Graphics;
 using Cosmos.Kernel.System.Graphics.Fonts;
-using SchedThread = Cosmos.Kernel.Core.Scheduler.Thread;
 using SysThread = System.Threading.Thread;
 
 namespace DevKernel.Diagnostics;
@@ -31,7 +30,7 @@ internal static class CpuStat
 
     public static void Run()
     {
-        if (!SchedulerManager.IsEnabled)
+        if (!SchedulerInfo.IsSupported)
         {
             Console.WriteLine("cpustat: scheduler disabled (set CosmosEnableScheduler=true).");
             return;
@@ -47,7 +46,7 @@ internal static class CpuStat
 
         long lastWall = Stopwatch.GetTimestamp();
         long lastStepWall = lastWall;
-        ulong lastBusy = SchedulerManager.GetBusyCpuTimeNs();
+        ulong lastBusy = SchedulerInfo.BusyCpuTimeNs;
 
         int target = 0;
         int direction = +1;
@@ -118,9 +117,9 @@ internal static class CpuStat
                 }
             }
 
-            ulong busyNow = SchedulerManager.GetBusyCpuTimeNs();
+            ulong busyNow = SchedulerInfo.BusyCpuTimeNs;
             long wallDelta = nowWall - lastWall;
-            uint cpuCount = SchedulerManager.CpuCount;
+            uint cpuCount = SchedulerInfo.CpuCount;
             if (wallDelta > 0 && cpuCount > 0)
             {
                 ulong busyDelta = busyNow >= lastBusy ? busyNow - lastBusy : 0UL;
@@ -384,9 +383,8 @@ internal static class CpuStat
 
     private static void DrawRegistry(Canvas canvas, PCScreenFont font, int x, int y, int maxWidth, int maxHeight, int lh, int charW)
     {
-        SchedThread?[]? threads = SchedulerManager.Threads;
-        int regCount = SchedulerManager.ThreadCount;
-        if (threads == null || regCount <= 0)
+        int regCount = SchedulerInfo.ThreadCount;
+        if (regCount <= 0)
         {
             return;
         }
@@ -412,10 +410,9 @@ internal static class CpuStat
 
         int maxEntries = cols * rows;
         int drawn = 0;
-        for (int i = 0; i < threads.Length && drawn < maxEntries; i++)
+        for (int slot = 0; slot < SchedulerInfo.ThreadSlotCount && drawn < maxEntries; slot++)
         {
-            SchedThread? t = threads[i];
-            if (t == null)
+            if (!SchedulerInfo.TryGetThread(slot, out KernelThreadInfo info))
             {
                 continue;
             }
@@ -424,27 +421,27 @@ internal static class CpuStat
             int rowIdx = drawn / cols;
             int ex = x + colIdx * colW;
             int ey = gridY + rowIdx * lh;
-            DrawTruncated(canvas, font, FormatThread(t), Color.White, ex, ey, colW - charW);
+            DrawTruncated(canvas, font, FormatThread(info), Color.White, ex, ey, colW - charW);
             drawn++;
         }
     }
 
-    private static string FormatThread(SchedThread t)
+    private static string FormatThread(KernelThreadInfo info)
     {
-        string flag = (t.Flags & ThreadFlags.IdleThread) != 0 ? "idle"
-                    : (t.Flags & ThreadFlags.Managed) != 0 ? "mgd"
+        string flag = info.IsIdle ? "idle"
+                    : info.IsManaged ? "mgd"
                     : "krn";
-        string state = t.State switch
+        string state = info.State switch
         {
-            Cosmos.Kernel.Core.Scheduler.ThreadState.Running => "RUN",
-            Cosmos.Kernel.Core.Scheduler.ThreadState.Ready => "RDY",
-            Cosmos.Kernel.Core.Scheduler.ThreadState.Blocked => "BLK",
-            Cosmos.Kernel.Core.Scheduler.ThreadState.Sleeping => "SLP",
-            Cosmos.Kernel.Core.Scheduler.ThreadState.Dead => "DED",
-            Cosmos.Kernel.Core.Scheduler.ThreadState.Created => "NEW",
+            KernelThreadState.Running => "RUN",
+            KernelThreadState.Ready => "RDY",
+            KernelThreadState.Blocked => "BLK",
+            KernelThreadState.Sleeping => "SLP",
+            KernelThreadState.Dead => "DED",
+            KernelThreadState.Created => "NEW",
             _ => "???"
         };
-        return "T" + t.Id + " " + flag + " " + state + " " + FormatRuntime(t.TotalRuntime);
+        return "T" + info.Id + " " + flag + " " + state + " " + FormatRuntime(info.TotalRuntimeNs);
     }
 
     private static string FormatRuntime(ulong ns)

--- a/examples/DevKernel/Diagnostics/GcMonitor.cs
+++ b/examples/DevKernel/Diagnostics/GcMonitor.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Drawing;
 using System.Threading;
-using Cosmos.Kernel.Core.Memory;
+using Cosmos.Kernel.System.Diagnostics;
 using Cosmos.Kernel.System.Graphics;
 using Cosmos.Kernel.System.Graphics.Fonts;
 using DevKernel.Graphics;
-using KernelGc = Cosmos.Kernel.Core.Memory.GarbageCollector.GarbageCollector;
-using KernelHeap = Cosmos.Kernel.Core.Memory.Heap.Heap;
 
 namespace DevKernel.Diagnostics;
 
@@ -71,7 +69,7 @@ internal static class GcMonitor
             canvas.DrawString($"Size values are in bytes, ESC to exit;", font, Color.Cyan, x, rowY);
             rowY += lineHeight;
 
-            canvas.DrawString($"RamSize         : {PageAllocator.RamSize,ValueAlignment}", font, Color.White, x, rowY);
+            canvas.DrawString($"RamSize         : {MemoryInfo.RamSizeBytes,ValueAlignment}", font, Color.White, x, rowY);
             rowY += lineHeight;
             canvas.DrawString($"HeapSize        : {info.HeapSizeBytes,ValueAlignment}", font, Color.White, x, rowY);
             rowY += lineHeight;
@@ -98,8 +96,8 @@ internal static class GcMonitor
             canvas.DrawString($"Frag size delta : {fragAfter - fragBefore,ValueAlignment}", font, Color.Yellow, x, rowY);
             rowY += lineHeight;
 
-            int pct = KernelGc.GetLastGCPercentTimeInGC();
-            KernelGc.GetStats(out int totalCollections, out int totalObjectsFreed);
+            int pct = MemoryInfo.GcTimePercent;
+            MemoryInfo.GetGcStats(out int totalCollections, out int totalObjectsFreed);
             canvas.DrawString(
                 $"Last GC % time in GC: {pct,PercentAlignment}%, Collections: {totalCollections,CountAlignment}, Objects Freed: {totalObjectsFreed,CountAlignment}",
                 font,
@@ -109,7 +107,7 @@ internal static class GcMonitor
 
             if (frames % CollectFrameInterval == 0)
             {
-                KernelHeap.Collect();
+                MemoryInfo.Collect();
                 info = GC.GetGCMemoryInfo();
                 sizeBefore = info.GenerationInfo[Gen0Index].SizeBeforeBytes;
                 sizeAfter = info.GenerationInfo[Gen0Index].SizeAfterBytes;

--- a/examples/DevKernel/Diagnostics/SystemMonitor.cs
+++ b/examples/DevKernel/Diagnostics/SystemMonitor.cs
@@ -1,12 +1,9 @@
 using System.Diagnostics;
 using System.Drawing;
-using Cosmos.Kernel.Core.IO;
-using Cosmos.Kernel.Core.Memory;
+using Cosmos.Kernel.System.Diagnostics;
 using Cosmos.Kernel.System.Graphics;
 using Cosmos.Kernel.System.Graphics.Fonts;
 using DevKernel.Graphics;
-using KernelGc = Cosmos.Kernel.Core.Memory.GarbageCollector.GarbageCollector;
-using KernelHeap = Cosmos.Kernel.Core.Memory.Heap.Heap;
 using MouseManager = Cosmos.Kernel.System.Mouse.MouseManager;
 
 namespace DevKernel.Diagnostics;
@@ -36,7 +33,7 @@ internal static class SystemMonitor
         long frameInterval = swFrequency / refreshRate;
         long lastFrameStart = Stopwatch.GetTimestamp();
 
-        Serial.Write("Testing Canvas with mode " + canvas.Mode + " @ " + refreshRate + " Hz\n");
+        Log.Write("Testing Canvas with mode " + canvas.Mode + " @ " + refreshRate + " Hz\n");
 
         MouseManager.SetScreenSize((int)canvas.Mode.Width, (int)canvas.Mode.Height);
 
@@ -72,7 +69,7 @@ internal static class SystemMonitor
 
             if (frames % GcCollectFrameInterval == 0)
             {
-                KernelHeap.Collect();
+                MemoryInfo.Collect();
             }
 
             canvas.Display();
@@ -81,13 +78,13 @@ internal static class SystemMonitor
         }
     }
 
-    /// <summary>Draws the page-allocator counters; returns the next free row.</summary>
+    /// <summary>Draws the memory counters; returns the next free row.</summary>
     private static int DrawMemorySection(Canvas canvas, PCScreenFont font, int x, int rowY, int lineHeight)
     {
-        ulong totalPages = PageAllocator.TotalPageCount;
-        ulong freePages = PageAllocator.FreePageCount;
+        ulong totalPages = MemoryInfo.TotalPages;
+        ulong freePages = MemoryInfo.FreePages;
         ulong usedPages = totalPages - freePages;
-        ulong pageSize = PageAllocator.PageSize;
+        ulong pageSize = MemoryInfo.PageSizeBytes;
 
         canvas.DrawString("Meminfo", font, Color.Cyan, x, rowY);
         rowY += lineHeight;
@@ -104,7 +101,7 @@ internal static class SystemMonitor
     /// <summary>Draws the collector counters; returns the next free row.</summary>
     private static int DrawGcSection(Canvas canvas, PCScreenFont font, int x, int rowY, int lineHeight)
     {
-        KernelGc.GetStats(out int totalCollections, out int totalObjectsFreed);
+        MemoryInfo.GetGcStats(out int totalCollections, out int totalObjectsFreed);
 
         canvas.DrawString("GCinfo", font, Color.Cyan, x, rowY);
         rowY += lineHeight;

--- a/examples/DevKernel/Kernel.cs
+++ b/examples/DevKernel/Kernel.cs
@@ -1,5 +1,5 @@
 using System;
-using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.System.Diagnostics;
 using DevKernel.Commands;
 using DevKernel.Shell;
 using DevKernel.Storage;
@@ -21,7 +21,7 @@ public class Kernel : Sys.Kernel
 
     protected override void BeforeRun()
     {
-        Serial.WriteString("[DevKernel] BeforeRun() called\n");
+        Log.WriteString("[DevKernel] BeforeRun() called\n");
 
         FatBootstrap.RegisterAndAutoMount();
 
@@ -82,7 +82,7 @@ public class Kernel : Sys.Kernel
 
     protected override void AfterRun()
     {
-        Serial.WriteString("[DevKernel] AfterRun() called\n");
+        Log.WriteString("[DevKernel] AfterRun() called\n");
         Console.WriteLine("Goodbye!");
     }
 }

--- a/examples/DevKernel/Storage/FatBootstrap.cs
+++ b/examples/DevKernel/Storage/FatBootstrap.cs
@@ -1,6 +1,6 @@
-using Cosmos.Kernel.Core;
-using Cosmos.Kernel.Core.IO;
 using Cosmos.Kernel.HAL.Vfs;
+using Cosmos.Kernel.System;
+using Cosmos.Kernel.System.Diagnostics;
 using Cosmos.Kernel.System.Filesystems.Fat;
 using Cosmos.Kernel.System.Storage;
 using Cosmos.Kernel.System.Vfs;
@@ -25,31 +25,31 @@ internal static class FatBootstrap
     /// <summary>Registers the FAT driver and auto-mounts partition 0 when it holds a FAT volume.</summary>
     public static void RegisterAndAutoMount()
     {
-        if (!CosmosFeatures.FatEnabled)
+        if (!KernelFeatures.Fat)
         {
             return;
         }
 
         if (!VfsManager.RegisterFilesystem(DriverName, new FatFilesystemType()))
         {
-            Serial.WriteString("[DevKernel] FAT driver already registered or invalid\n");
+            Log.WriteString("[DevKernel] FAT driver already registered or invalid\n");
             return;
         }
 
-        Serial.WriteString("[DevKernel] FAT driver registered\n");
+        Log.WriteString("[DevKernel] FAT driver registered\n");
 
-        if (!CosmosFeatures.StorageEnabled || StorageManager.Partitions.Count == 0)
+        if (!KernelFeatures.Storage || StorageManager.Partitions.Count == 0)
         {
             return;
         }
 
         if (VfsManager.TryMount(DriverName, AutoMountSource, MountFlags.None, AutoMountPoint, out _))
         {
-            Serial.WriteString("[DevKernel] FAT mounted on /mnt from partition 0\n");
+            Log.WriteString("[DevKernel] FAT mounted on /mnt from partition 0\n");
         }
         else
         {
-            Serial.WriteString("[DevKernel] FAT mount on partition 0 skipped (not FAT or unreadable)\n");
+            Log.WriteString("[DevKernel] FAT mount on partition 0 skipped (not FAT or unreadable)\n");
         }
     }
 }

--- a/examples/DevKernel/Units.cs
+++ b/examples/DevKernel/Units.cs
@@ -12,7 +12,7 @@ internal static class Units
     public const ulong BytesPerMiB = BytesPerKiB * BytesPerKiB;
 
     /// <summary>Nanoseconds per millisecond, for converting scheduler times to ms (short alias of the kernel-wide constant).</summary>
-    public const ulong NsPerMs = Cosmos.Kernel.Core.Scheduler.SchedulerManager.NanosecondsPerMillisecond;
+    public const ulong NsPerMs = Cosmos.Kernel.System.Diagnostics.SchedulerInfo.NanosecondsPerMillisecond;
 
     /// <summary>Scale factor for expressing a ratio as a percentage.</summary>
     public const ulong PercentScale = 100;

--- a/src/Cosmos.Kernel.Core.ARM64/Cosmos.Kernel.Core.ARM64.csproj
+++ b/src/Cosmos.Kernel.Core.ARM64/Cosmos.Kernel.Core.ARM64.csproj
@@ -9,6 +9,8 @@
     <PackageProjectUrl>https://github.com/valentinbreiz/nativeaot-patcher</PackageProjectUrl>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <DefineConstants>$(DefineConstants);ARCH_ARM64</DefineConstants>
+    <!-- Feeds timer ticks into the experimental scheduler seam (COSMOS0001). -->
+    <NoWarn>$(NoWarn);COSMOS0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cosmos.Kernel.Core.ARM64/Cpu/ARM64InterruptController.cs
+++ b/src/Cosmos.Kernel.Core.ARM64/Cpu/ARM64InterruptController.cs
@@ -118,7 +118,7 @@ public class ARM64InterruptController : IInterruptController
     /// LPI must still be enabled in the redistributor's PROPBASER table by
     /// <see cref="GICv3Lpi"/> before it can fire. Throws on exhaustion.
     /// </summary>
-    public static uint AllocateLpi(InterruptManager.IrqDelegate handler)
+    internal static uint AllocateLpi(InterruptManager.IrqDelegate handler)
     {
         if (s_lpiHandlers == null)
         {

--- a/src/Cosmos.Kernel.Core.X64/Cosmos.Kernel.Core.X64.csproj
+++ b/src/Cosmos.Kernel.Core.X64/Cosmos.Kernel.Core.X64.csproj
@@ -9,6 +9,8 @@
     <PackageProjectUrl>https://github.com/valentinbreiz/nativeaot-patcher</PackageProjectUrl>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <DefineConstants>$(DefineConstants);ARCH_X64</DefineConstants>
+    <!-- Feeds timer ticks into the experimental scheduler seam (COSMOS0001). -->
+    <NoWarn>$(NoWarn);COSMOS0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cosmos.Kernel.Core/Bridge/Export/HeapNative.cs
+++ b/src/Cosmos.Kernel.Core/Bridge/Export/HeapNative.cs
@@ -6,7 +6,7 @@ namespace Cosmos.Kernel.Core.Bridge;
 /// <summary>
 /// Bridge functions that let C library code allocate from the Cosmos heap.
 /// </summary>
-public static unsafe class HeapNative
+internal static unsafe class HeapNative
 {
     /// <summary>
     /// Allocate memory from Cosmos heap

--- a/src/Cosmos.Kernel.Core/Bridge/Export/IrqNative.cs
+++ b/src/Cosmos.Kernel.Core/Bridge/Export/IrqNative.cs
@@ -7,7 +7,7 @@ namespace Cosmos.Kernel.Core.Bridge;
 /// Native entry point invoked from the architecture-specific IRQ assembly stubs.
 /// Forwards straight into <see cref="InterruptManager.Dispatch"/> — no indirection.
 /// </summary>
-public static unsafe class IrqNative
+internal static unsafe class IrqNative
 {
     [UnmanagedCallersOnly(EntryPoint = "__managed__irq")]
     public static void Handler(IRQContext* ctx)

--- a/src/Cosmos.Kernel.Core/Bridge/Export/LimineNative.cs
+++ b/src/Cosmos.Kernel.Core/Bridge/Export/LimineNative.cs
@@ -9,7 +9,7 @@ namespace Cosmos.Kernel.Core.Bridge;
 /// NOTE: This is a data accessor wrapper - C code gets managed data, then continues in C.
 /// We do NOT call C code from managed code - only provide data access.
 /// </summary>
-public static unsafe class LimineNative
+internal static unsafe class LimineNative
 {
     /// <summary>
     /// Wrapper to expose Limine RSDP address to C bootstrap for LAI ACPI initialization

--- a/src/Cosmos.Kernel.Core/Bridge/Export/MemNative.cs
+++ b/src/Cosmos.Kernel.Core/Bridge/Export/MemNative.cs
@@ -6,7 +6,7 @@ namespace Cosmos.Kernel.Core.Bridge;
 /// <summary>
 /// Bridge functions for memcpy / memcmp used by C library code.
 /// </summary>
-public static unsafe class MemNative
+internal static unsafe class MemNative
 {
     /// <summary>
     /// Copy memory using Cosmos MemoryOp.MemCopy

--- a/src/Cosmos.Kernel.Core/Bridge/Export/SerialNative.cs
+++ b/src/Cosmos.Kernel.Core/Bridge/Export/SerialNative.cs
@@ -8,7 +8,7 @@ namespace Cosmos.Kernel.Core.Bridge;
 /// NOTE: These are NOT called from C bootstrap (kmain.c) - only from library code.
 /// C bootstrap uses pure C implementations for clean architecture.
 /// </summary>
-public static unsafe class SerialNative
+internal static unsafe class SerialNative
 {
     /// <summary>
     /// Initialize serial port (COM1 at 115200 baud, 8N1)

--- a/src/Cosmos.Kernel.Core/Bridge/Export/ThreadNative.cs
+++ b/src/Cosmos.Kernel.Core/Bridge/Export/ThreadNative.cs
@@ -10,7 +10,7 @@ namespace Cosmos.Kernel.Core.Bridge;
 /// the scheduler's managed entry implementation. Thread-start registration lives
 /// in <see cref="SchedulerManager.RegisterThreadStart"/>.
 /// </summary>
-public static class ThreadNative
+internal static class ThreadNative
 {
     [UnmanagedCallersOnly]
     public static void EntryPointStub(IntPtr parameter)

--- a/src/Cosmos.Kernel.Core/CPU/IInterruptController.cs
+++ b/src/Cosmos.Kernel.Core/CPU/IInterruptController.cs
@@ -19,6 +19,9 @@ public interface IInterruptController
     /// <summary>
     /// Route a hardware IRQ to a specific vector.
     /// </summary>
+    /// <param name="irqNo">Hardware IRQ index (0-15 for ISA IRQs).</param>
+    /// <param name="vector">CPU interrupt vector the IRQ is delivered on.</param>
+    /// <param name="startMasked">If true, the IRQ starts masked and must be explicitly unmasked.</param>
     void RouteIrq(byte irqNo, byte vector, bool startMasked);
 
     /// <summary>
@@ -32,5 +35,6 @@ public interface IInterruptController
     /// looking up and invoking the registered handler, signalling EOI, and
     /// handling fatal CPU exceptions.
     /// </summary>
+    /// <param name="ctx">Register context captured by the interrupt stub.</param>
     void Dispatch(ref IRQContext ctx);
 }

--- a/src/Cosmos.Kernel.Core/CPU/IRQContext.cs
+++ b/src/Cosmos.Kernel.Core/CPU/IRQContext.cs
@@ -6,84 +6,157 @@ namespace Cosmos.Kernel.Core.CPU;
 
 #if ARCH_ARM64
 
+/// <summary>
+/// Register state saved by the ARM64 exception entry stub, as handed to
+/// interrupt and exception handlers
+/// (<see cref="IInterruptController.Dispatch"/>). The layout mirrors the
+/// stub's save order exactly; changing it requires changing the assembly.
+/// </summary>
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
 public struct IRQContext
 {
-    // General purpose registers x0-x30
+    /// <summary>Saved general-purpose register x0.</summary>
     public ulong x0;
+    /// <summary>Saved general-purpose register x1.</summary>
     public ulong x1;
+    /// <summary>Saved general-purpose register x2.</summary>
     public ulong x2;
+    /// <summary>Saved general-purpose register x3.</summary>
     public ulong x3;
+    /// <summary>Saved general-purpose register x4.</summary>
     public ulong x4;
+    /// <summary>Saved general-purpose register x5.</summary>
     public ulong x5;
+    /// <summary>Saved general-purpose register x6.</summary>
     public ulong x6;
+    /// <summary>Saved general-purpose register x7.</summary>
     public ulong x7;
+    /// <summary>Saved general-purpose register x8.</summary>
     public ulong x8;
+    /// <summary>Saved general-purpose register x9.</summary>
     public ulong x9;
+    /// <summary>Saved general-purpose register x10.</summary>
     public ulong x10;
+    /// <summary>Saved general-purpose register x11.</summary>
     public ulong x11;
+    /// <summary>Saved general-purpose register x12.</summary>
     public ulong x12;
+    /// <summary>Saved general-purpose register x13.</summary>
     public ulong x13;
+    /// <summary>Saved general-purpose register x14.</summary>
     public ulong x14;
+    /// <summary>Saved general-purpose register x15.</summary>
     public ulong x15;
+    /// <summary>Saved general-purpose register x16.</summary>
     public ulong x16;
+    /// <summary>Saved general-purpose register x17.</summary>
     public ulong x17;
+    /// <summary>Saved general-purpose register x18.</summary>
     public ulong x18;
+    /// <summary>Saved general-purpose register x19.</summary>
     public ulong x19;
+    /// <summary>Saved general-purpose register x20.</summary>
     public ulong x20;
+    /// <summary>Saved general-purpose register x21.</summary>
     public ulong x21;
+    /// <summary>Saved general-purpose register x22.</summary>
     public ulong x22;
+    /// <summary>Saved general-purpose register x23.</summary>
     public ulong x23;
+    /// <summary>Saved general-purpose register x24.</summary>
     public ulong x24;
+    /// <summary>Saved general-purpose register x25.</summary>
     public ulong x25;
+    /// <summary>Saved general-purpose register x26.</summary>
     public ulong x26;
+    /// <summary>Saved general-purpose register x27.</summary>
     public ulong x27;
+    /// <summary>Saved general-purpose register x28.</summary>
     public ulong x28;
-    public ulong x29;  // Frame pointer
-    public ulong x30;  // Link register
+    /// <summary>Saved frame pointer (x29).</summary>
+    public ulong x29;
+    /// <summary>Saved link register (x30).</summary>
+    public ulong x30;
 
-    public ulong sp;   // Stack pointer
-    public ulong elr;  // Exception link register (return address)
-    public ulong spsr; // Saved program status register
+    /// <summary>Interrupted stack pointer.</summary>
+    public ulong sp;
+    /// <summary>Exception link register: the return address (ELR_EL1).</summary>
+    public ulong elr;
+    /// <summary>Saved program status register (SPSR_EL1).</summary>
+    public ulong spsr;
 
-    public ulong interrupt;       // Exception type (0=sync, 1=irq, 2=fiq, 3=serror)
-    public ulong cpu_flags;       // ESR_EL1 (exception syndrome)
-    public ulong fault_address;   // FAR_EL1 (fault address for data/instruction aborts)
+    /// <summary>Exception type: 0 sync, 1 IRQ, 2 FIQ, 3 SError.</summary>
+    public ulong interrupt;
+    /// <summary>Exception syndrome (ESR_EL1).</summary>
+    public ulong cpu_flags;
+    /// <summary>Fault address for data/instruction aborts (FAR_EL1).</summary>
+    public ulong fault_address;
 }
 
 #else
 
+/// <summary>
+/// Register state saved by the x64 interrupt stub, as handed to interrupt
+/// and exception handlers (<see cref="IInterruptController.Dispatch"/>).
+/// The layout mirrors the stub's push order exactly; changing it requires
+/// changing the assembly.
+/// </summary>
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
 public struct IRQContext
 {
+    /// <summary>Saved general-purpose register r15.</summary>
     public ulong r15;
+    /// <summary>Saved general-purpose register r14.</summary>
     public ulong r14;
+    /// <summary>Saved general-purpose register r13.</summary>
     public ulong r13;
+    /// <summary>Saved general-purpose register r12.</summary>
     public ulong r12;
+    /// <summary>Saved general-purpose register r11.</summary>
     public ulong r11;
+    /// <summary>Saved general-purpose register r10.</summary>
     public ulong r10;
+    /// <summary>Saved general-purpose register r9.</summary>
     public ulong r9;
+    /// <summary>Saved general-purpose register r8.</summary>
     public ulong r8;
+    /// <summary>Saved general-purpose register rdi.</summary>
     public ulong rdi;
+    /// <summary>Saved general-purpose register rsi.</summary>
     public ulong rsi;
+    /// <summary>Saved frame pointer (rbp).</summary>
     public ulong rbp;
+    /// <summary>Saved general-purpose register rbx.</summary>
     public ulong rbx;
+    /// <summary>Saved general-purpose register rdx.</summary>
     public ulong rdx;
+    /// <summary>Saved general-purpose register rcx.</summary>
     public ulong rcx;
+    /// <summary>Saved general-purpose register rax.</summary>
     public ulong rax;
+    /// <summary>Interrupt vector number.</summary>
     public ulong interrupt;
+    /// <summary>RFLAGS, copied from the hardware interrupt frame by the stub.</summary>
     public ulong cpu_flags;
-    public ulong fault_address;  // CR2: page-fault linear address (valid for #PF, int 14)
+    /// <summary>CR2: page-fault linear address (valid for #PF, int 14).</summary>
+    public ulong fault_address;
 
     // The interrupt stub's frame continues past the info block (see ThreadContext.X64 /
     // Interrupts.s): the TempRcx scratch slot followed by the hardware interrupt frame.
     // Exposing them here lets exception handlers report the faulting RIP.
-    public ulong temp_rcx;       // context-switch scratch slot (zero otherwise)
-    public ulong rip;            // faulting/interrupted instruction pointer
-    public ulong cs;             // code segment selector
-    public ulong rflags;         // saved RFLAGS
-    public ulong rsp;            // interrupted stack pointer (always pushed in 64-bit mode)
-    public ulong ss;             // stack segment selector
+
+    /// <summary>Context-switch scratch slot (zero otherwise).</summary>
+    public ulong temp_rcx;
+    /// <summary>Faulting/interrupted instruction pointer.</summary>
+    public ulong rip;
+    /// <summary>Code segment selector.</summary>
+    public ulong cs;
+    /// <summary>Saved RFLAGS.</summary>
+    public ulong rflags;
+    /// <summary>Interrupted stack pointer (always pushed in 64-bit mode).</summary>
+    public ulong rsp;
+    /// <summary>Stack segment selector.</summary>
+    public ulong ss;
 }
 
 #endif

--- a/src/Cosmos.Kernel.Core/CPU/InternalCpu.cs
+++ b/src/Cosmos.Kernel.Core/CPU/InternalCpu.cs
@@ -9,7 +9,7 @@ namespace Cosmos.Kernel.Core.CPU;
 /// Low-level CPU operations that can be used by Core components like the heap.
 /// Native imports live in Bridge/Import/CpuNative.cs.
 /// </summary>
-public static class InternalCpu
+internal static class InternalCpu
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void DisableInterrupts() => CpuNative.DisableInterrupts();

--- a/src/Cosmos.Kernel.Core/CPU/InterruptManager.cs
+++ b/src/Cosmos.Kernel.Core/CPU/InterruptManager.cs
@@ -11,7 +11,7 @@ namespace Cosmos.Kernel.Core.CPU;
 /// is delegated to the platform <see cref="IInterruptController"/>
 /// implementation in Cosmos.Kernel.Core.X64 / Cosmos.Kernel.Core.ARM64.
 /// </summary>
-public static class InterruptManager
+internal static class InterruptManager
 {
     /// <summary>
     /// Interrupt delegate signature.

--- a/src/Cosmos.Kernel.Core/CPU/MsiRouting.cs
+++ b/src/Cosmos.Kernel.Core/CPU/MsiRouting.cs
@@ -27,7 +27,7 @@ namespace Cosmos.Kernel.Core.CPU;
 /// this file free of <c>HAL/Pci</c> dependencies — Core can't reference
 /// HAL upstream.
 /// </summary>
-public static class MsiRouting
+internal static class MsiRouting
 {
     private static IMsiBinder? s_binder;
 
@@ -79,7 +79,7 @@ public static class MsiRouting
 /// <summary>
 /// Platform-specific MSI binding backend. Implemented once per arch.
 /// </summary>
-public interface IMsiBinder
+internal interface IMsiBinder
 {
     /// <summary>True if the underlying interrupt controller is online and ready to route MSIs.</summary>
     bool IsAvailable { get; }

--- a/src/Cosmos.Kernel.Core/CompatibilitySuppressions.xml
+++ b/src/Cosmos.Kernel.Core/CompatibilitySuppressions.xml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <!-- PKV0001 "no compile time asset for net10.0": intentional. The multi-arch
+       package ships only runtimes/linux-{x64,arm64}/lib/ assemblies; the
+       build/{PackageId}.props selects the reference by RID at build time
+       (Directory.MultiArch.targets), so there is no RID-agnostic lib/ asset. -->
+  <Suppression>
+    <DiagnosticId>PKV0001</DiagnosticId>
+    <Target>net10.0</Target>
+  </Suppression>
+</Suppressions>

--- a/src/Cosmos.Kernel.Core/Cosmos.Kernel.Core.csproj
+++ b/src/Cosmos.Kernel.Core/Cosmos.Kernel.Core.csproj
@@ -85,6 +85,13 @@
     <!-- White-box scheduler suite reads Stride bookkeeping and drives the
          sync primitives directly. -->
     <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Threading" />
+    <!-- White-box suites over Core primitives: alarms (Timer), vector
+         allocation and MSI routing (Interrupts), copy routines and page
+         allocation (Memory), MMIO probes (Storage). -->
+    <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Timer" />
+    <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Interrupts" />
+    <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Memory" />
+    <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Storage" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cosmos.Kernel.Core/Cosmos.Kernel.Core.csproj
+++ b/src/Cosmos.Kernel.Core/Cosmos.Kernel.Core.csproj
@@ -17,6 +17,10 @@
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <!-- This assembly declares the experimental scheduler seam and consumes it itself. -->
     <NoWarn>$(NoWarn);COSMOS0001</NoWarn>
+
+    <!-- Public surface tracked in PublicAPI.Shipped/Unshipped.txt (see Directory.Build.props):
+         the scheduler seam plus the platform contract interfaces. -->
+    <CosmosTrackPublicApi>true</CosmosTrackPublicApi>
   </PropertyGroup>
 
   <!-- Architecture-specific source files (defines are set by Cosmos.ArchitecturePicker.props) -->
@@ -62,6 +66,31 @@
       <Link>Runtime\Internal\Runtime\ExceptionIDs.cs</Link>
     </Compile>
   </ItemGroup>
+
+  <!-- Sources linked from the dotnet/runtime submodule above declare upstream
+       public types with no XML docs. The submodule's root .editorconfig
+       shields them from this repo's .editorconfig, so the API-tracking and
+       doc-requirement exclusions are handed to the compiler as a generated
+       global analyzer config naming each linked file. -->
+  <Target Name="_CosmosVendoredAnalyzerConfig" BeforeTargets="CoreCompile">
+    <PropertyGroup>
+      <_VendoredGlobalConfigFile>$(IntermediateOutputPath)vendored.globalconfig</_VendoredGlobalConfigFile>
+    </PropertyGroup>
+    <ItemGroup>
+      <_VendoredCompile Include="@(Compile)"
+                        Condition="$([System.String]::Copy('%(Compile.FullPath)').Replace('\', '/').Contains('/dotnet/runtime/'))" />
+      <_VendoredConfigLine Include="is_global = true" />
+      <_VendoredConfigLine Include="[$([System.String]::Copy('%(_VendoredCompile.FullPath)').Replace('\', '/'))]%0adotnet_diagnostic.RS0016.severity = none%0adotnet_diagnostic.RS0017.severity = none%0adotnet_diagnostic.CS1591.severity = none" />
+    </ItemGroup>
+    <WriteLinesToFile File="$(_VendoredGlobalConfigFile)"
+                      Lines="@(_VendoredConfigLine)"
+                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true" />
+    <ItemGroup>
+      <EditorConfigFiles Include="$(_VendoredGlobalConfigFile)" />
+      <FileWrites Include="$(_VendoredGlobalConfigFile)" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Runtime" />

--- a/src/Cosmos.Kernel.Core/Cosmos.Kernel.Core.csproj
+++ b/src/Cosmos.Kernel.Core/Cosmos.Kernel.Core.csproj
@@ -15,6 +15,8 @@
     <RepositoryUrl>https://github.com/valentinbreiz/nativeaot-patcher</RepositoryUrl>
     <PackageProjectUrl>https://github.com/valentinbreiz/nativeaot-patcher</PackageProjectUrl>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+    <!-- This assembly declares the experimental scheduler seam and consumes it itself. -->
+    <NoWarn>$(NoWarn);COSMOS0001</NoWarn>
   </PropertyGroup>
 
   <!-- Architecture-specific source files (defines are set by Cosmos.ArchitecturePicker.props) -->
@@ -71,6 +73,18 @@
     <InternalsVisibleTo Include="Cosmos.Kernel.Plugs" />
     <!-- White-box GC tests drive the CFI unwinder through ExceptionHelper. -->
     <InternalsVisibleTo Include="Cosmos.Kernel.Tests.GarbageCollector" />
+    <!-- The aggregator bootstraps the scheduler (Initialize, CreateThread,
+         idle-thread setup) from its library initializer. -->
+    <InternalsVisibleTo Include="Cosmos.Kernel" />
+    <!-- System's supported ring fronts Core internals (Serial log, memory
+         stats, thread kill) so kernels never reference Core directly. -->
+    <InternalsVisibleTo Include="Cosmos.Kernel.System" />
+    <!-- Arch HALs feed timer ticks and IRQ plumbing into Core. -->
+    <InternalsVisibleTo Include="Cosmos.Kernel.HAL.X64" />
+    <InternalsVisibleTo Include="Cosmos.Kernel.HAL.ARM64" />
+    <!-- White-box scheduler suite reads Stride bookkeeping and drives the
+         sync primitives directly. -->
+    <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Threading" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cosmos.Kernel.Core/Cosmos.Kernel.Core.csproj
+++ b/src/Cosmos.Kernel.Core/Cosmos.Kernel.Core.csproj
@@ -37,18 +37,17 @@
     <Compile Remove="Runtime\ExceptionHandling\ExceptionHelper.X64.cs" />
   </ItemGroup>
 
+  <!-- The metadata readers, TypeHashingAlgorithms, and ExceptionIDs used to be
+       linked from here too, but upstream declares their types public with no
+       define to flip them. They are vendored under Runtime\Internal\ with a
+       visibility-only diff (public -> internal), same precedent as
+       ReadyToRunHeader.cs and TypeManagerHandle.cs. -->
   <ItemGroup>
     <Compile Include="$(ToolCommonPath)Internal\NativeFormat\*.cs">
       <Link>Runtime\Internal\NativeFormat\%(Filename).cs</Link>
     </Compile>
-    <Compile Include="$(ToolCommonPath)Internal\Metadata\NativeFormat\*.cs">
-      <Link>Runtime\Internal\NativeFormat\Metadata\%(Filename).cs</Link>
-    </Compile>
     <Compile Include="$(AotCommonPath)..\..\System.Private.StackTraceMetadata\src\Internal\StackTraceMetadata\MethodNameFormatter.cs">
       <Link>System.Private.StackTraceMetadata\Internal\StackTraceMetadata\MethodNameFormatter.cs</Link>
-    </Compile>
-    <Compile Include="$(ToolCommonPath)TypeSystem\Common\TypeHashingAlgorithms.cs">
-      <Link>TypeSystem\Common\TypeHashingAlgorithms.cs</Link>
     </Compile>
     <Compile Include="$(ToolCommonPath)Internal\Runtime\MetadataBlob.cs">
       <Link>Runtime\Internal\Runtime\MetadataBlob.cs</Link>
@@ -61,9 +60,6 @@
     </Compile>
     <Compile Include="$(AotCommonPath)Internal\Runtime\MethodTable.cs">
       <Link>Runtime\Internal\Runtime\MethodTable.cs</Link>
-    </Compile>
-    <Compile Include="$(AotRuntimeBasePath)System\Runtime\ExceptionIDs.cs">
-      <Link>Runtime\Internal\Runtime\ExceptionIDs.cs</Link>
     </Compile>
   </ItemGroup>
 

--- a/src/Cosmos.Kernel.Core/CosmosFeatures.cs
+++ b/src/Cosmos.Kernel.Core/CosmosFeatures.cs
@@ -7,7 +7,7 @@ namespace Cosmos.Kernel.Core;
 /// These flags can be set via RuntimeHostConfigurationOption in csproj
 /// and are used by ILC for trimming.
 /// </summary>
-public static class CosmosFeatures
+internal static class CosmosFeatures
 {
     /// <summary>
     /// Controls interrupt setup (IDT/IRQ). Disabling this also disables Timer, Keyboard,

--- a/src/Cosmos.Kernel.Core/Extensions/ByteArray.cs
+++ b/src/Cosmos.Kernel.Core/Extensions/ByteArray.cs
@@ -2,7 +2,7 @@
 
 namespace Cosmos.Kernel.Core.Extensions;
 
-public static class ByteArray
+internal static class ByteArray
 {
     public static byte Read8(this byte[] memory, uint offset)
     {

--- a/src/Cosmos.Kernel.Core/IO/EarlyGop.cs
+++ b/src/Cosmos.Kernel.Core/IO/EarlyGop.cs
@@ -9,7 +9,7 @@ namespace Cosmos.Kernel.Core.IO;
 /// Safe to call from the very first kernel instruction as long as Limine has filled in
 /// the framebuffer response (i.e. as soon as static fields are accessible).
 /// </summary>
-public static unsafe class EarlyGop
+internal static unsafe class EarlyGop
 {
     private static int s_col;
     private static int s_row;

--- a/src/Cosmos.Kernel.Core/IO/IPortIO.cs
+++ b/src/Cosmos.Kernel.Core/IO/IPortIO.cs
@@ -1,12 +1,51 @@
 namespace Cosmos.Kernel.Core.IO;
 
+/// <summary>
+/// Platform-specific port I/O. The x64 implementation issues in/out
+/// instructions; ARM64 has no I/O port space and maps port numbers onto
+/// an MMIO base instead.
+/// </summary>
 public interface IPortIO
 {
+    /// <summary>
+    /// Read one byte from an I/O port.
+    /// </summary>
+    /// <param name="port">I/O port address.</param>
+    /// <returns>The byte read from the port.</returns>
     byte ReadByte(ushort port);
+
+    /// <summary>
+    /// Read a 16-bit word from an I/O port.
+    /// </summary>
+    /// <param name="port">I/O port address.</param>
+    /// <returns>The word read from the port.</returns>
     ushort ReadWord(ushort port);
+
+    /// <summary>
+    /// Read a 32-bit dword from an I/O port.
+    /// </summary>
+    /// <param name="port">I/O port address.</param>
+    /// <returns>The dword read from the port.</returns>
     uint ReadDWord(ushort port);
 
+    /// <summary>
+    /// Write one byte to an I/O port.
+    /// </summary>
+    /// <param name="port">I/O port address.</param>
+    /// <param name="value">Byte to write.</param>
     void WriteByte(ushort port, byte value);
+
+    /// <summary>
+    /// Write a 16-bit word to an I/O port.
+    /// </summary>
+    /// <param name="port">I/O port address.</param>
+    /// <param name="value">Word to write.</param>
     void WriteWord(ushort port, ushort value);
+
+    /// <summary>
+    /// Write a 32-bit dword to an I/O port.
+    /// </summary>
+    /// <param name="port">I/O port address.</param>
+    /// <param name="value">Dword to write.</param>
     void WriteDWord(ushort port, uint value);
 }

--- a/src/Cosmos.Kernel.Core/IO/Serial.cs
+++ b/src/Cosmos.Kernel.Core/IO/Serial.cs
@@ -5,7 +5,7 @@ namespace Cosmos.Kernel.Core.IO;
 /// - x86-64: 16550 UART via port I/O (COM1 at 0x3F8)
 /// - ARM64: PL011 UART via MMIO (QEMU virt at 0x09000000)
 /// </summary>
-public static class Serial
+internal static class Serial
 {
     #region x86-64 16550 UART Constants
 

--- a/src/Cosmos.Kernel.Core/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
+++ b/src/Cosmos.Kernel.Core/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
@@ -8,7 +8,7 @@ namespace Internal.Runtime.CompilerHelpers
     /// <summary>
     /// This class is responsible for initializing the library and its dependencies. It is called by the runtime before any managed code is executed.
     /// </summary>
-    public class LibraryInitializer
+    internal class LibraryInitializer
     {
         /// <summary>
         /// Initialize all Core Elements of Cosmos, such as heap memory, garbage collector, and managed modules. This method is called by the runtime before any managed code is executed.

--- a/src/Cosmos.Kernel.Core/Memory/AddressSpace.cs
+++ b/src/Cosmos.Kernel.Core/Memory/AddressSpace.cs
@@ -5,7 +5,7 @@ namespace Cosmos.Kernel.Core.Memory;
 /// <summary>
 /// Virtual address-space layout constants shared across the kernel.
 /// </summary>
-public static class AddressSpace
+internal static class AddressSpace
 {
     /// <summary>
     /// Lowest canonical higher-half address (48-bit virtual addressing) — the start of

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/AllocContext.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/AllocContext.cs
@@ -9,7 +9,7 @@ namespace Cosmos.Kernel.Core.Memory.GarbageCollector;
 /// Stored inline on each <see cref="Scheduler.Thread"/> to provide contention-free allocation.
 /// </summary>
 [StructLayout(LayoutKind.Sequential)]
-public unsafe struct AllocContext
+internal unsafe struct AllocContext
 {
     /// <summary>
     /// Current allocation pointer within the TLAB. Advances toward <see cref="AllocLimit"/>.

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Alloc.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Alloc.cs
@@ -8,7 +8,7 @@ namespace Cosmos.Kernel.Core.Memory.GarbageCollector;
 /// <summary>
 /// Allocation methods: segment management, bump allocation, and free list operations.
 /// </summary>
-public static unsafe partial class GarbageCollector
+internal static unsafe partial class GarbageCollector
 {
     /// <summary>
     /// Aligns a size up to the nearest pointer-sized boundary.

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Frozen.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Frozen.cs
@@ -9,7 +9,7 @@ namespace Cosmos.Kernel.Core.Memory.GarbageCollector;
 /// <summary>
 /// Frozen segment registration: pre-initialized read-only objects that are never collected.
 /// </summary>
-public static unsafe partial class GarbageCollector
+internal static unsafe partial class GarbageCollector
 {
     // --- Nested types ---
 

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.GCHandler.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.GCHandler.cs
@@ -9,7 +9,7 @@ namespace Cosmos.Kernel.Core.Memory.GarbageCollector;
 /// <summary>
 /// GC handle table: allocation, freeing, and weak handle cleanup for Weak, Normal, and Pinned handles.
 /// </summary>
-public static unsafe partial class GarbageCollector
+internal static unsafe partial class GarbageCollector
 {
     /// <summary>
     /// Allocates a new GC handle for the specified object.

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Info.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Info.cs
@@ -515,9 +515,9 @@ internal static unsafe partial class GarbageCollector
                     SchedulerThread? thread = threads[i];
                     if (thread != null)
                     {
-                        if (thread.AllocContext.AllocLimit != null && thread.AllocContext.AllocPtr != null)
+                        if (thread._allocContext.AllocLimit != null && thread._allocContext.AllocPtr != null)
                         {
-                            unused += (ulong)(thread.AllocContext.AllocLimit - thread.AllocContext.AllocPtr);
+                            unused += (ulong)(thread._allocContext.AllocLimit - thread._allocContext.AllocPtr);
                         }
 
                         count--;

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Info.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Info.cs
@@ -13,7 +13,7 @@ namespace Cosmos.Kernel.Core.Memory.GarbageCollector;
 /// <summary>
 /// Information methods
 /// </summary>
-public static unsafe partial class GarbageCollector
+internal static unsafe partial class GarbageCollector
 {
     /// <summary>
     /// Simple snapshot of GC memory statistics used by runtime memory queries.

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Mark.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Mark.cs
@@ -14,7 +14,7 @@ namespace Cosmos.Kernel.Core.Memory.GarbageCollector;
 /// <summary>
 /// Mark phase: root scanning, reference enumeration, and mark stack management.
 /// </summary>
-public static unsafe partial class GarbageCollector
+internal static unsafe partial class GarbageCollector
 {
     /// <summary>
     /// Executes the mark phase: scans roots (stack, GC handles) and marks all reachable objects.

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.PinnedHeap.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.PinnedHeap.cs
@@ -9,7 +9,7 @@ namespace Cosmos.Kernel.Core.Memory.GarbageCollector;
 /// <summary>
 /// Pinned object heap: allocation, sweeping, and segment management for pinned objects.
 /// </summary>
-public static unsafe partial class GarbageCollector
+internal static unsafe partial class GarbageCollector
 {
     // --- Constants ---
 

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.PreciseStack.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.PreciseStack.cs
@@ -22,7 +22,7 @@ namespace Cosmos.Kernel.Core.Memory.GarbageCollector;
 /// can describe (asm entry stubs, native imports, IRQ entry — no CFI at all) or a frame's slot table
 /// is too large to decode.
 /// </summary>
-public static unsafe partial class GarbageCollector
+internal static unsafe partial class GarbageCollector
 {
     private const int MaxPreciseFrames = 256;
 

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Sweep.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Sweep.cs
@@ -9,7 +9,7 @@ namespace Cosmos.Kernel.Core.Memory.GarbageCollector;
 /// <summary>
 /// Sweep phase: segment sweeping and heap range helpers.
 /// </summary>
-public static unsafe partial class GarbageCollector
+internal static unsafe partial class GarbageCollector
 {
     /// <summary>
     /// Executes the sweep phase across the GC-managed heaps: GC segments and the

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Tlab.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Tlab.cs
@@ -11,7 +11,7 @@ namespace Cosmos.Kernel.Core.Memory.GarbageCollector;
 /// <summary>
 /// Thread-Local Allocation Buffer (TLAB) management: refill, return, and per-thread context access.
 /// </summary>
-public static unsafe partial class GarbageCollector
+internal static unsafe partial class GarbageCollector
 {
     /// <summary>
     /// Default TLAB size in bytes (8KB).

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Tlab.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Tlab.cs
@@ -33,7 +33,7 @@ internal static unsafe partial class GarbageCollector
             PerCpuState? cpuState = SchedulerManager.GetCpuState(SchedulerManager.GetCurrentCpuId());
             if (cpuState?.CurrentThread != null)
             {
-                return ref cpuState.CurrentThread.AllocContext;
+                return ref cpuState.CurrentThread._allocContext;
             }
         }
 
@@ -152,7 +152,7 @@ internal static unsafe partial class GarbageCollector
                     SchedulerThread? thread = threads[i];
                     if (thread != null)
                     {
-                        ReturnAllocContext(ref thread.AllocContext);
+                        ReturnAllocContext(ref thread._allocContext);
                         count--;
                     }
                 }

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.cs
@@ -16,7 +16,7 @@ namespace Cosmos.Kernel.Core.Memory.GarbageCollector;
 /// Mark-and-sweep garbage collector with free list allocation.
 /// Manages GC heap segments, pinned heap, frozen segments, and GC handles.
 /// </summary>
-public static unsafe partial class GarbageCollector
+internal static unsafe partial class GarbageCollector
 {
     // --- Nested types ---
 

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GcInfo/GcInfoBitStreamReader.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GcInfo/GcInfoBitStreamReader.cs
@@ -11,7 +11,7 @@ namespace Cosmos.Kernel.Core.Memory.GarbageCollector.GcInfo;
 /// Reads a GCInfo bit stream. Mutable struct — pass by <c>ref</c> for sequential reads;
 /// copy by value to fork an independent cursor (matches <c>BitStreamReader</c>'s copy semantics).
 /// </summary>
-public unsafe struct GcInfoBitStreamReader
+internal unsafe struct GcInfoBitStreamReader
 {
     private const int BitsPerWord = 64;
 

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GcInfo/GcInfoDecoder.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GcInfo/GcInfoDecoder.cs
@@ -16,7 +16,7 @@ using Cosmos.Kernel.Core.Runtime;
 namespace Cosmos.Kernel.Core.Memory.GarbageCollector.GcInfo;
 
 /// <summary>Decodes one method's GCInfo blob. Construct, then query / <see cref="EnumerateLiveSlots"/>.</summary>
-public unsafe struct GcInfoDecoder
+internal unsafe struct GcInfoDecoder
 {
     private const uint NO_STACK_BASE_REGISTER = 0xFFFFFFFF;
 

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GcInfo/GcInfoTypes.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GcInfo/GcInfoTypes.cs
@@ -14,7 +14,7 @@ namespace Cosmos.Kernel.Core.Memory.GarbageCollector.GcInfo;
 
 /// <summary>Flags controlling which parts of a GCInfo blob the decoder pre-decodes.</summary>
 [Flags]
-public enum GcInfoDecoderFlags : uint
+internal enum GcInfoDecoderFlags : uint
 {
     DECODE_EVERYTHING = 0x0,
     DECODE_SECURITY_OBJECT = 0x01,
@@ -34,7 +34,7 @@ public enum GcInfoDecoderFlags : uint
 
 /// <summary>Flags stored at the start of a (fat) GCInfo header.</summary>
 [Flags]
-public enum GcInfoHeaderFlags : uint
+internal enum GcInfoHeaderFlags : uint
 {
     GC_INFO_HAS_GS_COOKIE = 0x4,
     GC_INFO_HAS_GENERICS_INST_CONTEXT_MASK = 0x30,
@@ -54,7 +54,7 @@ public enum GcInfoHeaderFlags : uint
 
 /// <summary>Per-slot flags decoded from the 2-bit field in the slot table (matches GcSlotFlags / GC_CALL_*).</summary>
 [Flags]
-public enum GcSlotFlags
+internal enum GcSlotFlags
 {
     GC_SLOT_BASE = 0x0,
     GC_SLOT_INTERIOR = 0x1,   // == GC_CALL_INTERIOR
@@ -63,7 +63,7 @@ public enum GcSlotFlags
 }
 
 /// <summary>Stack-slot base register kind (matches GcStackSlotBase).</summary>
-public enum GcStackSlotBase
+internal enum GcStackSlotBase
 {
     GC_CALLER_SP_REL = 0x0,
     GC_SP_REL = 0x1,
@@ -72,7 +72,7 @@ public enum GcStackSlotBase
 
 /// <summary>Per-frame flags passed to <see cref="GcInfoDecoder.EnumerateLiveSlots"/> (subset of ICodeManagerFlags).</summary>
 [Flags]
-public enum CodeManagerFlags : uint
+internal enum CodeManagerFlags : uint
 {
     None = 0,
     ActiveStackFrame = 0x0001, // currently-active (leaf) frame
@@ -83,14 +83,14 @@ public enum CodeManagerFlags : uint
 }
 
 /// <summary>GC reference flags reported to the enum callback (matches GC_CALL_INTERIOR / GC_CALL_PINNED).</summary>
-public static class GcRefFlags
+internal static class GcRefFlags
 {
     public const uint GC_CALL_INTERIOR = 0x1;
     public const uint GC_CALL_PINNED = 0x2;
 }
 
 /// <summary>One decoded slot-table entry: a register, or a (base,offset) stack location.</summary>
-public struct GcSlotDesc
+internal struct GcSlotDesc
 {
     public uint RegisterNumber;     // valid when IsRegister
     public int SpOffset;            // valid when !IsRegister; denormalized (bytes)
@@ -108,7 +108,7 @@ public struct GcSlotDesc
 /// Architecture-specific GCInfo encoding parameters (the AMD64GcInfoEncoding / ARM64GcInfoEncoding
 /// constants from gcinfotypes.h). Format version is fixed at <see cref="GCINFO_VERSION"/>.
 /// </summary>
-public static class GcInfoEncoding
+internal static class GcInfoEncoding
 {
     /// <summary>The GCInfo format version this decoder understands (GCINFO_VERSION in gcinfo.h).</summary>
     public const uint GCINFO_VERSION = 4;

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GcInfo/GcSlotTable.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GcInfo/GcSlotTable.cs
@@ -10,7 +10,7 @@ using Cosmos.Kernel.Core.IO;
 namespace Cosmos.Kernel.Core.Memory.GarbageCollector.GcInfo;
 
 /// <summary>Decoded GCInfo slot table for a single method. Backs onto caller-supplied storage.</summary>
-public unsafe struct GcSlotTable
+internal unsafe struct GcSlotTable
 {
     private GcSlotDesc* _slots;
     private uint _capacity;

--- a/src/Cosmos.Kernel.Core/Memory/Heap/Heap.cs
+++ b/src/Cosmos.Kernel.Core/Memory/Heap/Heap.cs
@@ -6,7 +6,7 @@ namespace Cosmos.Kernel.Core.Memory.Heap;
 /// <summary>
 /// a basic Heap that uses PageAllocator
 /// </summary>
-public static unsafe class Heap
+internal static unsafe class Heap
 {
     /// <summary>
     /// Re-allocates or "re-sizes" data asigned to a pointer.

--- a/src/Cosmos.Kernel.Core/Memory/Heap/LargeHeap.cs
+++ b/src/Cosmos.Kernel.Core/Memory/Heap/LargeHeap.cs
@@ -5,7 +5,7 @@ namespace Cosmos.Kernel.Core.Memory.Heap;
 /// <summary>
 /// will use more then 1 page
 /// </summary>
-public static unsafe class LargeHeap
+internal static unsafe class LargeHeap
 {
     public static ulong PrefixBytes => (ulong)sizeof(LargeHeapHeader);
 

--- a/src/Cosmos.Kernel.Core/Memory/Heap/LargeHeapHeader.cs
+++ b/src/Cosmos.Kernel.Core/Memory/Heap/LargeHeapHeader.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.Core.Memory.Heap;
 
 [StructLayout(LayoutKind.Sequential)]
-public struct LargeHeapHeader
+internal struct LargeHeapHeader
 {
     public ulong Used;
     public uint Size;

--- a/src/Cosmos.Kernel.Core/Memory/Heap/MediumHeap.cs
+++ b/src/Cosmos.Kernel.Core/Memory/Heap/MediumHeap.cs
@@ -5,7 +5,7 @@ namespace Cosmos.Kernel.Core.Memory.Heap;
 /// <summary>
 /// will mostly fill a whole page
 /// </summary>
-public static unsafe class MediumHeap
+internal static unsafe class MediumHeap
 {
     public static ulong PrefixBytes => (ulong)sizeof(MediumHeapHeader);
 

--- a/src/Cosmos.Kernel.Core/Memory/Heap/MediumHeapHeader.cs
+++ b/src/Cosmos.Kernel.Core/Memory/Heap/MediumHeapHeader.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.Core.Memory.Heap;
 
 [StructLayout(LayoutKind.Sequential)]
-public struct MediumHeapHeader
+internal struct MediumHeapHeader
 {
     public ushort Size;
 }

--- a/src/Cosmos.Kernel.Core/Memory/Heap/SmallHeap.cs
+++ b/src/Cosmos.Kernel.Core/Memory/Heap/SmallHeap.cs
@@ -8,7 +8,7 @@ namespace Cosmos.Kernel.Core.Memory.Heap;
 /// <summary>
 /// Page containing Size Map Table
 /// </summary>
-public unsafe struct SMTPage
+internal unsafe struct SMTPage
 {
     /// <summary>
     /// Pointer to the next page
@@ -21,7 +21,7 @@ public unsafe struct SMTPage
     public RootSMTBlock* First;
 }
 
-public unsafe struct RootSMTBlock
+internal unsafe struct RootSMTBlock
 {
     /// <summary>
     /// Elements stored in the page have a size less or equal to this
@@ -41,7 +41,7 @@ public unsafe struct RootSMTBlock
 }
 
 // Changing the ordering will break SMTBlock* NextFreeBlock(SMTPage* aPage)
-public unsafe struct SMTBlock
+internal unsafe struct SMTBlock
 {
     /// <summary>
     /// Pointer to the actual page, where the elements are stored
@@ -59,7 +59,7 @@ public unsafe struct SMTBlock
     public SMTBlock* NextBlock;
 }
 
-public static unsafe class SmallHeap
+internal static unsafe class SmallHeap
 {
     public static ulong MaxSize => PageAllocator.PageSize / 2 - 1;
 

--- a/src/Cosmos.Kernel.Core/Memory/Heap/SmallHeapHeader.cs
+++ b/src/Cosmos.Kernel.Core/Memory/Heap/SmallHeapHeader.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.Core.Memory.Heap;
 
 [StructLayout(LayoutKind.Sequential)]
-public struct SmallHeapHeader
+internal struct SmallHeapHeader
 {
     public ushort Size;
 }

--- a/src/Cosmos.Kernel.Core/Memory/ManagedMemoryBlock.cs
+++ b/src/Cosmos.Kernel.Core/Memory/ManagedMemoryBlock.cs
@@ -5,7 +5,7 @@ namespace Cosmos.Kernel.Core.Memory;
 /// <summary>
 /// ManagedMemoryBlock class. Used to read and write a managed memory block.
 /// </summary>
-public unsafe class ManagedMemoryBlock
+internal unsafe class ManagedMemoryBlock
 {
     private readonly byte[] _array;
     private readonly Memory<byte> _memory;

--- a/src/Cosmos.Kernel.Core/Memory/MemoryBlock.cs
+++ b/src/Cosmos.Kernel.Core/Memory/MemoryBlock.cs
@@ -6,7 +6,7 @@ namespace Cosmos.Kernel.Core.Memory;
 /// <summary>
 /// MemoryBlock class. Used to read and write to memory blocks.
 /// </summary>
-public class MemoryBlock
+internal class MemoryBlock
 {
     /// <summary>
     /// Memory block base address.
@@ -466,7 +466,7 @@ public class MemoryBlock
 /// <summary>
 /// MemoryBlock08 class.
 /// </summary>
-public class MemoryBlock08
+internal class MemoryBlock08
 {
     /// <summary>
     /// Base.
@@ -518,7 +518,7 @@ public class MemoryBlock08
 /// <summary>
 /// MemoryBlock16 class.
 /// </summary>
-public class MemoryBlock16
+internal class MemoryBlock16
 {
     /// <summary>
     /// Base.
@@ -571,7 +571,7 @@ public class MemoryBlock16
 /// <summary>
 /// MemoryBlock32 class.
 /// </summary>
-public class MemoryBlock32
+internal class MemoryBlock32
 {
     /// <summary>
     /// Base.

--- a/src/Cosmos.Kernel.Core/Memory/MemoryOp.cs
+++ b/src/Cosmos.Kernel.Core/Memory/MemoryOp.cs
@@ -5,7 +5,7 @@ namespace Cosmos.Kernel.Core.Memory;
 /// <summary>
 /// Native SIMD imports live in Bridge/Import/SimdNative.cs.
 /// </summary>
-public static unsafe class MemoryOp
+internal static unsafe class MemoryOp
 {
     public static void InitializeHeap(ulong heapBase, ulong heapSize) =>
         PageAllocator.InitializeHeap((byte*)heapBase, heapSize);

--- a/src/Cosmos.Kernel.Core/Memory/PageAllocator.cs
+++ b/src/Cosmos.Kernel.Core/Memory/PageAllocator.cs
@@ -7,7 +7,7 @@ namespace Cosmos.Kernel.Core.Memory;
 /// <summary>
 /// a basic page allocator
 /// </summary>
-public static unsafe class PageAllocator
+internal static unsafe class PageAllocator
 {
     /// <summary>
     /// Native Intel page size.

--- a/src/Cosmos.Kernel.Core/Memory/PageType.cs
+++ b/src/Cosmos.Kernel.Core/Memory/PageType.cs
@@ -4,7 +4,7 @@ namespace Cosmos.Kernel.Core.Memory;
 /// PageType enum. Used to define the type of the page.
 /// Data Types from 1, special meanings from 255 down.
 /// </summary>
-public enum PageType : byte
+internal enum PageType : byte
 {
     /// <summary>
     /// Empty page.

--- a/src/Cosmos.Kernel.Core/Memory/Panics.cs
+++ b/src/Cosmos.Kernel.Core/Memory/Panics.cs
@@ -3,7 +3,7 @@ namespace Cosmos.Kernel.Core.Memory;
 /// <summary>
 /// panics used be the Memory sub system
 /// </summary>
-public static class Panics
+internal static class Panics
 {
     /// <summary>
     /// this page is not managed by a heap backend

--- a/src/Cosmos.Kernel.Core/Native.cs
+++ b/src/Cosmos.Kernel.Core/Native.cs
@@ -9,7 +9,7 @@ namespace Cosmos.Kernel.Core;
 /// Native low-level hardware access primitives.
 /// Architecture-specific implementations for I/O operations.
 /// </summary>
-public static class Native
+internal static class Native
 {
     /// <summary>
     /// x86-64 Port I/O operations.

--- a/src/Cosmos.Kernel.Core/Panic.cs
+++ b/src/Cosmos.Kernel.Core/Panic.cs
@@ -7,7 +7,7 @@ namespace Cosmos.Kernel.Core;
 /// <summary>
 /// Kernel panic handler for fatal errors.
 /// </summary>
-public static class Panic
+internal static class Panic
 {
     /// <summary>
     /// Triggers a kernel panic with the specified message.

--- a/src/Cosmos.Kernel.Core/PublicAPI.Shipped.txt
+++ b/src/Cosmos.Kernel.Core/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Cosmos.Kernel.Core/PublicAPI.Unshipped.txt
+++ b/src/Cosmos.Kernel.Core/PublicAPI.Unshipped.txt
@@ -18,10 +18,6 @@ Cosmos.Kernel.Core.IO.IPortIO.WriteWord(ushort port, ushort value) -> void
 Cosmos.Kernel.Core.Power.IPowerOps
 Cosmos.Kernel.Core.Power.IPowerOps.Reboot() -> void
 Cosmos.Kernel.Core.Power.IPowerOps.Shutdown() -> void
-Cosmos.Kernel.Core.Runtime.AmbiguousImplementationException
-Cosmos.Kernel.Core.Runtime.AmbiguousImplementationException.AmbiguousImplementationException() -> void
-Cosmos.Kernel.Core.Runtime.AmbiguousImplementationException.AmbiguousImplementationException(string! message) -> void
-Cosmos.Kernel.Core.Runtime.AmbiguousImplementationException.AmbiguousImplementationException(string! message, System.Exception! innerException) -> void
 [COSMOS0001]const Cosmos.Kernel.Core.Scheduler.SchedulerManager.DefaultQuantumNs = 10000000 -> ulong
 [COSMOS0001]const Cosmos.Kernel.Core.Scheduler.SchedulerManager.NanosecondsPerMillisecond = 1000000 -> ulong
 [COSMOS0001]const Cosmos.Kernel.Core.Scheduler.Thread.DefaultStackSize = 262144 -> nuint

--- a/src/Cosmos.Kernel.Core/PublicAPI.Unshipped.txt
+++ b/src/Cosmos.Kernel.Core/PublicAPI.Unshipped.txt
@@ -1,0 +1,107 @@
+#nullable enable
+Cosmos.Kernel.Core.CPU.ICpuOps
+Cosmos.Kernel.Core.CPU.ICpuOps.DisableInterrupts() -> void
+Cosmos.Kernel.Core.CPU.ICpuOps.EnableInterrupts() -> void
+Cosmos.Kernel.Core.CPU.ICpuOps.Halt() -> void
+Cosmos.Kernel.Core.CPU.IInterruptController
+Cosmos.Kernel.Core.CPU.IInterruptController.Dispatch(ref Cosmos.Kernel.Core.CPU.IRQContext ctx) -> void
+Cosmos.Kernel.Core.CPU.IInterruptController.Initialize() -> void
+Cosmos.Kernel.Core.CPU.IInterruptController.IsInitialized.get -> bool
+Cosmos.Kernel.Core.CPU.IInterruptController.RouteIrq(byte irqNo, byte vector, bool startMasked) -> void
+Cosmos.Kernel.Core.IO.IPortIO
+Cosmos.Kernel.Core.IO.IPortIO.ReadByte(ushort port) -> byte
+Cosmos.Kernel.Core.IO.IPortIO.ReadDWord(ushort port) -> uint
+Cosmos.Kernel.Core.IO.IPortIO.ReadWord(ushort port) -> ushort
+Cosmos.Kernel.Core.IO.IPortIO.WriteByte(ushort port, byte value) -> void
+Cosmos.Kernel.Core.IO.IPortIO.WriteDWord(ushort port, uint value) -> void
+Cosmos.Kernel.Core.IO.IPortIO.WriteWord(ushort port, ushort value) -> void
+Cosmos.Kernel.Core.Power.IPowerOps
+Cosmos.Kernel.Core.Power.IPowerOps.Reboot() -> void
+Cosmos.Kernel.Core.Power.IPowerOps.Shutdown() -> void
+Cosmos.Kernel.Core.Runtime.AmbiguousImplementationException
+Cosmos.Kernel.Core.Runtime.AmbiguousImplementationException.AmbiguousImplementationException() -> void
+Cosmos.Kernel.Core.Runtime.AmbiguousImplementationException.AmbiguousImplementationException(string! message) -> void
+Cosmos.Kernel.Core.Runtime.AmbiguousImplementationException.AmbiguousImplementationException(string! message, System.Exception! innerException) -> void
+[COSMOS0001]const Cosmos.Kernel.Core.Scheduler.SchedulerManager.DefaultQuantumNs = 10000000 -> ulong
+[COSMOS0001]const Cosmos.Kernel.Core.Scheduler.SchedulerManager.NanosecondsPerMillisecond = 1000000 -> ulong
+[COSMOS0001]const Cosmos.Kernel.Core.Scheduler.Thread.DefaultStackSize = 262144 -> nuint
+[COSMOS0001]const Cosmos.Kernel.Core.Scheduler.Thread.MaxThreadCount = 256 -> int
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.InterruptMaskScope
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.InterruptMaskScope.Dispose() -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.InterruptMaskScope.InterruptMaskScope() -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.Balance(Cosmos.Kernel.Core.Scheduler.PerCpuState! cpuState, Cosmos.Kernel.Core.Scheduler.PerCpuState![]! allCpuStates) -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.GetPriority(Cosmos.Kernel.Core.Scheduler.Thread! thread) -> long
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.GetRunQueueCount(Cosmos.Kernel.Core.Scheduler.PerCpuState! cpuState) -> int
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.GetRunQueueThread(Cosmos.Kernel.Core.Scheduler.PerCpuState! cpuState, int index) -> Cosmos.Kernel.Core.Scheduler.Thread?
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.InitializeCpu(Cosmos.Kernel.Core.Scheduler.PerCpuState! cpuState) -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.Name.get -> string!
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.OnPickFailed(Cosmos.Kernel.Core.Scheduler.PerCpuState! cpuState, Cosmos.Kernel.Core.Scheduler.Thread! thread) -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.OnThreadBlocked(Cosmos.Kernel.Core.Scheduler.PerCpuState! cpuState, Cosmos.Kernel.Core.Scheduler.Thread! thread) -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.OnThreadCreate(Cosmos.Kernel.Core.Scheduler.PerCpuState! cpuState, Cosmos.Kernel.Core.Scheduler.Thread! thread) -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.OnThreadExit(Cosmos.Kernel.Core.Scheduler.PerCpuState! cpuState, Cosmos.Kernel.Core.Scheduler.Thread! thread) -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.OnThreadMigrate(Cosmos.Kernel.Core.Scheduler.Thread! thread, Cosmos.Kernel.Core.Scheduler.PerCpuState! fromState, Cosmos.Kernel.Core.Scheduler.PerCpuState! toState) -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.OnThreadReady(Cosmos.Kernel.Core.Scheduler.PerCpuState! cpuState, Cosmos.Kernel.Core.Scheduler.Thread! thread) -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.OnThreadYield(Cosmos.Kernel.Core.Scheduler.PerCpuState! cpuState, Cosmos.Kernel.Core.Scheduler.Thread! thread) -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.OnTick(Cosmos.Kernel.Core.Scheduler.PerCpuState! cpuState, Cosmos.Kernel.Core.Scheduler.Thread! current, ulong elapsedNs) -> bool
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.PickNext(Cosmos.Kernel.Core.Scheduler.PerCpuState! cpuState) -> Cosmos.Kernel.Core.Scheduler.Thread?
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.SelectCpu(Cosmos.Kernel.Core.Scheduler.Thread! thread, uint currentCpu, uint cpuCount) -> uint
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.SetPriority(Cosmos.Kernel.Core.Scheduler.PerCpuState! cpuState, Cosmos.Kernel.Core.Scheduler.Thread! thread, long priority) -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.IScheduler.ShutdownCpu(Cosmos.Kernel.Core.Scheduler.PerCpuState! cpuState) -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.PerCpuState
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.PerCpuState.CpuId.get -> uint
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.PerCpuState.CurrentThread.get -> Cosmos.Kernel.Core.Scheduler.Thread?
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.PerCpuState.IdleThread.get -> Cosmos.Kernel.Core.Scheduler.Thread?
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.PerCpuState.LastTickAt.get -> ulong
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.PerCpuState.PerCpuState() -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.SchedulerExtensible
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.SchedulerExtensible.GetSchedulerData<T>() -> T?
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.SchedulerExtensible.SchedulerData.get -> object?
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.SchedulerExtensible.SchedulerData.set -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.SchedulerExtensible.SchedulerExtensible() -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.SchedulerManager
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.Thread
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.Thread.CpuId.get -> uint
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.Thread.CreatedAt.get -> ulong
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.Thread.Flags.get -> Cosmos.Kernel.Core.Scheduler.ThreadFlags
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.Thread.Id.get -> uint
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.Thread.InstructionPointer.get -> nuint
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.Thread.LastScheduledAt.get -> ulong
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.Thread.StackBase.get -> nuint
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.Thread.StackPointer.get -> nuint
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.Thread.StackSize.get -> nuint
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.Thread.State.get -> Cosmos.Kernel.Core.Scheduler.ThreadState
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.Thread.Thread() -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.Thread.TotalRuntime.get -> ulong
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.Thread.TotalRuntime.set -> void
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.Thread.WakeupTime.get -> ulong
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.ThreadFlags
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.ThreadFlags.IdleThread = 2 -> Cosmos.Kernel.Core.Scheduler.ThreadFlags
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.ThreadFlags.KernelThread = 1 -> Cosmos.Kernel.Core.Scheduler.ThreadFlags
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.ThreadFlags.Managed = 8 -> Cosmos.Kernel.Core.Scheduler.ThreadFlags
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.ThreadFlags.None = 0 -> Cosmos.Kernel.Core.Scheduler.ThreadFlags
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.ThreadFlags.Pinned = 4 -> Cosmos.Kernel.Core.Scheduler.ThreadFlags
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.ThreadState
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.ThreadState.Blocked = 3 -> Cosmos.Kernel.Core.Scheduler.ThreadState
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.ThreadState.Created = 0 -> Cosmos.Kernel.Core.Scheduler.ThreadState
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.ThreadState.Dead = 5 -> Cosmos.Kernel.Core.Scheduler.ThreadState
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.ThreadState.Ready = 1 -> Cosmos.Kernel.Core.Scheduler.ThreadState
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.ThreadState.Running = 2 -> Cosmos.Kernel.Core.Scheduler.ThreadState
+[COSMOS0001]Cosmos.Kernel.Core.Scheduler.ThreadState.Sleeping = 4 -> Cosmos.Kernel.Core.Scheduler.ThreadState
+[COSMOS0001]static Cosmos.Kernel.Core.Scheduler.SchedulerManager.Balance(uint cpuId) -> void
+[COSMOS0001]static Cosmos.Kernel.Core.Scheduler.SchedulerManager.CpuCount.get -> uint
+[COSMOS0001]static Cosmos.Kernel.Core.Scheduler.SchedulerManager.Current.get -> Cosmos.Kernel.Core.Scheduler.IScheduler?
+[COSMOS0001]static Cosmos.Kernel.Core.Scheduler.SchedulerManager.Enabled.get -> bool
+[COSMOS0001]static Cosmos.Kernel.Core.Scheduler.SchedulerManager.GetAllCpuStates() -> Cosmos.Kernel.Core.Scheduler.PerCpuState![]?
+[COSMOS0001]static Cosmos.Kernel.Core.Scheduler.SchedulerManager.GetBusyCpuTimeNs() -> ulong
+[COSMOS0001]static Cosmos.Kernel.Core.Scheduler.SchedulerManager.GetCpuState(uint cpuId) -> Cosmos.Kernel.Core.Scheduler.PerCpuState?
+[COSMOS0001]static Cosmos.Kernel.Core.Scheduler.SchedulerManager.GetCurrentCpuId() -> uint
+[COSMOS0001]static Cosmos.Kernel.Core.Scheduler.SchedulerManager.GetPriority(Cosmos.Kernel.Core.Scheduler.Thread! thread) -> long
+[COSMOS0001]static Cosmos.Kernel.Core.Scheduler.SchedulerManager.IsEnabled.get -> bool
+[COSMOS0001]static Cosmos.Kernel.Core.Scheduler.SchedulerManager.IsReady.get -> bool
+[COSMOS0001]static Cosmos.Kernel.Core.Scheduler.SchedulerManager.MaskInterrupts() -> Cosmos.Kernel.Core.Scheduler.InterruptMaskScope
+[COSMOS0001]static Cosmos.Kernel.Core.Scheduler.SchedulerManager.SelectCpu(Cosmos.Kernel.Core.Scheduler.Thread! thread, uint currentCpu) -> uint
+[COSMOS0001]static Cosmos.Kernel.Core.Scheduler.SchedulerManager.SetPriority(uint cpuId, Cosmos.Kernel.Core.Scheduler.Thread! thread, long priority) -> void
+[COSMOS0001]static Cosmos.Kernel.Core.Scheduler.SchedulerManager.SetScheduler(Cosmos.Kernel.Core.Scheduler.IScheduler! scheduler) -> void
+[COSMOS0001]static Cosmos.Kernel.Core.Scheduler.SchedulerManager.ThreadCount.get -> int
+[COSMOS0001]static Cosmos.Kernel.Core.Scheduler.SchedulerManager.Threads.get -> Cosmos.Kernel.Core.Scheduler.Thread?[]?

--- a/src/Cosmos.Kernel.Core/Runtime/BootStack.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/BootStack.cs
@@ -8,7 +8,7 @@ namespace Cosmos.Kernel.Core.Runtime;
 /// The top is captured by kmain before any managed code executes; the size is
 /// the Limine stack-size request when honored, else the 64 KiB protocol default.
 /// </summary>
-public static unsafe class BootStack
+internal static unsafe class BootStack
 {
     /// <summary>Stack size Limine guarantees when no stack-size request is honored.</summary>
     private const nuint LimineDefaultStackSize = 64 * 1024;

--- a/src/Cosmos.Kernel.Core/Runtime/Cpu.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Cpu.cs
@@ -2,7 +2,7 @@ using System.Runtime;
 
 namespace Cosmos.Kernel.Core.Runtime;
 
-public static class Cpu
+internal static class Cpu
 {
     /// <summary>
     /// replace this with some thing better

--- a/src/Cosmos.Kernel.Core/Runtime/DispatchResolve.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/DispatchResolve.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime;
 using System.Runtime.InteropServices;
 using Internal.Runtime;
 
@@ -11,25 +12,6 @@ using Debug = System.Diagnostics.Debug;
 
 namespace Cosmos.Kernel.Core.Runtime
 {
-    /// <summary>
-    /// Thrown by interface dispatch when default-interface-method resolution is ambiguous
-    /// (the diamond problem). Mirrors the BCL's <c>System.Runtime.AmbiguousImplementationException</c>;
-    /// catch this type to handle ambiguous dispatch in kernel code.
-    /// </summary>
-    public class AmbiguousImplementationException : Exception
-    {
-        /// <summary>Creates the exception with a default message.</summary>
-        public AmbiguousImplementationException() { }
-
-        /// <summary>Creates the exception with the given message.</summary>
-        /// <param name="message">Description of the ambiguous dispatch.</param>
-        public AmbiguousImplementationException(string message) : base(message) { }
-
-        /// <summary>Creates the exception with a message and an inner exception.</summary>
-        /// <param name="message">Description of the ambiguous dispatch.</param>
-        /// <param name="innerException">The exception that caused this one.</param>
-        public AmbiguousImplementationException(string message, Exception innerException) : base(message, innerException) { }
-    }
     internal static unsafe class DispatchResolve
     {
         public static IntPtr FindInterfaceMethodImplementationTarget(MethodTable* pTgtType,

--- a/src/Cosmos.Kernel.Core/Runtime/DispatchResolve.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/DispatchResolve.cs
@@ -12,7 +12,9 @@ using Debug = System.Diagnostics.Debug;
 namespace Cosmos.Kernel.Core.Runtime
 {
     /// <summary>
-    /// Exception thrown when an ambiguous interface implementation is detected (diamond problem)
+    /// Thrown by interface dispatch when default-interface-method resolution is ambiguous
+    /// (the diamond problem). Mirrors the BCL's <c>System.Runtime.AmbiguousImplementationException</c>;
+    /// catch this type to handle ambiguous dispatch in kernel code.
     /// </summary>
     public class AmbiguousImplementationException : Exception
     {

--- a/src/Cosmos.Kernel.Core/Runtime/DispatchResolve.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/DispatchResolve.cs
@@ -18,8 +18,16 @@ namespace Cosmos.Kernel.Core.Runtime
     /// </summary>
     public class AmbiguousImplementationException : Exception
     {
+        /// <summary>Creates the exception with a default message.</summary>
         public AmbiguousImplementationException() { }
+
+        /// <summary>Creates the exception with the given message.</summary>
+        /// <param name="message">Description of the ambiguous dispatch.</param>
         public AmbiguousImplementationException(string message) : base(message) { }
+
+        /// <summary>Creates the exception with a message and an inner exception.</summary>
+        /// <param name="message">Description of the ambiguous dispatch.</param>
+        /// <param name="innerException">The exception that caused this one.</param>
         public AmbiguousImplementationException(string message, Exception innerException) : base(message, innerException) { }
     }
     internal static unsafe class DispatchResolve

--- a/src/Cosmos.Kernel.Core/Runtime/ExceptionHandling/ExceptionTypes.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/ExceptionHandling/ExceptionTypes.cs
@@ -5,7 +5,7 @@ namespace Cosmos.Kernel.Core.Runtime;
 /// <summary>
 /// Runtime exception IDs.
 /// </summary>
-public enum ExceptionIDs
+internal enum ExceptionIDs
 {
     OutOfMemory = 1,
     NullReference = 2,
@@ -20,7 +20,7 @@ public enum ExceptionIDs
 /// <summary>
 /// Exception handling clauses as defined in ICodeManager.h.
 /// </summary>
-public enum EHClauseKind
+internal enum EHClauseKind
 {
     EH_CLAUSE_TYPED = 0,   // Catch handler for specific exception type
     EH_CLAUSE_FAULT = 1,   // Fault handler (like finally, runs on exception)
@@ -31,7 +31,7 @@ public enum EHClauseKind
 /// Exception handling clause structure matching NativeAOT format.
 /// </summary>
 [StructLayout(LayoutKind.Sequential)]
-public unsafe struct EHClause
+internal unsafe struct EHClause
 {
     public EHClauseKind ClauseKind;
     public uint TryStartOffset;
@@ -44,7 +44,7 @@ public unsafe struct EHClause
 /// <summary>
 /// Stack frame information for the frame-pointer chain walker.
 /// </summary>
-public unsafe struct StackFrame
+internal unsafe struct StackFrame
 {
     public nuint ReturnAddress;   // Where this frame returns to
     public nuint FramePointer;    // RBP/FP value for this frame

--- a/src/Cosmos.Kernel.Core/Runtime/ExceptionHandling/RegisterContext.ARM64.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/ExceptionHandling/RegisterContext.ARM64.cs
@@ -6,7 +6,7 @@ namespace Cosmos.Kernel.Core.Runtime;
 /// PAL_LIMITED_CONTEXT structure matching ARM64 assembly offsets.
 /// </summary>
 [StructLayout(LayoutKind.Explicit, Size = 0x70)]
-public unsafe struct PAL_LIMITED_CONTEXT
+internal unsafe struct PAL_LIMITED_CONTEXT
 {
     [FieldOffset(0x00)] public nuint SP;    // Stack pointer
     [FieldOffset(0x08)] public nuint IP;    // Instruction pointer (PC/LR)
@@ -29,7 +29,7 @@ public unsafe struct PAL_LIMITED_CONTEXT
 /// Uses direct values instead of pointers to avoid stack corruption.
 /// </summary>
 [StructLayout(LayoutKind.Explicit, Size = 0x68)]
-public unsafe struct REGDISPLAY
+internal unsafe struct REGDISPLAY
 {
     // Stack pointer for resume
     [FieldOffset(0x00)] public nuint SP;

--- a/src/Cosmos.Kernel.Core/Runtime/ExceptionHandling/RegisterContext.X64.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/ExceptionHandling/RegisterContext.X64.cs
@@ -6,7 +6,7 @@ namespace Cosmos.Kernel.Core.Runtime;
 /// PAL_LIMITED_CONTEXT structure matching x64 assembly offsets.
 /// </summary>
 [StructLayout(LayoutKind.Explicit, Size = 0x50)]
-public unsafe struct PAL_LIMITED_CONTEXT
+internal unsafe struct PAL_LIMITED_CONTEXT
 {
     [FieldOffset(0x00)] public nuint IP;    // Instruction pointer (return address)
     [FieldOffset(0x08)] public nuint Rsp;   // Stack pointer
@@ -24,7 +24,7 @@ public unsafe struct PAL_LIMITED_CONTEXT
 /// REGDISPLAY structure for x64 funclet calls - matches assembly offsets exactly.
 /// </summary>
 [StructLayout(LayoutKind.Explicit, Size = 0x88)]
-public unsafe struct REGDISPLAY
+internal unsafe struct REGDISPLAY
 {
     // Storage for register values
     [FieldOffset(0x00)] public nuint Rbx;

--- a/src/Cosmos.Kernel.Core/Runtime/GcInfo/MethodGcInfoLookup.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/GcInfo/MethodGcInfoLookup.cs
@@ -17,7 +17,7 @@ using Cosmos.Kernel.Core.Bridge;
 namespace Cosmos.Kernel.Core.Runtime.GcInfo;
 
 /// <summary>Maps an instruction pointer to its method's GCInfo blob, LSDA, and CFI data.</summary>
-public static unsafe class MethodGcInfoLookup
+internal static unsafe class MethodGcInfoLookup
 {
     // LSDA "unwind block" flags (UnixNativeCodeManager.cpp).
     public const byte UBF_FUNC_KIND_MASK = 0x03;

--- a/src/Cosmos.Kernel.Core/Runtime/Internal/NativeFormat/Metadata/MdBinaryReader.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Internal/NativeFormat/Metadata/MdBinaryReader.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Internal.NativeFormat;
+
+namespace Internal.Metadata.NativeFormat
+{
+    internal static partial class MdBinaryReader
+    {
+        public static uint Read(this NativeReader reader, uint offset, out bool value)
+        {
+            value = (reader.ReadUInt8(offset) != 0) ? true : false;
+            return offset + 1;
+        }
+
+        public static uint Read(this NativeReader reader, uint offset, out string value)
+        {
+            return reader.DecodeString(offset, out value);
+        }
+
+        public static uint Read(this NativeReader reader, uint offset, out char value)
+        {
+            uint val;
+            offset = reader.DecodeUnsigned(offset, out val);
+            value = (char)val;
+            return offset;
+        }
+
+        public static uint Read(this NativeReader reader, uint offset, out short value)
+        {
+            int val;
+            offset = reader.DecodeSigned(offset, out val);
+            value = (short)val;
+            return offset;
+        }
+
+        public static uint Read(this NativeReader reader, uint offset, out sbyte value)
+        {
+            value = (sbyte)reader.ReadUInt8(offset);
+            return offset + 1;
+        }
+
+        public static uint Read(this NativeReader reader, uint offset, out ulong value)
+        {
+            return reader.DecodeUnsignedLong(offset, out value);
+        }
+
+        public static uint Read(this NativeReader reader, uint offset, out int value)
+        {
+            return reader.DecodeSigned(offset, out value);
+        }
+
+        public static uint Read(this NativeReader reader, uint offset, out uint value)
+        {
+            return reader.DecodeUnsigned(offset, out value);
+        }
+
+        public static uint Read(this NativeReader reader, uint offset, out byte value)
+        {
+            value = reader.ReadUInt8(offset);
+            return offset + 1;
+        }
+
+        public static uint Read(this NativeReader reader, uint offset, out ushort value)
+        {
+            uint val;
+            offset = reader.DecodeUnsigned(offset, out val);
+            value = (ushort)val;
+            return offset;
+        }
+
+        public static uint Read(this NativeReader reader, uint offset, out long value)
+        {
+            return reader.DecodeSignedLong(offset, out value);
+        }
+
+        public static uint Read(this NativeReader reader, uint offset, out Handle handle)
+        {
+            uint rawValue;
+            offset = reader.DecodeUnsigned(offset, out rawValue);
+            handle = new Handle((HandleType)(rawValue & 0x7F), (int)(rawValue >> 7));
+            return offset;
+        }
+
+        public static uint Read(this NativeReader reader, uint offset, out float value)
+        {
+            value = reader.ReadFloat(offset);
+            return offset + 4;
+        }
+
+        public static uint Read(this NativeReader reader, uint offset, out double value)
+        {
+            value = reader.ReadDouble(offset);
+            return offset + 8;
+        }
+    }
+}

--- a/src/Cosmos.Kernel.Core/Runtime/Internal/NativeFormat/Metadata/MdBinaryReaderGen.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Internal/NativeFormat/Metadata/MdBinaryReaderGen.cs
@@ -1,0 +1,990 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// NOTE: This is a generated file - do not manually edit!
+
+#pragma warning disable 649, SA1121, IDE0036, SA1129
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Internal.NativeFormat;
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.Metadata.NativeFormat
+{
+    internal static partial class MdBinaryReader
+    {
+        public static unsafe uint Read(this NativeReader reader, uint offset, out BooleanCollection values)
+        {
+            values = new BooleanCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            offset = checked(offset + count * sizeof(bool));
+            return offset;
+        } // Read
+
+        public static unsafe uint Read(this NativeReader reader, uint offset, out CharCollection values)
+        {
+            values = new CharCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            offset = checked(offset + count * sizeof(char));
+            return offset;
+        } // Read
+
+        public static unsafe uint Read(this NativeReader reader, uint offset, out ByteCollection values)
+        {
+            values = new ByteCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            offset = checked(offset + count * sizeof(byte));
+            return offset;
+        } // Read
+
+        public static unsafe uint Read(this NativeReader reader, uint offset, out SByteCollection values)
+        {
+            values = new SByteCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            offset = checked(offset + count * sizeof(sbyte));
+            return offset;
+        } // Read
+
+        public static unsafe uint Read(this NativeReader reader, uint offset, out Int16Collection values)
+        {
+            values = new Int16Collection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            offset = checked(offset + count * sizeof(short));
+            return offset;
+        } // Read
+
+        public static unsafe uint Read(this NativeReader reader, uint offset, out UInt16Collection values)
+        {
+            values = new UInt16Collection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            offset = checked(offset + count * sizeof(ushort));
+            return offset;
+        } // Read
+
+        public static unsafe uint Read(this NativeReader reader, uint offset, out Int32Collection values)
+        {
+            values = new Int32Collection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            offset = checked(offset + count * sizeof(int));
+            return offset;
+        } // Read
+
+        public static unsafe uint Read(this NativeReader reader, uint offset, out UInt32Collection values)
+        {
+            values = new UInt32Collection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            offset = checked(offset + count * sizeof(uint));
+            return offset;
+        } // Read
+
+        public static unsafe uint Read(this NativeReader reader, uint offset, out Int64Collection values)
+        {
+            values = new Int64Collection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            offset = checked(offset + count * sizeof(long));
+            return offset;
+        } // Read
+
+        public static unsafe uint Read(this NativeReader reader, uint offset, out UInt64Collection values)
+        {
+            values = new UInt64Collection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            offset = checked(offset + count * sizeof(ulong));
+            return offset;
+        } // Read
+
+        public static unsafe uint Read(this NativeReader reader, uint offset, out SingleCollection values)
+        {
+            values = new SingleCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            offset = checked(offset + count * sizeof(float));
+            return offset;
+        } // Read
+
+        public static unsafe uint Read(this NativeReader reader, uint offset, out DoubleCollection values)
+        {
+            values = new DoubleCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            offset = checked(offset + count * sizeof(double));
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out AssemblyFlags value)
+        {
+            uint ivalue;
+            offset = reader.DecodeUnsigned(offset, out ivalue);
+            value = (AssemblyFlags)ivalue;
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out AssemblyHashAlgorithm value)
+        {
+            uint ivalue;
+            offset = reader.DecodeUnsigned(offset, out ivalue);
+            value = (AssemblyHashAlgorithm)ivalue;
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out CallingConventions value)
+        {
+            uint ivalue;
+            offset = reader.DecodeUnsigned(offset, out ivalue);
+            value = (CallingConventions)ivalue;
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out SignatureCallingConvention value)
+        {
+            uint ivalue;
+            offset = reader.DecodeUnsigned(offset, out ivalue);
+            value = (SignatureCallingConvention)ivalue;
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out EventAttributes value)
+        {
+            uint ivalue;
+            offset = reader.DecodeUnsigned(offset, out ivalue);
+            value = (EventAttributes)ivalue;
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out FieldAttributes value)
+        {
+            uint ivalue;
+            offset = reader.DecodeUnsigned(offset, out ivalue);
+            value = (FieldAttributes)ivalue;
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out GenericParameterAttributes value)
+        {
+            uint ivalue;
+            offset = reader.DecodeUnsigned(offset, out ivalue);
+            value = (GenericParameterAttributes)ivalue;
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out GenericParameterKind value)
+        {
+            uint ivalue;
+            offset = reader.DecodeUnsigned(offset, out ivalue);
+            value = (GenericParameterKind)ivalue;
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out MethodAttributes value)
+        {
+            uint ivalue;
+            offset = reader.DecodeUnsigned(offset, out ivalue);
+            value = (MethodAttributes)ivalue;
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out MethodImplAttributes value)
+        {
+            uint ivalue;
+            offset = reader.DecodeUnsigned(offset, out ivalue);
+            value = (MethodImplAttributes)ivalue;
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out MethodSemanticsAttributes value)
+        {
+            uint ivalue;
+            offset = reader.DecodeUnsigned(offset, out ivalue);
+            value = (MethodSemanticsAttributes)ivalue;
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out NamedArgumentMemberKind value)
+        {
+            uint ivalue;
+            offset = reader.DecodeUnsigned(offset, out ivalue);
+            value = (NamedArgumentMemberKind)ivalue;
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ParameterAttributes value)
+        {
+            uint ivalue;
+            offset = reader.DecodeUnsigned(offset, out ivalue);
+            value = (ParameterAttributes)ivalue;
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out PInvokeAttributes value)
+        {
+            uint ivalue;
+            offset = reader.DecodeUnsigned(offset, out ivalue);
+            value = (PInvokeAttributes)ivalue;
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out PropertyAttributes value)
+        {
+            uint ivalue;
+            offset = reader.DecodeUnsigned(offset, out ivalue);
+            value = (PropertyAttributes)ivalue;
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out TypeAttributes value)
+        {
+            uint ivalue;
+            offset = reader.DecodeUnsigned(offset, out ivalue);
+            value = (TypeAttributes)ivalue;
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out HandleCollection values)
+        {
+            values = new HandleCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            for (uint i = 0; i < count; ++i)
+            {
+                offset = reader.SkipInteger(offset);
+            }
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ArraySignatureHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ArraySignatureHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ByReferenceSignatureHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ByReferenceSignatureHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantBooleanArrayHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantBooleanArrayHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantBooleanValueHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantBooleanValueHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantByteArrayHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantByteArrayHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantByteValueHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantByteValueHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantCharArrayHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantCharArrayHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantCharValueHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantCharValueHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantDoubleArrayHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantDoubleArrayHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantDoubleValueHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantDoubleValueHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantEnumArrayHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantEnumArrayHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantEnumValueHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantEnumValueHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantHandleArrayHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantHandleArrayHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantInt16ArrayHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantInt16ArrayHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantInt16ValueHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantInt16ValueHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantInt32ArrayHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantInt32ArrayHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantInt32ValueHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantInt32ValueHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantInt64ArrayHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantInt64ArrayHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantInt64ValueHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantInt64ValueHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantReferenceValueHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantReferenceValueHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantSByteArrayHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantSByteArrayHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantSByteValueHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantSByteValueHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantSingleArrayHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantSingleArrayHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantSingleValueHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantSingleValueHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantStringArrayHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantStringArrayHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantStringValueHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantStringValueHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantUInt16ArrayHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantUInt16ArrayHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantUInt16ValueHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantUInt16ValueHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantUInt32ArrayHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantUInt32ArrayHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantUInt32ValueHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantUInt32ValueHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantUInt64ArrayHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantUInt64ArrayHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ConstantUInt64ValueHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ConstantUInt64ValueHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out CustomAttributeHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new CustomAttributeHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out EventHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new EventHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out FieldHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new FieldHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out FieldSignatureHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new FieldSignatureHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out FunctionPointerSignatureHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new FunctionPointerSignatureHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out GenericParameterHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new GenericParameterHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out MemberReferenceHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new MemberReferenceHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out MethodHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new MethodHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out MethodInstantiationHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new MethodInstantiationHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out MethodSemanticsHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new MethodSemanticsHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out MethodSignatureHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new MethodSignatureHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out MethodTypeVariableSignatureHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new MethodTypeVariableSignatureHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ModifiedTypeHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ModifiedTypeHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out NamedArgumentHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new NamedArgumentHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out NamespaceDefinitionHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new NamespaceDefinitionHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out NamespaceReferenceHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new NamespaceReferenceHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ParameterHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ParameterHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out PointerSignatureHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new PointerSignatureHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out PropertyHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new PropertyHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out PropertySignatureHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new PropertySignatureHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out QualifiedFieldHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new QualifiedFieldHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out QualifiedMethodHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new QualifiedMethodHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out SZArraySignatureHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new SZArraySignatureHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ScopeDefinitionHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ScopeDefinitionHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ScopeReferenceHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new ScopeReferenceHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out TypeDefinitionHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new TypeDefinitionHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out TypeForwarderHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new TypeForwarderHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out TypeInstantiationSignatureHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new TypeInstantiationSignatureHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out TypeReferenceHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new TypeReferenceHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out TypeSpecificationHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new TypeSpecificationHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out TypeVariableSignatureHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new TypeVariableSignatureHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out NamedArgumentHandleCollection values)
+        {
+            values = new NamedArgumentHandleCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            for (uint i = 0; i < count; ++i)
+            {
+                offset = reader.SkipInteger(offset);
+            }
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out MethodSemanticsHandleCollection values)
+        {
+            values = new MethodSemanticsHandleCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            for (uint i = 0; i < count; ++i)
+            {
+                offset = reader.SkipInteger(offset);
+            }
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out CustomAttributeHandleCollection values)
+        {
+            values = new CustomAttributeHandleCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            for (uint i = 0; i < count; ++i)
+            {
+                offset = reader.SkipInteger(offset);
+            }
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ParameterHandleCollection values)
+        {
+            values = new ParameterHandleCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            for (uint i = 0; i < count; ++i)
+            {
+                offset = reader.SkipInteger(offset);
+            }
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out GenericParameterHandleCollection values)
+        {
+            values = new GenericParameterHandleCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            for (uint i = 0; i < count; ++i)
+            {
+                offset = reader.SkipInteger(offset);
+            }
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out TypeDefinitionHandleCollection values)
+        {
+            values = new TypeDefinitionHandleCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            for (uint i = 0; i < count; ++i)
+            {
+                offset = reader.SkipInteger(offset);
+            }
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out TypeForwarderHandleCollection values)
+        {
+            values = new TypeForwarderHandleCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            for (uint i = 0; i < count; ++i)
+            {
+                offset = reader.SkipInteger(offset);
+            }
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out NamespaceDefinitionHandleCollection values)
+        {
+            values = new NamespaceDefinitionHandleCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            for (uint i = 0; i < count; ++i)
+            {
+                offset = reader.SkipInteger(offset);
+            }
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out MethodHandleCollection values)
+        {
+            values = new MethodHandleCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            for (uint i = 0; i < count; ++i)
+            {
+                offset = reader.SkipInteger(offset);
+            }
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out FieldHandleCollection values)
+        {
+            values = new FieldHandleCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            for (uint i = 0; i < count; ++i)
+            {
+                offset = reader.SkipInteger(offset);
+            }
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out PropertyHandleCollection values)
+        {
+            values = new PropertyHandleCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            for (uint i = 0; i < count; ++i)
+            {
+                offset = reader.SkipInteger(offset);
+            }
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out EventHandleCollection values)
+        {
+            values = new EventHandleCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            for (uint i = 0; i < count; ++i)
+            {
+                offset = reader.SkipInteger(offset);
+            }
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out ScopeDefinitionHandleCollection values)
+        {
+            values = new ScopeDefinitionHandleCollection(reader, offset);
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            for (uint i = 0; i < count; ++i)
+            {
+                offset = reader.SkipInteger(offset);
+            }
+            return offset;
+        } // Read
+    } // MdBinaryReader
+} // Internal.Metadata.NativeFormat

--- a/src/Cosmos.Kernel.Core/Runtime/Internal/NativeFormat/Metadata/MetadataTypeHashingAlgorithms.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Internal/NativeFormat/Metadata/MetadataTypeHashingAlgorithms.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Debug = System.Diagnostics.Debug;
+using HashCodeBuilder = Internal.NativeFormat.TypeHashingAlgorithms.HashCodeBuilder;
+using TypeAttributes = System.Reflection.TypeAttributes;
+using TypeHashingAlgorithms = Internal.NativeFormat.TypeHashingAlgorithms;
+
+namespace Internal.Metadata.NativeFormat
+{
+    internal static class MetadataTypeHashingAlgorithms
+    {
+        private static void AppendNamespaceHashCode(ref HashCodeBuilder builder, NamespaceDefinitionHandle namespaceDefHandle, MetadataReader reader)
+        {
+            NamespaceDefinition namespaceDefinition = reader.GetNamespaceDefinition(namespaceDefHandle);
+
+            Handle parentHandle = namespaceDefinition.ParentScopeOrNamespace;
+            HandleType parentHandleType = parentHandle.HandleType;
+            if (parentHandleType == HandleType.NamespaceDefinition)
+            {
+                AppendNamespaceHashCode(ref builder, parentHandle.ToNamespaceDefinitionHandle(reader), reader);
+                string namespaceNamePart = reader.GetString(namespaceDefinition.Name);
+                builder.Append(namespaceNamePart);
+                builder.Append(".");
+            }
+            else
+            {
+                Debug.Assert(parentHandleType == HandleType.ScopeDefinition);
+                Debug.Assert(string.IsNullOrEmpty(reader.GetString(namespaceDefinition.Name)), "Root namespace with a name?");
+            }
+        }
+
+        private static void AppendNamespaceHashCode(ref HashCodeBuilder builder, NamespaceReferenceHandle namespaceRefHandle, MetadataReader reader)
+        {
+            NamespaceReference namespaceReference = reader.GetNamespaceReference(namespaceRefHandle);
+
+            Handle parentHandle = namespaceReference.ParentScopeOrNamespace;
+            HandleType parentHandleType = parentHandle.HandleType;
+            if (parentHandleType == HandleType.NamespaceReference)
+            {
+                AppendNamespaceHashCode(ref builder, parentHandle.ToNamespaceReferenceHandle(reader), reader);
+                string namespaceNamePart = reader.GetString(namespaceReference.Name);
+                builder.Append(namespaceNamePart);
+                builder.Append(".");
+            }
+            else
+            {
+                Debug.Assert(parentHandleType == HandleType.ScopeReference);
+                Debug.Assert(string.IsNullOrEmpty(reader.GetString(namespaceReference.Name)), "Root namespace with a name?");
+            }
+        }
+
+        public static int ComputeHashCode(this TypeDefinitionHandle typeDefHandle, MetadataReader reader)
+        {
+            HashCodeBuilder builder = new HashCodeBuilder("");
+
+            TypeDefinition typeDef = reader.GetTypeDefinition(typeDefHandle);
+            bool isNested = typeDef.Flags.IsNested();
+            if (!isNested)
+            {
+                AppendNamespaceHashCode(ref builder, typeDef.NamespaceDefinition, reader);
+            }
+
+            string typeName = reader.GetString(typeDef.Name);
+            builder.Append(typeName);
+
+            if (isNested)
+            {
+                int enclosingTypeHashCode = typeDef.EnclosingType.ComputeHashCode(reader);
+                return TypeHashingAlgorithms.ComputeNestedTypeHashCode(enclosingTypeHashCode, builder.ToHashCode());
+            }
+
+            return builder.ToHashCode();
+        }
+
+        public static int ComputeHashCode(this TypeReferenceHandle typeRefHandle, MetadataReader reader)
+        {
+            HashCodeBuilder builder = new HashCodeBuilder("");
+
+            TypeReference typeRef = reader.GetTypeReference(typeRefHandle);
+            HandleType parentHandleType = typeRef.ParentNamespaceOrType.HandleType;
+            bool isNested = parentHandleType == HandleType.TypeReference;
+            if (!isNested)
+            {
+                Debug.Assert(parentHandleType == HandleType.NamespaceReference);
+                AppendNamespaceHashCode(ref builder, typeRef.ParentNamespaceOrType.ToNamespaceReferenceHandle(reader), reader);
+            }
+
+            string typeName = reader.GetString(typeRef.TypeName);
+            builder.Append(typeName);
+
+            if (isNested)
+            {
+                int enclosingTypeHashCode = typeRef.ParentNamespaceOrType.ToTypeReferenceHandle(reader).ComputeHashCode(reader);
+                return TypeHashingAlgorithms.ComputeNestedTypeHashCode(enclosingTypeHashCode, builder.ToHashCode());
+            }
+
+            return builder.ToHashCode();
+        }
+
+        // This mask is the fastest way to check if a type is nested from its flags,
+        // but it should not be added to the BCL enum as its semantics can be misleading.
+        // Consider, for example, that (NestedFamANDAssem & NestedMask) == NestedFamORAssem.
+        // Only comparison of the masked value to 0 is meaningful, which is different from
+        // the other masks in the enum.
+        private const TypeAttributes NestedMask = (TypeAttributes)0x00000006;
+
+        private static bool IsNested(this TypeAttributes flags)
+        {
+            return (flags & NestedMask) != 0;
+        }
+    }
+}

--- a/src/Cosmos.Kernel.Core/Runtime/Internal/NativeFormat/Metadata/NativeFormatReaderCommonGen.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Internal/NativeFormat/Metadata/NativeFormatReaderCommonGen.cs
@@ -1,0 +1,154 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// NOTE: This is a generated file - do not manually edit!
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+#pragma warning disable 108     // base type 'uint' is not CLS-compliant
+#pragma warning disable 3009    // base type 'uint' is not CLS-compliant
+#pragma warning disable 282     // There is no defined ordering between fields in multiple declarations of partial class or struct
+
+namespace Internal.Metadata.NativeFormat
+{
+    [Flags]
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal enum AssemblyFlags : uint
+    {
+        /// The assembly reference holds the full (unhashed) public key.
+        PublicKey = 0x1,
+
+        /// The implementation of this assembly used at runtime is not expected to match the version seen at compile time.
+        Retargetable = 0x100,
+
+        /// Content type mask. Masked bits correspond to values of System.Reflection.AssemblyContentType
+        ContentTypeMask = 0x00000e00,
+    } // AssemblyFlags
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal enum AssemblyHashAlgorithm : uint
+    {
+        None = 0x0,
+        Reserved = 0x8003,
+        SHA1 = 0x8004,
+    } // AssemblyHashAlgorithm
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal enum GenericParameterKind : byte
+    {
+        /// Represents a type parameter for a generic type.
+        GenericTypeParameter = 0x0,
+
+        /// Represents a type parameter from a generic method.
+        GenericMethodParameter = 0x1,
+    } // GenericParameterKind
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal enum NamedArgumentMemberKind : byte
+    {
+        /// Specifies the name of a property
+        Property = 0x0,
+
+        /// Specifies the name of a field
+        Field = 0x1,
+    } // NamedArgumentMemberKind
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal enum SignatureCallingConvention : byte
+    {
+        HasThis = 0x20,
+        ExplicitThis = 0x40,
+        Default = 0x00,
+        Vararg = 0x05,
+        Cdecl = 0x01,
+        StdCall = 0x02,
+        ThisCall = 0x03,
+        FastCall = 0x04,
+        Unmanaged = 0x09,
+        UnmanagedCallingConventionMask = 0x0F,
+    } // SignatureCallingConvention
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal enum HandleType : byte
+    {
+        Null = 0x0,
+        ArraySignature = 0x1,
+        ByReferenceSignature = 0x2,
+        ConstantBooleanArray = 0x3,
+        ConstantBooleanValue = 0x4,
+        ConstantByteArray = 0x5,
+        ConstantByteValue = 0x6,
+        ConstantCharArray = 0x7,
+        ConstantCharValue = 0x8,
+        ConstantDoubleArray = 0x9,
+        ConstantDoubleValue = 0xa,
+        ConstantEnumArray = 0xb,
+        ConstantEnumValue = 0xc,
+        ConstantHandleArray = 0xd,
+        ConstantInt16Array = 0xe,
+        ConstantInt16Value = 0xf,
+        ConstantInt32Array = 0x10,
+        ConstantInt32Value = 0x11,
+        ConstantInt64Array = 0x12,
+        ConstantInt64Value = 0x13,
+        ConstantReferenceValue = 0x14,
+        ConstantSByteArray = 0x15,
+        ConstantSByteValue = 0x16,
+        ConstantSingleArray = 0x17,
+        ConstantSingleValue = 0x18,
+        ConstantStringArray = 0x19,
+        ConstantStringValue = 0x1a,
+        ConstantUInt16Array = 0x1b,
+        ConstantUInt16Value = 0x1c,
+        ConstantUInt32Array = 0x1d,
+        ConstantUInt32Value = 0x1e,
+        ConstantUInt64Array = 0x1f,
+        ConstantUInt64Value = 0x20,
+        CustomAttribute = 0x21,
+        Event = 0x22,
+        Field = 0x23,
+        FieldSignature = 0x24,
+        FunctionPointerSignature = 0x25,
+        GenericParameter = 0x26,
+        MemberReference = 0x27,
+        Method = 0x28,
+        MethodInstantiation = 0x29,
+        MethodSemantics = 0x2a,
+        MethodSignature = 0x2b,
+        MethodTypeVariableSignature = 0x2c,
+        ModifiedType = 0x2d,
+        NamedArgument = 0x2e,
+        NamespaceDefinition = 0x2f,
+        NamespaceReference = 0x30,
+        Parameter = 0x31,
+        PointerSignature = 0x32,
+        Property = 0x33,
+        PropertySignature = 0x34,
+        QualifiedField = 0x35,
+        QualifiedMethod = 0x36,
+        SZArraySignature = 0x37,
+        ScopeDefinition = 0x38,
+        ScopeReference = 0x39,
+        TypeDefinition = 0x3a,
+        TypeForwarder = 0x3b,
+        TypeInstantiationSignature = 0x3c,
+        TypeReference = 0x3d,
+        TypeSpecification = 0x3e,
+        TypeVariableSignature = 0x3f,
+    } // HandleType
+} // Internal.Metadata.NativeFormat

--- a/src/Cosmos.Kernel.Core/Runtime/Internal/NativeFormat/Metadata/NativeFormatReaderGen.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Internal/NativeFormat/Metadata/NativeFormatReaderGen.cs
@@ -1,0 +1,7923 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// NOTE: This is a generated file - do not manually edit!
+
+#pragma warning disable 649
+#pragma warning disable 169
+#pragma warning disable 282 // There is no defined ordering between fields in multiple declarations of partial class or struct
+#pragma warning disable CA1066 // IEquatable<T> implementations aren't used
+#pragma warning disable CA1822
+#pragma warning disable IDE0059
+#pragma warning disable SA1121
+#pragma warning disable IDE0036, SA1129
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Internal.NativeFormat;
+
+namespace Internal.Metadata.NativeFormat
+{
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ArraySignature
+    {
+        private readonly MetadataReader _reader;
+        private readonly ArraySignatureHandle _handle;
+
+        internal ArraySignature(MetadataReader reader, ArraySignatureHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _elementType);
+            offset = streamReader.Read(offset, out _rank);
+            offset = streamReader.Read(offset, out _sizes);
+            offset = streamReader.Read(offset, out _lowerBounds);
+        }
+
+        public ArraySignatureHandle Handle => _handle;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
+        public Handle ElementType => _elementType;
+        private readonly Handle _elementType;
+
+        public int Rank => _rank;
+        private readonly int _rank;
+
+        public Int32Collection Sizes => _sizes;
+        private readonly Int32Collection _sizes;
+
+        public Int32Collection LowerBounds => _lowerBounds;
+        private readonly Int32Collection _lowerBounds;
+    } // ArraySignature
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ArraySignatureHandle
+    {
+        internal readonly int _value;
+
+        internal ArraySignatureHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ArraySignatureHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ArraySignature || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ArraySignature) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ArraySignatureHandle)
+                return _value == ((ArraySignatureHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ArraySignatureHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ArraySignatureHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ArraySignature GetArraySignature(MetadataReader reader)
+            => new ArraySignature(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ArraySignature)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ArraySignatureHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ByReferenceSignature
+    {
+        private readonly MetadataReader _reader;
+        private readonly ByReferenceSignatureHandle _handle;
+
+        internal ByReferenceSignature(MetadataReader reader, ByReferenceSignatureHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _type);
+        }
+
+        public ByReferenceSignatureHandle Handle => _handle;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
+        public Handle Type => _type;
+        private readonly Handle _type;
+    } // ByReferenceSignature
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ByReferenceSignatureHandle
+    {
+        internal readonly int _value;
+
+        internal ByReferenceSignatureHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ByReferenceSignatureHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ByReferenceSignature || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ByReferenceSignature) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ByReferenceSignatureHandle)
+                return _value == ((ByReferenceSignatureHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ByReferenceSignatureHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ByReferenceSignatureHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ByReferenceSignature GetByReferenceSignature(MetadataReader reader)
+            => new ByReferenceSignature(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ByReferenceSignature)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ByReferenceSignatureHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantBooleanArray
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantBooleanArrayHandle _handle;
+
+        internal ConstantBooleanArray(MetadataReader reader, ConstantBooleanArrayHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantBooleanArrayHandle Handle => _handle;
+
+        public BooleanCollection Value => _value;
+        private readonly BooleanCollection _value;
+    } // ConstantBooleanArray
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantBooleanArrayHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantBooleanArrayHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantBooleanArrayHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantBooleanArray || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantBooleanArray) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantBooleanArrayHandle)
+                return _value == ((ConstantBooleanArrayHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantBooleanArrayHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantBooleanArrayHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantBooleanArray GetConstantBooleanArray(MetadataReader reader)
+            => new ConstantBooleanArray(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantBooleanArray)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantBooleanArrayHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantBooleanValue
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantBooleanValueHandle _handle;
+
+        internal ConstantBooleanValue(MetadataReader reader, ConstantBooleanValueHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantBooleanValueHandle Handle => _handle;
+
+        public bool Value => _value;
+        private readonly bool _value;
+    } // ConstantBooleanValue
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantBooleanValueHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantBooleanValueHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantBooleanValueHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantBooleanValue || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantBooleanValue) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantBooleanValueHandle)
+                return _value == ((ConstantBooleanValueHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantBooleanValueHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantBooleanValueHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantBooleanValue GetConstantBooleanValue(MetadataReader reader)
+            => new ConstantBooleanValue(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantBooleanValue)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantBooleanValueHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantByteArray
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantByteArrayHandle _handle;
+
+        internal ConstantByteArray(MetadataReader reader, ConstantByteArrayHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantByteArrayHandle Handle => _handle;
+
+        public ByteCollection Value => _value;
+        private readonly ByteCollection _value;
+    } // ConstantByteArray
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantByteArrayHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantByteArrayHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantByteArrayHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantByteArray || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantByteArray) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantByteArrayHandle)
+                return _value == ((ConstantByteArrayHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantByteArrayHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantByteArrayHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantByteArray GetConstantByteArray(MetadataReader reader)
+            => new ConstantByteArray(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantByteArray)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantByteArrayHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantByteValue
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantByteValueHandle _handle;
+
+        internal ConstantByteValue(MetadataReader reader, ConstantByteValueHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantByteValueHandle Handle => _handle;
+
+        public byte Value => _value;
+        private readonly byte _value;
+    } // ConstantByteValue
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantByteValueHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantByteValueHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantByteValueHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantByteValue || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantByteValue) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantByteValueHandle)
+                return _value == ((ConstantByteValueHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantByteValueHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantByteValueHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantByteValue GetConstantByteValue(MetadataReader reader)
+            => new ConstantByteValue(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantByteValue)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantByteValueHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantCharArray
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantCharArrayHandle _handle;
+
+        internal ConstantCharArray(MetadataReader reader, ConstantCharArrayHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantCharArrayHandle Handle => _handle;
+
+        public CharCollection Value => _value;
+        private readonly CharCollection _value;
+    } // ConstantCharArray
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantCharArrayHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantCharArrayHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantCharArrayHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantCharArray || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantCharArray) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantCharArrayHandle)
+                return _value == ((ConstantCharArrayHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantCharArrayHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantCharArrayHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantCharArray GetConstantCharArray(MetadataReader reader)
+            => new ConstantCharArray(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantCharArray)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantCharArrayHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantCharValue
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantCharValueHandle _handle;
+
+        internal ConstantCharValue(MetadataReader reader, ConstantCharValueHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantCharValueHandle Handle => _handle;
+
+        public char Value => _value;
+        private readonly char _value;
+    } // ConstantCharValue
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantCharValueHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantCharValueHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantCharValueHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantCharValue || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantCharValue) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantCharValueHandle)
+                return _value == ((ConstantCharValueHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantCharValueHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantCharValueHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantCharValue GetConstantCharValue(MetadataReader reader)
+            => new ConstantCharValue(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantCharValue)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantCharValueHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantDoubleArray
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantDoubleArrayHandle _handle;
+
+        internal ConstantDoubleArray(MetadataReader reader, ConstantDoubleArrayHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantDoubleArrayHandle Handle => _handle;
+
+        public DoubleCollection Value => _value;
+        private readonly DoubleCollection _value;
+    } // ConstantDoubleArray
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantDoubleArrayHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantDoubleArrayHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantDoubleArrayHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantDoubleArray || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantDoubleArray) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantDoubleArrayHandle)
+                return _value == ((ConstantDoubleArrayHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantDoubleArrayHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantDoubleArrayHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantDoubleArray GetConstantDoubleArray(MetadataReader reader)
+            => new ConstantDoubleArray(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantDoubleArray)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantDoubleArrayHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantDoubleValue
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantDoubleValueHandle _handle;
+
+        internal ConstantDoubleValue(MetadataReader reader, ConstantDoubleValueHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantDoubleValueHandle Handle => _handle;
+
+        public double Value => _value;
+        private readonly double _value;
+    } // ConstantDoubleValue
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantDoubleValueHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantDoubleValueHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantDoubleValueHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantDoubleValue || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantDoubleValue) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantDoubleValueHandle)
+                return _value == ((ConstantDoubleValueHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantDoubleValueHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantDoubleValueHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantDoubleValue GetConstantDoubleValue(MetadataReader reader)
+            => new ConstantDoubleValue(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantDoubleValue)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantDoubleValueHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantEnumArray
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantEnumArrayHandle _handle;
+
+        internal ConstantEnumArray(MetadataReader reader, ConstantEnumArrayHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _elementType);
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantEnumArrayHandle Handle => _handle;
+
+        public Handle ElementType => _elementType;
+        private readonly Handle _elementType;
+
+        public Handle Value => _value;
+        private readonly Handle _value;
+    } // ConstantEnumArray
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantEnumArrayHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantEnumArrayHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantEnumArrayHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantEnumArray || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantEnumArray) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantEnumArrayHandle)
+                return _value == ((ConstantEnumArrayHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantEnumArrayHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantEnumArrayHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantEnumArray GetConstantEnumArray(MetadataReader reader)
+            => new ConstantEnumArray(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantEnumArray)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantEnumArrayHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantEnumValue
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantEnumValueHandle _handle;
+
+        internal ConstantEnumValue(MetadataReader reader, ConstantEnumValueHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+            offset = streamReader.Read(offset, out _type);
+        }
+
+        public ConstantEnumValueHandle Handle => _handle;
+
+        public Handle Value => _value;
+        private readonly Handle _value;
+
+        public Handle Type => _type;
+        private readonly Handle _type;
+    } // ConstantEnumValue
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantEnumValueHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantEnumValueHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantEnumValueHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantEnumValue || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantEnumValue) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantEnumValueHandle)
+                return _value == ((ConstantEnumValueHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantEnumValueHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantEnumValueHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantEnumValue GetConstantEnumValue(MetadataReader reader)
+            => new ConstantEnumValue(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantEnumValue)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantEnumValueHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantHandleArray
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantHandleArrayHandle _handle;
+
+        internal ConstantHandleArray(MetadataReader reader, ConstantHandleArrayHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantHandleArrayHandle Handle => _handle;
+
+        public HandleCollection Value => _value;
+        private readonly HandleCollection _value;
+    } // ConstantHandleArray
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantHandleArrayHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantHandleArrayHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantHandleArrayHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantHandleArray || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantHandleArray) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantHandleArrayHandle)
+                return _value == ((ConstantHandleArrayHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantHandleArrayHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantHandleArrayHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantHandleArray GetConstantHandleArray(MetadataReader reader)
+            => new ConstantHandleArray(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantHandleArray)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantHandleArrayHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantInt16Array
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantInt16ArrayHandle _handle;
+
+        internal ConstantInt16Array(MetadataReader reader, ConstantInt16ArrayHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantInt16ArrayHandle Handle => _handle;
+
+        public Int16Collection Value => _value;
+        private readonly Int16Collection _value;
+    } // ConstantInt16Array
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantInt16ArrayHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantInt16ArrayHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantInt16ArrayHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantInt16Array || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantInt16Array) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantInt16ArrayHandle)
+                return _value == ((ConstantInt16ArrayHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantInt16ArrayHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantInt16ArrayHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantInt16Array GetConstantInt16Array(MetadataReader reader)
+            => new ConstantInt16Array(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantInt16Array)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantInt16ArrayHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantInt16Value
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantInt16ValueHandle _handle;
+
+        internal ConstantInt16Value(MetadataReader reader, ConstantInt16ValueHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantInt16ValueHandle Handle => _handle;
+
+        public short Value => _value;
+        private readonly short _value;
+    } // ConstantInt16Value
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantInt16ValueHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantInt16ValueHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantInt16ValueHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantInt16Value || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantInt16Value) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantInt16ValueHandle)
+                return _value == ((ConstantInt16ValueHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantInt16ValueHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantInt16ValueHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantInt16Value GetConstantInt16Value(MetadataReader reader)
+            => new ConstantInt16Value(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantInt16Value)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantInt16ValueHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantInt32Array
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantInt32ArrayHandle _handle;
+
+        internal ConstantInt32Array(MetadataReader reader, ConstantInt32ArrayHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantInt32ArrayHandle Handle => _handle;
+
+        public Int32Collection Value => _value;
+        private readonly Int32Collection _value;
+    } // ConstantInt32Array
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantInt32ArrayHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantInt32ArrayHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantInt32ArrayHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantInt32Array || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantInt32Array) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantInt32ArrayHandle)
+                return _value == ((ConstantInt32ArrayHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantInt32ArrayHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantInt32ArrayHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantInt32Array GetConstantInt32Array(MetadataReader reader)
+            => new ConstantInt32Array(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantInt32Array)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantInt32ArrayHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantInt32Value
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantInt32ValueHandle _handle;
+
+        internal ConstantInt32Value(MetadataReader reader, ConstantInt32ValueHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantInt32ValueHandle Handle => _handle;
+
+        public int Value => _value;
+        private readonly int _value;
+    } // ConstantInt32Value
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantInt32ValueHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantInt32ValueHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantInt32ValueHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantInt32Value || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantInt32Value) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantInt32ValueHandle)
+                return _value == ((ConstantInt32ValueHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantInt32ValueHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantInt32ValueHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantInt32Value GetConstantInt32Value(MetadataReader reader)
+            => new ConstantInt32Value(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantInt32Value)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantInt32ValueHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantInt64Array
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantInt64ArrayHandle _handle;
+
+        internal ConstantInt64Array(MetadataReader reader, ConstantInt64ArrayHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantInt64ArrayHandle Handle => _handle;
+
+        public Int64Collection Value => _value;
+        private readonly Int64Collection _value;
+    } // ConstantInt64Array
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantInt64ArrayHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantInt64ArrayHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantInt64ArrayHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantInt64Array || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantInt64Array) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantInt64ArrayHandle)
+                return _value == ((ConstantInt64ArrayHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantInt64ArrayHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantInt64ArrayHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantInt64Array GetConstantInt64Array(MetadataReader reader)
+            => new ConstantInt64Array(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantInt64Array)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantInt64ArrayHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantInt64Value
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantInt64ValueHandle _handle;
+
+        internal ConstantInt64Value(MetadataReader reader, ConstantInt64ValueHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantInt64ValueHandle Handle => _handle;
+
+        public long Value => _value;
+        private readonly long _value;
+    } // ConstantInt64Value
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantInt64ValueHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantInt64ValueHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantInt64ValueHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantInt64Value || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantInt64Value) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantInt64ValueHandle)
+                return _value == ((ConstantInt64ValueHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantInt64ValueHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantInt64ValueHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantInt64Value GetConstantInt64Value(MetadataReader reader)
+            => new ConstantInt64Value(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantInt64Value)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantInt64ValueHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantReferenceValue
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantReferenceValueHandle _handle;
+
+        internal ConstantReferenceValue(MetadataReader reader, ConstantReferenceValueHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+        }
+
+        public ConstantReferenceValueHandle Handle => _handle;
+    } // ConstantReferenceValue
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantReferenceValueHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantReferenceValueHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantReferenceValueHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantReferenceValue || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantReferenceValue) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantReferenceValueHandle)
+                return _value == ((ConstantReferenceValueHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantReferenceValueHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantReferenceValueHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantReferenceValue GetConstantReferenceValue(MetadataReader reader)
+            => new ConstantReferenceValue(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantReferenceValue)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantReferenceValueHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantSByteArray
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantSByteArrayHandle _handle;
+
+        internal ConstantSByteArray(MetadataReader reader, ConstantSByteArrayHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantSByteArrayHandle Handle => _handle;
+
+        public SByteCollection Value => _value;
+        private readonly SByteCollection _value;
+    } // ConstantSByteArray
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantSByteArrayHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantSByteArrayHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantSByteArrayHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantSByteArray || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantSByteArray) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantSByteArrayHandle)
+                return _value == ((ConstantSByteArrayHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantSByteArrayHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantSByteArrayHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantSByteArray GetConstantSByteArray(MetadataReader reader)
+            => new ConstantSByteArray(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantSByteArray)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantSByteArrayHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantSByteValue
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantSByteValueHandle _handle;
+
+        internal ConstantSByteValue(MetadataReader reader, ConstantSByteValueHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantSByteValueHandle Handle => _handle;
+
+        public sbyte Value => _value;
+        private readonly sbyte _value;
+    } // ConstantSByteValue
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantSByteValueHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantSByteValueHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantSByteValueHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantSByteValue || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantSByteValue) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantSByteValueHandle)
+                return _value == ((ConstantSByteValueHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantSByteValueHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantSByteValueHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantSByteValue GetConstantSByteValue(MetadataReader reader)
+            => new ConstantSByteValue(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantSByteValue)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantSByteValueHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantSingleArray
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantSingleArrayHandle _handle;
+
+        internal ConstantSingleArray(MetadataReader reader, ConstantSingleArrayHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantSingleArrayHandle Handle => _handle;
+
+        public SingleCollection Value => _value;
+        private readonly SingleCollection _value;
+    } // ConstantSingleArray
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantSingleArrayHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantSingleArrayHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantSingleArrayHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantSingleArray || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantSingleArray) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantSingleArrayHandle)
+                return _value == ((ConstantSingleArrayHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantSingleArrayHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantSingleArrayHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantSingleArray GetConstantSingleArray(MetadataReader reader)
+            => new ConstantSingleArray(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantSingleArray)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantSingleArrayHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantSingleValue
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantSingleValueHandle _handle;
+
+        internal ConstantSingleValue(MetadataReader reader, ConstantSingleValueHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantSingleValueHandle Handle => _handle;
+
+        public float Value => _value;
+        private readonly float _value;
+    } // ConstantSingleValue
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantSingleValueHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantSingleValueHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantSingleValueHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantSingleValue || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantSingleValue) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantSingleValueHandle)
+                return _value == ((ConstantSingleValueHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantSingleValueHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantSingleValueHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantSingleValue GetConstantSingleValue(MetadataReader reader)
+            => new ConstantSingleValue(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantSingleValue)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantSingleValueHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantStringArray
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantStringArrayHandle _handle;
+
+        internal ConstantStringArray(MetadataReader reader, ConstantStringArrayHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantStringArrayHandle Handle => _handle;
+
+        /// One of: ConstantStringValue, ConstantReferenceValue
+        public HandleCollection Value => _value;
+        private readonly HandleCollection _value;
+    } // ConstantStringArray
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantStringArrayHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantStringArrayHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantStringArrayHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantStringArray || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantStringArray) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantStringArrayHandle)
+                return _value == ((ConstantStringArrayHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantStringArrayHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantStringArrayHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantStringArray GetConstantStringArray(MetadataReader reader)
+            => new ConstantStringArray(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantStringArray)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantStringArrayHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantStringValue
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantStringValueHandle _handle;
+
+        internal ConstantStringValue(MetadataReader reader, ConstantStringValueHandle handle)
+        {
+            if (handle.IsNil)
+                return;
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantStringValueHandle Handle => _handle;
+
+        public string Value => _value;
+        private readonly string _value;
+    } // ConstantStringValue
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantStringValueHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantStringValueHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantStringValueHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantStringValue || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantStringValue) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantStringValueHandle)
+                return _value == ((ConstantStringValueHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantStringValueHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantStringValueHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantStringValue GetConstantStringValue(MetadataReader reader)
+            => new ConstantStringValue(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantStringValue)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantStringValueHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantUInt16Array
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantUInt16ArrayHandle _handle;
+
+        internal ConstantUInt16Array(MetadataReader reader, ConstantUInt16ArrayHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantUInt16ArrayHandle Handle => _handle;
+
+        public UInt16Collection Value => _value;
+        private readonly UInt16Collection _value;
+    } // ConstantUInt16Array
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantUInt16ArrayHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantUInt16ArrayHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantUInt16ArrayHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantUInt16Array || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantUInt16Array) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantUInt16ArrayHandle)
+                return _value == ((ConstantUInt16ArrayHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantUInt16ArrayHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantUInt16ArrayHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantUInt16Array GetConstantUInt16Array(MetadataReader reader)
+            => new ConstantUInt16Array(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantUInt16Array)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantUInt16ArrayHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantUInt16Value
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantUInt16ValueHandle _handle;
+
+        internal ConstantUInt16Value(MetadataReader reader, ConstantUInt16ValueHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantUInt16ValueHandle Handle => _handle;
+
+        public ushort Value => _value;
+        private readonly ushort _value;
+    } // ConstantUInt16Value
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantUInt16ValueHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantUInt16ValueHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantUInt16ValueHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantUInt16Value || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantUInt16Value) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantUInt16ValueHandle)
+                return _value == ((ConstantUInt16ValueHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantUInt16ValueHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantUInt16ValueHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantUInt16Value GetConstantUInt16Value(MetadataReader reader)
+            => new ConstantUInt16Value(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantUInt16Value)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantUInt16ValueHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantUInt32Array
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantUInt32ArrayHandle _handle;
+
+        internal ConstantUInt32Array(MetadataReader reader, ConstantUInt32ArrayHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantUInt32ArrayHandle Handle => _handle;
+
+        public UInt32Collection Value => _value;
+        private readonly UInt32Collection _value;
+    } // ConstantUInt32Array
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantUInt32ArrayHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantUInt32ArrayHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantUInt32ArrayHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantUInt32Array || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantUInt32Array) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantUInt32ArrayHandle)
+                return _value == ((ConstantUInt32ArrayHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantUInt32ArrayHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantUInt32ArrayHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantUInt32Array GetConstantUInt32Array(MetadataReader reader)
+            => new ConstantUInt32Array(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantUInt32Array)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantUInt32ArrayHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantUInt32Value
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantUInt32ValueHandle _handle;
+
+        internal ConstantUInt32Value(MetadataReader reader, ConstantUInt32ValueHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantUInt32ValueHandle Handle => _handle;
+
+        public uint Value => _value;
+        private readonly uint _value;
+    } // ConstantUInt32Value
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantUInt32ValueHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantUInt32ValueHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantUInt32ValueHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantUInt32Value || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantUInt32Value) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantUInt32ValueHandle)
+                return _value == ((ConstantUInt32ValueHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantUInt32ValueHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantUInt32ValueHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantUInt32Value GetConstantUInt32Value(MetadataReader reader)
+            => new ConstantUInt32Value(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantUInt32Value)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantUInt32ValueHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantUInt64Array
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantUInt64ArrayHandle _handle;
+
+        internal ConstantUInt64Array(MetadataReader reader, ConstantUInt64ArrayHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantUInt64ArrayHandle Handle => _handle;
+
+        public UInt64Collection Value => _value;
+        private readonly UInt64Collection _value;
+    } // ConstantUInt64Array
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantUInt64ArrayHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantUInt64ArrayHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantUInt64ArrayHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantUInt64Array || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantUInt64Array) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantUInt64ArrayHandle)
+                return _value == ((ConstantUInt64ArrayHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantUInt64ArrayHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantUInt64ArrayHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantUInt64Array GetConstantUInt64Array(MetadataReader reader)
+            => new ConstantUInt64Array(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantUInt64Array)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantUInt64ArrayHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantUInt64Value
+    {
+        private readonly MetadataReader _reader;
+        private readonly ConstantUInt64ValueHandle _handle;
+
+        internal ConstantUInt64Value(MetadataReader reader, ConstantUInt64ValueHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public ConstantUInt64ValueHandle Handle => _handle;
+
+        public ulong Value => _value;
+        private readonly ulong _value;
+    } // ConstantUInt64Value
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ConstantUInt64ValueHandle
+    {
+        internal readonly int _value;
+
+        internal ConstantUInt64ValueHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ConstantUInt64ValueHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ConstantUInt64Value || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ConstantUInt64Value) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConstantUInt64ValueHandle)
+                return _value == ((ConstantUInt64ValueHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ConstantUInt64ValueHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ConstantUInt64ValueHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ConstantUInt64Value GetConstantUInt64Value(MetadataReader reader)
+            => new ConstantUInt64Value(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ConstantUInt64Value)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ConstantUInt64ValueHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct CustomAttribute
+    {
+        private readonly MetadataReader _reader;
+        private readonly CustomAttributeHandle _handle;
+
+        internal CustomAttribute(MetadataReader reader, CustomAttributeHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _constructor);
+            offset = streamReader.Read(offset, out _fixedArguments);
+            offset = streamReader.Read(offset, out _namedArguments);
+        }
+
+        public CustomAttributeHandle Handle => _handle;
+
+        /// One of: QualifiedMethod, MemberReference
+        public Handle Constructor => _constructor;
+        private readonly Handle _constructor;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ConstantBooleanArray, ConstantBooleanValue, ConstantByteArray, ConstantByteValue, ConstantCharArray, ConstantCharValue, ConstantDoubleArray, ConstantDoubleValue, ConstantEnumArray, ConstantEnumValue, ConstantHandleArray, ConstantInt16Array, ConstantInt16Value, ConstantInt32Array, ConstantInt32Value, ConstantInt64Array, ConstantInt64Value, ConstantReferenceValue, ConstantSByteArray, ConstantSByteValue, ConstantSingleArray, ConstantSingleValue, ConstantStringArray, ConstantStringValue, ConstantUInt16Array, ConstantUInt16Value, ConstantUInt32Array, ConstantUInt32Value, ConstantUInt64Array, ConstantUInt64Value
+        public HandleCollection FixedArguments => _fixedArguments;
+        private readonly HandleCollection _fixedArguments;
+
+        public NamedArgumentHandleCollection NamedArguments => _namedArguments;
+        private readonly NamedArgumentHandleCollection _namedArguments;
+    } // CustomAttribute
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct CustomAttributeHandle
+    {
+        internal readonly int _value;
+
+        internal CustomAttributeHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal CustomAttributeHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.CustomAttribute || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.CustomAttribute) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is CustomAttributeHandle)
+                return _value == ((CustomAttributeHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(CustomAttributeHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(CustomAttributeHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public CustomAttribute GetCustomAttribute(MetadataReader reader)
+            => new CustomAttribute(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.CustomAttribute)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // CustomAttributeHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct Event
+    {
+        private readonly MetadataReader _reader;
+        private readonly EventHandle _handle;
+
+        internal Event(MetadataReader reader, EventHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _flags);
+            offset = streamReader.Read(offset, out _name);
+            offset = streamReader.Read(offset, out _type);
+            offset = streamReader.Read(offset, out _methodSemantics);
+            offset = streamReader.Read(offset, out _customAttributes);
+        }
+
+        public EventHandle Handle => _handle;
+
+        public EventAttributes Flags => _flags;
+        private readonly EventAttributes _flags;
+
+        public ConstantStringValueHandle Name => _name;
+        private readonly ConstantStringValueHandle _name;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification
+        public Handle Type => _type;
+        private readonly Handle _type;
+
+        public MethodSemanticsHandleCollection MethodSemantics => _methodSemantics;
+        private readonly MethodSemanticsHandleCollection _methodSemantics;
+
+        public CustomAttributeHandleCollection CustomAttributes => _customAttributes;
+        private readonly CustomAttributeHandleCollection _customAttributes;
+    } // Event
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct EventHandle
+    {
+        internal readonly int _value;
+
+        internal EventHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal EventHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.Event || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.Event) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is EventHandle)
+                return _value == ((EventHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(EventHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(EventHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public Event GetEvent(MetadataReader reader)
+            => new Event(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.Event)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // EventHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct Field
+    {
+        private readonly MetadataReader _reader;
+        private readonly FieldHandle _handle;
+
+        internal Field(MetadataReader reader, FieldHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _flags);
+            offset = streamReader.Read(offset, out _name);
+            offset = streamReader.Read(offset, out _signature);
+            offset = streamReader.Read(offset, out _defaultValue);
+            offset = streamReader.Read(offset, out _offset);
+            offset = streamReader.Read(offset, out _customAttributes);
+        }
+
+        public FieldHandle Handle => _handle;
+
+        public FieldAttributes Flags => _flags;
+        private readonly FieldAttributes _flags;
+
+        public ConstantStringValueHandle Name => _name;
+        private readonly ConstantStringValueHandle _name;
+
+        public FieldSignatureHandle Signature => _signature;
+        private readonly FieldSignatureHandle _signature;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ConstantBooleanArray, ConstantBooleanValue, ConstantByteArray, ConstantByteValue, ConstantCharArray, ConstantCharValue, ConstantDoubleArray, ConstantDoubleValue, ConstantEnumArray, ConstantEnumValue, ConstantHandleArray, ConstantInt16Array, ConstantInt16Value, ConstantInt32Array, ConstantInt32Value, ConstantInt64Array, ConstantInt64Value, ConstantReferenceValue, ConstantSByteArray, ConstantSByteValue, ConstantSingleArray, ConstantSingleValue, ConstantStringArray, ConstantStringValue, ConstantUInt16Array, ConstantUInt16Value, ConstantUInt32Array, ConstantUInt32Value, ConstantUInt64Array, ConstantUInt64Value
+        public Handle DefaultValue => _defaultValue;
+        private readonly Handle _defaultValue;
+
+        public uint Offset => _offset;
+        private readonly uint _offset;
+
+        public CustomAttributeHandleCollection CustomAttributes => _customAttributes;
+        private readonly CustomAttributeHandleCollection _customAttributes;
+    } // Field
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct FieldHandle
+    {
+        internal readonly int _value;
+
+        internal FieldHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal FieldHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.Field || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.Field) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is FieldHandle)
+                return _value == ((FieldHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(FieldHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(FieldHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public Field GetField(MetadataReader reader)
+            => new Field(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.Field)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // FieldHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct FieldSignature
+    {
+        private readonly MetadataReader _reader;
+        private readonly FieldSignatureHandle _handle;
+
+        internal FieldSignature(MetadataReader reader, FieldSignatureHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _type);
+        }
+
+        public FieldSignatureHandle Handle => _handle;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
+        public Handle Type => _type;
+        private readonly Handle _type;
+    } // FieldSignature
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct FieldSignatureHandle
+    {
+        internal readonly int _value;
+
+        internal FieldSignatureHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal FieldSignatureHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.FieldSignature || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.FieldSignature) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is FieldSignatureHandle)
+                return _value == ((FieldSignatureHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(FieldSignatureHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(FieldSignatureHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public FieldSignature GetFieldSignature(MetadataReader reader)
+            => new FieldSignature(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.FieldSignature)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // FieldSignatureHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct FunctionPointerSignature
+    {
+        private readonly MetadataReader _reader;
+        private readonly FunctionPointerSignatureHandle _handle;
+
+        internal FunctionPointerSignature(MetadataReader reader, FunctionPointerSignatureHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _signature);
+        }
+
+        public FunctionPointerSignatureHandle Handle => _handle;
+
+        public MethodSignatureHandle Signature => _signature;
+        private readonly MethodSignatureHandle _signature;
+    } // FunctionPointerSignature
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct FunctionPointerSignatureHandle
+    {
+        internal readonly int _value;
+
+        internal FunctionPointerSignatureHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal FunctionPointerSignatureHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.FunctionPointerSignature || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.FunctionPointerSignature) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is FunctionPointerSignatureHandle)
+                return _value == ((FunctionPointerSignatureHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(FunctionPointerSignatureHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(FunctionPointerSignatureHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public FunctionPointerSignature GetFunctionPointerSignature(MetadataReader reader)
+            => new FunctionPointerSignature(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.FunctionPointerSignature)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // FunctionPointerSignatureHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct GenericParameter
+    {
+        private readonly MetadataReader _reader;
+        private readonly GenericParameterHandle _handle;
+
+        internal GenericParameter(MetadataReader reader, GenericParameterHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _number);
+            offset = streamReader.Read(offset, out _flags);
+            offset = streamReader.Read(offset, out _kind);
+            offset = streamReader.Read(offset, out _name);
+            offset = streamReader.Read(offset, out _constraints);
+            offset = streamReader.Read(offset, out _customAttributes);
+        }
+
+        public GenericParameterHandle Handle => _handle;
+
+        public ushort Number => _number;
+        private readonly ushort _number;
+
+        public GenericParameterAttributes Flags => _flags;
+        private readonly GenericParameterAttributes _flags;
+
+        public GenericParameterKind Kind => _kind;
+        private readonly GenericParameterKind _kind;
+
+        public ConstantStringValueHandle Name => _name;
+        private readonly ConstantStringValueHandle _name;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
+        public HandleCollection Constraints => _constraints;
+        private readonly HandleCollection _constraints;
+
+        public CustomAttributeHandleCollection CustomAttributes => _customAttributes;
+        private readonly CustomAttributeHandleCollection _customAttributes;
+    } // GenericParameter
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct GenericParameterHandle
+    {
+        internal readonly int _value;
+
+        internal GenericParameterHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal GenericParameterHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.GenericParameter || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.GenericParameter) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is GenericParameterHandle)
+                return _value == ((GenericParameterHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(GenericParameterHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(GenericParameterHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public GenericParameter GetGenericParameter(MetadataReader reader)
+            => new GenericParameter(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.GenericParameter)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // GenericParameterHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct MemberReference
+    {
+        private readonly MetadataReader _reader;
+        private readonly MemberReferenceHandle _handle;
+
+        internal MemberReference(MetadataReader reader, MemberReferenceHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _parent);
+            offset = streamReader.Read(offset, out _name);
+            offset = streamReader.Read(offset, out _signature);
+        }
+
+        public MemberReferenceHandle Handle => _handle;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification
+        public Handle Parent => _parent;
+        private readonly Handle _parent;
+
+        public ConstantStringValueHandle Name => _name;
+        private readonly ConstantStringValueHandle _name;
+
+        /// One of: MethodSignature, FieldSignature
+        public Handle Signature => _signature;
+        private readonly Handle _signature;
+    } // MemberReference
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct MemberReferenceHandle
+    {
+        internal readonly int _value;
+
+        internal MemberReferenceHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal MemberReferenceHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.MemberReference || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.MemberReference) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is MemberReferenceHandle)
+                return _value == ((MemberReferenceHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(MemberReferenceHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(MemberReferenceHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public MemberReference GetMemberReference(MetadataReader reader)
+            => new MemberReference(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.MemberReference)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // MemberReferenceHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct Method
+    {
+        private readonly MetadataReader _reader;
+        private readonly MethodHandle _handle;
+
+        internal Method(MetadataReader reader, MethodHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _flags);
+            offset = streamReader.Read(offset, out _implFlags);
+            offset = streamReader.Read(offset, out _name);
+            offset = streamReader.Read(offset, out _signature);
+            offset = streamReader.Read(offset, out _parameters);
+            offset = streamReader.Read(offset, out _genericParameters);
+            offset = streamReader.Read(offset, out _customAttributes);
+        }
+
+        public MethodHandle Handle => _handle;
+
+        public MethodAttributes Flags => _flags;
+        private readonly MethodAttributes _flags;
+
+        public MethodImplAttributes ImplFlags => _implFlags;
+        private readonly MethodImplAttributes _implFlags;
+
+        public ConstantStringValueHandle Name => _name;
+        private readonly ConstantStringValueHandle _name;
+
+        public MethodSignatureHandle Signature => _signature;
+        private readonly MethodSignatureHandle _signature;
+
+        public ParameterHandleCollection Parameters => _parameters;
+        private readonly ParameterHandleCollection _parameters;
+
+        public GenericParameterHandleCollection GenericParameters => _genericParameters;
+        private readonly GenericParameterHandleCollection _genericParameters;
+
+        public CustomAttributeHandleCollection CustomAttributes => _customAttributes;
+        private readonly CustomAttributeHandleCollection _customAttributes;
+    } // Method
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct MethodHandle
+    {
+        internal readonly int _value;
+
+        internal MethodHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal MethodHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.Method || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.Method) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is MethodHandle)
+                return _value == ((MethodHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(MethodHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(MethodHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public Method GetMethod(MetadataReader reader)
+            => new Method(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.Method)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // MethodHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct MethodInstantiation
+    {
+        private readonly MetadataReader _reader;
+        private readonly MethodInstantiationHandle _handle;
+
+        internal MethodInstantiation(MetadataReader reader, MethodInstantiationHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _method);
+            offset = streamReader.Read(offset, out _genericTypeArguments);
+        }
+
+        public MethodInstantiationHandle Handle => _handle;
+
+        /// One of: QualifiedMethod, MemberReference
+        public Handle Method => _method;
+        private readonly Handle _method;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
+        public HandleCollection GenericTypeArguments => _genericTypeArguments;
+        private readonly HandleCollection _genericTypeArguments;
+    } // MethodInstantiation
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct MethodInstantiationHandle
+    {
+        internal readonly int _value;
+
+        internal MethodInstantiationHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal MethodInstantiationHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.MethodInstantiation || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.MethodInstantiation) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is MethodInstantiationHandle)
+                return _value == ((MethodInstantiationHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(MethodInstantiationHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(MethodInstantiationHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public MethodInstantiation GetMethodInstantiation(MetadataReader reader)
+            => new MethodInstantiation(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.MethodInstantiation)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // MethodInstantiationHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct MethodSemantics
+    {
+        private readonly MetadataReader _reader;
+        private readonly MethodSemanticsHandle _handle;
+
+        internal MethodSemantics(MetadataReader reader, MethodSemanticsHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _attributes);
+            offset = streamReader.Read(offset, out _method);
+        }
+
+        public MethodSemanticsHandle Handle => _handle;
+
+        public MethodSemanticsAttributes Attributes => _attributes;
+        private readonly MethodSemanticsAttributes _attributes;
+
+        public MethodHandle Method => _method;
+        private readonly MethodHandle _method;
+    } // MethodSemantics
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct MethodSemanticsHandle
+    {
+        internal readonly int _value;
+
+        internal MethodSemanticsHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal MethodSemanticsHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.MethodSemantics || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.MethodSemantics) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is MethodSemanticsHandle)
+                return _value == ((MethodSemanticsHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(MethodSemanticsHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(MethodSemanticsHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public MethodSemantics GetMethodSemantics(MetadataReader reader)
+            => new MethodSemantics(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.MethodSemantics)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // MethodSemanticsHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct MethodSignature
+    {
+        private readonly MetadataReader _reader;
+        private readonly MethodSignatureHandle _handle;
+
+        internal MethodSignature(MetadataReader reader, MethodSignatureHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _callingConvention);
+            offset = streamReader.Read(offset, out _genericParameterCount);
+            offset = streamReader.Read(offset, out _returnType);
+            offset = streamReader.Read(offset, out _parameters);
+            offset = streamReader.Read(offset, out _varArgParameters);
+        }
+
+        public MethodSignatureHandle Handle => _handle;
+
+        public SignatureCallingConvention CallingConvention => _callingConvention;
+        private readonly SignatureCallingConvention _callingConvention;
+
+        public int GenericParameterCount => _genericParameterCount;
+        private readonly int _genericParameterCount;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
+        public Handle ReturnType => _returnType;
+        private readonly Handle _returnType;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
+        public HandleCollection Parameters => _parameters;
+        private readonly HandleCollection _parameters;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
+        public HandleCollection VarArgParameters => _varArgParameters;
+        private readonly HandleCollection _varArgParameters;
+    } // MethodSignature
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct MethodSignatureHandle
+    {
+        internal readonly int _value;
+
+        internal MethodSignatureHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal MethodSignatureHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.MethodSignature || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.MethodSignature) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is MethodSignatureHandle)
+                return _value == ((MethodSignatureHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(MethodSignatureHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(MethodSignatureHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public MethodSignature GetMethodSignature(MetadataReader reader)
+            => new MethodSignature(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.MethodSignature)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // MethodSignatureHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct MethodTypeVariableSignature
+    {
+        private readonly MetadataReader _reader;
+        private readonly MethodTypeVariableSignatureHandle _handle;
+
+        internal MethodTypeVariableSignature(MetadataReader reader, MethodTypeVariableSignatureHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _number);
+        }
+
+        public MethodTypeVariableSignatureHandle Handle => _handle;
+
+        public int Number => _number;
+        private readonly int _number;
+    } // MethodTypeVariableSignature
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct MethodTypeVariableSignatureHandle
+    {
+        internal readonly int _value;
+
+        internal MethodTypeVariableSignatureHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal MethodTypeVariableSignatureHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.MethodTypeVariableSignature || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.MethodTypeVariableSignature) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is MethodTypeVariableSignatureHandle)
+                return _value == ((MethodTypeVariableSignatureHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(MethodTypeVariableSignatureHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(MethodTypeVariableSignatureHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public MethodTypeVariableSignature GetMethodTypeVariableSignature(MetadataReader reader)
+            => new MethodTypeVariableSignature(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.MethodTypeVariableSignature)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // MethodTypeVariableSignatureHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ModifiedType
+    {
+        private readonly MetadataReader _reader;
+        private readonly ModifiedTypeHandle _handle;
+
+        internal ModifiedType(MetadataReader reader, ModifiedTypeHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _isOptional);
+            offset = streamReader.Read(offset, out _modifierType);
+            offset = streamReader.Read(offset, out _type);
+        }
+
+        public ModifiedTypeHandle Handle => _handle;
+
+        public bool IsOptional => _isOptional;
+        private readonly bool _isOptional;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification
+        public Handle ModifierType => _modifierType;
+        private readonly Handle _modifierType;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
+        public Handle Type => _type;
+        private readonly Handle _type;
+    } // ModifiedType
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ModifiedTypeHandle
+    {
+        internal readonly int _value;
+
+        internal ModifiedTypeHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ModifiedTypeHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ModifiedType || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ModifiedType) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ModifiedTypeHandle)
+                return _value == ((ModifiedTypeHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ModifiedTypeHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ModifiedTypeHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ModifiedType GetModifiedType(MetadataReader reader)
+            => new ModifiedType(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ModifiedType)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ModifiedTypeHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct NamedArgument
+    {
+        private readonly MetadataReader _reader;
+        private readonly NamedArgumentHandle _handle;
+
+        internal NamedArgument(MetadataReader reader, NamedArgumentHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _flags);
+            offset = streamReader.Read(offset, out _name);
+            offset = streamReader.Read(offset, out _type);
+            offset = streamReader.Read(offset, out _value);
+        }
+
+        public NamedArgumentHandle Handle => _handle;
+
+        public NamedArgumentMemberKind Flags => _flags;
+        private readonly NamedArgumentMemberKind _flags;
+
+        public ConstantStringValueHandle Name => _name;
+        private readonly ConstantStringValueHandle _name;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification
+        public Handle Type => _type;
+        private readonly Handle _type;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ConstantBooleanArray, ConstantBooleanValue, ConstantByteArray, ConstantByteValue, ConstantCharArray, ConstantCharValue, ConstantDoubleArray, ConstantDoubleValue, ConstantEnumArray, ConstantEnumValue, ConstantHandleArray, ConstantInt16Array, ConstantInt16Value, ConstantInt32Array, ConstantInt32Value, ConstantInt64Array, ConstantInt64Value, ConstantReferenceValue, ConstantSByteArray, ConstantSByteValue, ConstantSingleArray, ConstantSingleValue, ConstantStringArray, ConstantStringValue, ConstantUInt16Array, ConstantUInt16Value, ConstantUInt32Array, ConstantUInt32Value, ConstantUInt64Array, ConstantUInt64Value
+        public Handle Value => _value;
+        private readonly Handle _value;
+    } // NamedArgument
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct NamedArgumentHandle
+    {
+        internal readonly int _value;
+
+        internal NamedArgumentHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal NamedArgumentHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.NamedArgument || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.NamedArgument) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is NamedArgumentHandle)
+                return _value == ((NamedArgumentHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(NamedArgumentHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(NamedArgumentHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public NamedArgument GetNamedArgument(MetadataReader reader)
+            => new NamedArgument(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.NamedArgument)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // NamedArgumentHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct NamespaceDefinition
+    {
+        private readonly MetadataReader _reader;
+        private readonly NamespaceDefinitionHandle _handle;
+
+        internal NamespaceDefinition(MetadataReader reader, NamespaceDefinitionHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _parentScopeOrNamespace);
+            offset = streamReader.Read(offset, out _name);
+            offset = streamReader.Read(offset, out _typeDefinitions);
+            offset = streamReader.Read(offset, out _typeForwarders);
+            offset = streamReader.Read(offset, out _namespaceDefinitions);
+        }
+
+        public NamespaceDefinitionHandle Handle => _handle;
+
+        /// One of: NamespaceDefinition, ScopeDefinition
+        public Handle ParentScopeOrNamespace => _parentScopeOrNamespace;
+        private readonly Handle _parentScopeOrNamespace;
+
+        public ConstantStringValueHandle Name => _name;
+        private readonly ConstantStringValueHandle _name;
+
+        public TypeDefinitionHandleCollection TypeDefinitions => _typeDefinitions;
+        private readonly TypeDefinitionHandleCollection _typeDefinitions;
+
+        public TypeForwarderHandleCollection TypeForwarders => _typeForwarders;
+        private readonly TypeForwarderHandleCollection _typeForwarders;
+
+        public NamespaceDefinitionHandleCollection NamespaceDefinitions => _namespaceDefinitions;
+        private readonly NamespaceDefinitionHandleCollection _namespaceDefinitions;
+    } // NamespaceDefinition
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct NamespaceDefinitionHandle
+    {
+        internal readonly int _value;
+
+        internal NamespaceDefinitionHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal NamespaceDefinitionHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.NamespaceDefinition || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.NamespaceDefinition) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is NamespaceDefinitionHandle)
+                return _value == ((NamespaceDefinitionHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(NamespaceDefinitionHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(NamespaceDefinitionHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public NamespaceDefinition GetNamespaceDefinition(MetadataReader reader)
+            => new NamespaceDefinition(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.NamespaceDefinition)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // NamespaceDefinitionHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct NamespaceReference
+    {
+        private readonly MetadataReader _reader;
+        private readonly NamespaceReferenceHandle _handle;
+
+        internal NamespaceReference(MetadataReader reader, NamespaceReferenceHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _parentScopeOrNamespace);
+            offset = streamReader.Read(offset, out _name);
+        }
+
+        public NamespaceReferenceHandle Handle => _handle;
+
+        /// One of: NamespaceReference, ScopeReference
+        public Handle ParentScopeOrNamespace => _parentScopeOrNamespace;
+        private readonly Handle _parentScopeOrNamespace;
+
+        public ConstantStringValueHandle Name => _name;
+        private readonly ConstantStringValueHandle _name;
+    } // NamespaceReference
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct NamespaceReferenceHandle
+    {
+        internal readonly int _value;
+
+        internal NamespaceReferenceHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal NamespaceReferenceHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.NamespaceReference || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.NamespaceReference) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is NamespaceReferenceHandle)
+                return _value == ((NamespaceReferenceHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(NamespaceReferenceHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(NamespaceReferenceHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public NamespaceReference GetNamespaceReference(MetadataReader reader)
+            => new NamespaceReference(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.NamespaceReference)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // NamespaceReferenceHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct Parameter
+    {
+        private readonly MetadataReader _reader;
+        private readonly ParameterHandle _handle;
+
+        internal Parameter(MetadataReader reader, ParameterHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _flags);
+            offset = streamReader.Read(offset, out _sequence);
+            offset = streamReader.Read(offset, out _name);
+            offset = streamReader.Read(offset, out _defaultValue);
+            offset = streamReader.Read(offset, out _customAttributes);
+        }
+
+        public ParameterHandle Handle => _handle;
+
+        public ParameterAttributes Flags => _flags;
+        private readonly ParameterAttributes _flags;
+
+        public ushort Sequence => _sequence;
+        private readonly ushort _sequence;
+
+        public ConstantStringValueHandle Name => _name;
+        private readonly ConstantStringValueHandle _name;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ConstantBooleanArray, ConstantBooleanValue, ConstantByteArray, ConstantByteValue, ConstantCharArray, ConstantCharValue, ConstantDoubleArray, ConstantDoubleValue, ConstantEnumArray, ConstantEnumValue, ConstantHandleArray, ConstantInt16Array, ConstantInt16Value, ConstantInt32Array, ConstantInt32Value, ConstantInt64Array, ConstantInt64Value, ConstantReferenceValue, ConstantSByteArray, ConstantSByteValue, ConstantSingleArray, ConstantSingleValue, ConstantStringArray, ConstantStringValue, ConstantUInt16Array, ConstantUInt16Value, ConstantUInt32Array, ConstantUInt32Value, ConstantUInt64Array, ConstantUInt64Value
+        public Handle DefaultValue => _defaultValue;
+        private readonly Handle _defaultValue;
+
+        public CustomAttributeHandleCollection CustomAttributes => _customAttributes;
+        private readonly CustomAttributeHandleCollection _customAttributes;
+    } // Parameter
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ParameterHandle
+    {
+        internal readonly int _value;
+
+        internal ParameterHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ParameterHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.Parameter || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.Parameter) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ParameterHandle)
+                return _value == ((ParameterHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ParameterHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ParameterHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public Parameter GetParameter(MetadataReader reader)
+            => new Parameter(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.Parameter)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ParameterHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct PointerSignature
+    {
+        private readonly MetadataReader _reader;
+        private readonly PointerSignatureHandle _handle;
+
+        internal PointerSignature(MetadataReader reader, PointerSignatureHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _type);
+        }
+
+        public PointerSignatureHandle Handle => _handle;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
+        public Handle Type => _type;
+        private readonly Handle _type;
+    } // PointerSignature
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct PointerSignatureHandle
+    {
+        internal readonly int _value;
+
+        internal PointerSignatureHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal PointerSignatureHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.PointerSignature || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.PointerSignature) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is PointerSignatureHandle)
+                return _value == ((PointerSignatureHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(PointerSignatureHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(PointerSignatureHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public PointerSignature GetPointerSignature(MetadataReader reader)
+            => new PointerSignature(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.PointerSignature)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // PointerSignatureHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct Property
+    {
+        private readonly MetadataReader _reader;
+        private readonly PropertyHandle _handle;
+
+        internal Property(MetadataReader reader, PropertyHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _flags);
+            offset = streamReader.Read(offset, out _name);
+            offset = streamReader.Read(offset, out _signature);
+            offset = streamReader.Read(offset, out _methodSemantics);
+            offset = streamReader.Read(offset, out _defaultValue);
+            offset = streamReader.Read(offset, out _customAttributes);
+        }
+
+        public PropertyHandle Handle => _handle;
+
+        public PropertyAttributes Flags => _flags;
+        private readonly PropertyAttributes _flags;
+
+        public ConstantStringValueHandle Name => _name;
+        private readonly ConstantStringValueHandle _name;
+
+        public PropertySignatureHandle Signature => _signature;
+        private readonly PropertySignatureHandle _signature;
+
+        public MethodSemanticsHandleCollection MethodSemantics => _methodSemantics;
+        private readonly MethodSemanticsHandleCollection _methodSemantics;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ConstantBooleanArray, ConstantBooleanValue, ConstantByteArray, ConstantByteValue, ConstantCharArray, ConstantCharValue, ConstantDoubleArray, ConstantDoubleValue, ConstantEnumArray, ConstantEnumValue, ConstantHandleArray, ConstantInt16Array, ConstantInt16Value, ConstantInt32Array, ConstantInt32Value, ConstantInt64Array, ConstantInt64Value, ConstantReferenceValue, ConstantSByteArray, ConstantSByteValue, ConstantSingleArray, ConstantSingleValue, ConstantStringArray, ConstantStringValue, ConstantUInt16Array, ConstantUInt16Value, ConstantUInt32Array, ConstantUInt32Value, ConstantUInt64Array, ConstantUInt64Value
+        public Handle DefaultValue => _defaultValue;
+        private readonly Handle _defaultValue;
+
+        public CustomAttributeHandleCollection CustomAttributes => _customAttributes;
+        private readonly CustomAttributeHandleCollection _customAttributes;
+    } // Property
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct PropertyHandle
+    {
+        internal readonly int _value;
+
+        internal PropertyHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal PropertyHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.Property || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.Property) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is PropertyHandle)
+                return _value == ((PropertyHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(PropertyHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(PropertyHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public Property GetProperty(MetadataReader reader)
+            => new Property(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.Property)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // PropertyHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct PropertySignature
+    {
+        private readonly MetadataReader _reader;
+        private readonly PropertySignatureHandle _handle;
+
+        internal PropertySignature(MetadataReader reader, PropertySignatureHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _callingConvention);
+            offset = streamReader.Read(offset, out _type);
+            offset = streamReader.Read(offset, out _parameters);
+        }
+
+        public PropertySignatureHandle Handle => _handle;
+
+        public CallingConventions CallingConvention => _callingConvention;
+        private readonly CallingConventions _callingConvention;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
+        public Handle Type => _type;
+        private readonly Handle _type;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
+        public HandleCollection Parameters => _parameters;
+        private readonly HandleCollection _parameters;
+    } // PropertySignature
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct PropertySignatureHandle
+    {
+        internal readonly int _value;
+
+        internal PropertySignatureHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal PropertySignatureHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.PropertySignature || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.PropertySignature) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is PropertySignatureHandle)
+                return _value == ((PropertySignatureHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(PropertySignatureHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(PropertySignatureHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public PropertySignature GetPropertySignature(MetadataReader reader)
+            => new PropertySignature(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.PropertySignature)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // PropertySignatureHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct QualifiedField
+    {
+        private readonly MetadataReader _reader;
+        private readonly QualifiedFieldHandle _handle;
+
+        internal QualifiedField(MetadataReader reader, QualifiedFieldHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _field);
+            offset = streamReader.Read(offset, out _enclosingType);
+        }
+
+        public QualifiedFieldHandle Handle => _handle;
+
+        public FieldHandle Field => _field;
+        private readonly FieldHandle _field;
+
+        public TypeDefinitionHandle EnclosingType => _enclosingType;
+        private readonly TypeDefinitionHandle _enclosingType;
+    } // QualifiedField
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct QualifiedFieldHandle
+    {
+        internal readonly int _value;
+
+        internal QualifiedFieldHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal QualifiedFieldHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.QualifiedField || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.QualifiedField) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is QualifiedFieldHandle)
+                return _value == ((QualifiedFieldHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(QualifiedFieldHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(QualifiedFieldHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public QualifiedField GetQualifiedField(MetadataReader reader)
+            => new QualifiedField(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.QualifiedField)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // QualifiedFieldHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct QualifiedMethod
+    {
+        private readonly MetadataReader _reader;
+        private readonly QualifiedMethodHandle _handle;
+
+        internal QualifiedMethod(MetadataReader reader, QualifiedMethodHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _method);
+            offset = streamReader.Read(offset, out _enclosingType);
+        }
+
+        public QualifiedMethodHandle Handle => _handle;
+
+        public MethodHandle Method => _method;
+        private readonly MethodHandle _method;
+
+        public TypeDefinitionHandle EnclosingType => _enclosingType;
+        private readonly TypeDefinitionHandle _enclosingType;
+    } // QualifiedMethod
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct QualifiedMethodHandle
+    {
+        internal readonly int _value;
+
+        internal QualifiedMethodHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal QualifiedMethodHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.QualifiedMethod || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.QualifiedMethod) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is QualifiedMethodHandle)
+                return _value == ((QualifiedMethodHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(QualifiedMethodHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(QualifiedMethodHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public QualifiedMethod GetQualifiedMethod(MetadataReader reader)
+            => new QualifiedMethod(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.QualifiedMethod)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // QualifiedMethodHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct SZArraySignature
+    {
+        private readonly MetadataReader _reader;
+        private readonly SZArraySignatureHandle _handle;
+
+        internal SZArraySignature(MetadataReader reader, SZArraySignatureHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _elementType);
+        }
+
+        public SZArraySignatureHandle Handle => _handle;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
+        public Handle ElementType => _elementType;
+        private readonly Handle _elementType;
+    } // SZArraySignature
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct SZArraySignatureHandle
+    {
+        internal readonly int _value;
+
+        internal SZArraySignatureHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal SZArraySignatureHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.SZArraySignature || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.SZArraySignature) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is SZArraySignatureHandle)
+                return _value == ((SZArraySignatureHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(SZArraySignatureHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(SZArraySignatureHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public SZArraySignature GetSZArraySignature(MetadataReader reader)
+            => new SZArraySignature(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.SZArraySignature)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // SZArraySignatureHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ScopeDefinition
+    {
+        private readonly MetadataReader _reader;
+        private readonly ScopeDefinitionHandle _handle;
+
+        internal ScopeDefinition(MetadataReader reader, ScopeDefinitionHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _flags);
+            offset = streamReader.Read(offset, out _name);
+            offset = streamReader.Read(offset, out _hashAlgorithm);
+            offset = streamReader.Read(offset, out _majorVersion);
+            offset = streamReader.Read(offset, out _minorVersion);
+            offset = streamReader.Read(offset, out _buildNumber);
+            offset = streamReader.Read(offset, out _revisionNumber);
+            offset = streamReader.Read(offset, out _publicKey);
+            offset = streamReader.Read(offset, out _culture);
+            offset = streamReader.Read(offset, out _rootNamespaceDefinition);
+            offset = streamReader.Read(offset, out _entryPoint);
+            offset = streamReader.Read(offset, out _globalModuleType);
+            offset = streamReader.Read(offset, out _customAttributes);
+            offset = streamReader.Read(offset, out _moduleName);
+            offset = streamReader.Read(offset, out _mvid);
+            offset = streamReader.Read(offset, out _moduleCustomAttributes);
+        }
+
+        public ScopeDefinitionHandle Handle => _handle;
+
+        public AssemblyFlags Flags => _flags;
+        private readonly AssemblyFlags _flags;
+
+        public ConstantStringValueHandle Name => _name;
+        private readonly ConstantStringValueHandle _name;
+
+        public AssemblyHashAlgorithm HashAlgorithm => _hashAlgorithm;
+        private readonly AssemblyHashAlgorithm _hashAlgorithm;
+
+        public ushort MajorVersion => _majorVersion;
+        private readonly ushort _majorVersion;
+
+        public ushort MinorVersion => _minorVersion;
+        private readonly ushort _minorVersion;
+
+        public ushort BuildNumber => _buildNumber;
+        private readonly ushort _buildNumber;
+
+        public ushort RevisionNumber => _revisionNumber;
+        private readonly ushort _revisionNumber;
+
+        public ByteCollection PublicKey => _publicKey;
+        private readonly ByteCollection _publicKey;
+
+        public ConstantStringValueHandle Culture => _culture;
+        private readonly ConstantStringValueHandle _culture;
+
+        public NamespaceDefinitionHandle RootNamespaceDefinition => _rootNamespaceDefinition;
+        private readonly NamespaceDefinitionHandle _rootNamespaceDefinition;
+
+        public QualifiedMethodHandle EntryPoint => _entryPoint;
+        private readonly QualifiedMethodHandle _entryPoint;
+
+        public TypeDefinitionHandle GlobalModuleType => _globalModuleType;
+        private readonly TypeDefinitionHandle _globalModuleType;
+
+        public CustomAttributeHandleCollection CustomAttributes => _customAttributes;
+        private readonly CustomAttributeHandleCollection _customAttributes;
+
+        public ConstantStringValueHandle ModuleName => _moduleName;
+        private readonly ConstantStringValueHandle _moduleName;
+
+        public ByteCollection Mvid => _mvid;
+        private readonly ByteCollection _mvid;
+
+        public CustomAttributeHandleCollection ModuleCustomAttributes => _moduleCustomAttributes;
+        private readonly CustomAttributeHandleCollection _moduleCustomAttributes;
+    } // ScopeDefinition
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ScopeDefinitionHandle
+    {
+        internal readonly int _value;
+
+        internal ScopeDefinitionHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ScopeDefinitionHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ScopeDefinition || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ScopeDefinition) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ScopeDefinitionHandle)
+                return _value == ((ScopeDefinitionHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ScopeDefinitionHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ScopeDefinitionHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ScopeDefinition GetScopeDefinition(MetadataReader reader)
+            => new ScopeDefinition(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ScopeDefinition)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ScopeDefinitionHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ScopeReference
+    {
+        private readonly MetadataReader _reader;
+        private readonly ScopeReferenceHandle _handle;
+
+        internal ScopeReference(MetadataReader reader, ScopeReferenceHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _flags);
+            offset = streamReader.Read(offset, out _name);
+            offset = streamReader.Read(offset, out _majorVersion);
+            offset = streamReader.Read(offset, out _minorVersion);
+            offset = streamReader.Read(offset, out _buildNumber);
+            offset = streamReader.Read(offset, out _revisionNumber);
+            offset = streamReader.Read(offset, out _publicKeyOrToken);
+            offset = streamReader.Read(offset, out _culture);
+        }
+
+        public ScopeReferenceHandle Handle => _handle;
+
+        public AssemblyFlags Flags => _flags;
+        private readonly AssemblyFlags _flags;
+
+        public ConstantStringValueHandle Name => _name;
+        private readonly ConstantStringValueHandle _name;
+
+        public ushort MajorVersion => _majorVersion;
+        private readonly ushort _majorVersion;
+
+        public ushort MinorVersion => _minorVersion;
+        private readonly ushort _minorVersion;
+
+        public ushort BuildNumber => _buildNumber;
+        private readonly ushort _buildNumber;
+
+        public ushort RevisionNumber => _revisionNumber;
+        private readonly ushort _revisionNumber;
+
+        public ByteCollection PublicKeyOrToken => _publicKeyOrToken;
+        private readonly ByteCollection _publicKeyOrToken;
+
+        public ConstantStringValueHandle Culture => _culture;
+        private readonly ConstantStringValueHandle _culture;
+    } // ScopeReference
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ScopeReferenceHandle
+    {
+        internal readonly int _value;
+
+        internal ScopeReferenceHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal ScopeReferenceHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.ScopeReference || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.ScopeReference) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ScopeReferenceHandle)
+                return _value == ((ScopeReferenceHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(ScopeReferenceHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(ScopeReferenceHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public ScopeReference GetScopeReference(MetadataReader reader)
+            => new ScopeReference(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.ScopeReference)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // ScopeReferenceHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct TypeDefinition
+    {
+        private readonly MetadataReader _reader;
+        private readonly TypeDefinitionHandle _handle;
+
+        internal TypeDefinition(MetadataReader reader, TypeDefinitionHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _flags);
+            offset = streamReader.Read(offset, out _baseType);
+            offset = streamReader.Read(offset, out _namespaceDefinition);
+            offset = streamReader.Read(offset, out _name);
+            offset = streamReader.Read(offset, out _size);
+            offset = streamReader.Read(offset, out _packingSize);
+            offset = streamReader.Read(offset, out _enclosingType);
+            offset = streamReader.Read(offset, out _nestedTypes);
+            offset = streamReader.Read(offset, out _methods);
+            offset = streamReader.Read(offset, out _fields);
+            offset = streamReader.Read(offset, out _properties);
+            offset = streamReader.Read(offset, out _events);
+            offset = streamReader.Read(offset, out _genericParameters);
+            offset = streamReader.Read(offset, out _interfaces);
+            offset = streamReader.Read(offset, out _customAttributes);
+        }
+
+        public TypeDefinitionHandle Handle => _handle;
+
+        public TypeAttributes Flags => _flags;
+        private readonly TypeAttributes _flags;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification
+        public Handle BaseType => _baseType;
+        private readonly Handle _baseType;
+
+        public NamespaceDefinitionHandle NamespaceDefinition => _namespaceDefinition;
+        private readonly NamespaceDefinitionHandle _namespaceDefinition;
+
+        public ConstantStringValueHandle Name => _name;
+        private readonly ConstantStringValueHandle _name;
+
+        public uint Size => _size;
+        private readonly uint _size;
+
+        public ushort PackingSize => _packingSize;
+        private readonly ushort _packingSize;
+
+        public TypeDefinitionHandle EnclosingType => _enclosingType;
+        private readonly TypeDefinitionHandle _enclosingType;
+
+        public TypeDefinitionHandleCollection NestedTypes => _nestedTypes;
+        private readonly TypeDefinitionHandleCollection _nestedTypes;
+
+        public MethodHandleCollection Methods => _methods;
+        private readonly MethodHandleCollection _methods;
+
+        public FieldHandleCollection Fields => _fields;
+        private readonly FieldHandleCollection _fields;
+
+        public PropertyHandleCollection Properties => _properties;
+        private readonly PropertyHandleCollection _properties;
+
+        public EventHandleCollection Events => _events;
+        private readonly EventHandleCollection _events;
+
+        public GenericParameterHandleCollection GenericParameters => _genericParameters;
+        private readonly GenericParameterHandleCollection _genericParameters;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification
+        public HandleCollection Interfaces => _interfaces;
+        private readonly HandleCollection _interfaces;
+
+        public CustomAttributeHandleCollection CustomAttributes => _customAttributes;
+        private readonly CustomAttributeHandleCollection _customAttributes;
+    } // TypeDefinition
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct TypeDefinitionHandle
+    {
+        internal readonly int _value;
+
+        internal TypeDefinitionHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal TypeDefinitionHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.TypeDefinition || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.TypeDefinition) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is TypeDefinitionHandle)
+                return _value == ((TypeDefinitionHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(TypeDefinitionHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(TypeDefinitionHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public TypeDefinition GetTypeDefinition(MetadataReader reader)
+            => new TypeDefinition(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.TypeDefinition)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // TypeDefinitionHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct TypeForwarder
+    {
+        private readonly MetadataReader _reader;
+        private readonly TypeForwarderHandle _handle;
+
+        internal TypeForwarder(MetadataReader reader, TypeForwarderHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _scope);
+            offset = streamReader.Read(offset, out _name);
+            offset = streamReader.Read(offset, out _nestedTypes);
+        }
+
+        public TypeForwarderHandle Handle => _handle;
+
+        public ScopeReferenceHandle Scope => _scope;
+        private readonly ScopeReferenceHandle _scope;
+
+        public ConstantStringValueHandle Name => _name;
+        private readonly ConstantStringValueHandle _name;
+
+        public TypeForwarderHandleCollection NestedTypes => _nestedTypes;
+        private readonly TypeForwarderHandleCollection _nestedTypes;
+    } // TypeForwarder
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct TypeForwarderHandle
+    {
+        internal readonly int _value;
+
+        internal TypeForwarderHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal TypeForwarderHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.TypeForwarder || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.TypeForwarder) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is TypeForwarderHandle)
+                return _value == ((TypeForwarderHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(TypeForwarderHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(TypeForwarderHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public TypeForwarder GetTypeForwarder(MetadataReader reader)
+            => new TypeForwarder(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.TypeForwarder)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // TypeForwarderHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct TypeInstantiationSignature
+    {
+        private readonly MetadataReader _reader;
+        private readonly TypeInstantiationSignatureHandle _handle;
+
+        internal TypeInstantiationSignature(MetadataReader reader, TypeInstantiationSignatureHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _genericType);
+            offset = streamReader.Read(offset, out _genericTypeArguments);
+        }
+
+        public TypeInstantiationSignatureHandle Handle => _handle;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification
+        public Handle GenericType => _genericType;
+        private readonly Handle _genericType;
+
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
+        public HandleCollection GenericTypeArguments => _genericTypeArguments;
+        private readonly HandleCollection _genericTypeArguments;
+    } // TypeInstantiationSignature
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct TypeInstantiationSignatureHandle
+    {
+        internal readonly int _value;
+
+        internal TypeInstantiationSignatureHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal TypeInstantiationSignatureHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.TypeInstantiationSignature || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.TypeInstantiationSignature) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is TypeInstantiationSignatureHandle)
+                return _value == ((TypeInstantiationSignatureHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(TypeInstantiationSignatureHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(TypeInstantiationSignatureHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public TypeInstantiationSignature GetTypeInstantiationSignature(MetadataReader reader)
+            => new TypeInstantiationSignature(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.TypeInstantiationSignature)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // TypeInstantiationSignatureHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct TypeReference
+    {
+        private readonly MetadataReader _reader;
+        private readonly TypeReferenceHandle _handle;
+
+        internal TypeReference(MetadataReader reader, TypeReferenceHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _parentNamespaceOrType);
+            offset = streamReader.Read(offset, out _typeName);
+        }
+
+        public TypeReferenceHandle Handle => _handle;
+
+        /// One of: NamespaceReference, TypeReference
+        public Handle ParentNamespaceOrType => _parentNamespaceOrType;
+        private readonly Handle _parentNamespaceOrType;
+
+        public ConstantStringValueHandle TypeName => _typeName;
+        private readonly ConstantStringValueHandle _typeName;
+    } // TypeReference
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct TypeReferenceHandle
+    {
+        internal readonly int _value;
+
+        internal TypeReferenceHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal TypeReferenceHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.TypeReference || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.TypeReference) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is TypeReferenceHandle)
+                return _value == ((TypeReferenceHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(TypeReferenceHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(TypeReferenceHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public TypeReference GetTypeReference(MetadataReader reader)
+            => new TypeReference(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.TypeReference)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // TypeReferenceHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct TypeSpecification
+    {
+        private readonly MetadataReader _reader;
+        private readonly TypeSpecificationHandle _handle;
+
+        internal TypeSpecification(MetadataReader reader, TypeSpecificationHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _signature);
+        }
+
+        public TypeSpecificationHandle Handle => _handle;
+
+        /// One of: TypeDefinition, TypeReference, TypeInstantiationSignature, SZArraySignature, ArraySignature, PointerSignature, FunctionPointerSignature, ByReferenceSignature, TypeVariableSignature, MethodTypeVariableSignature
+        public Handle Signature => _signature;
+        private readonly Handle _signature;
+    } // TypeSpecification
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct TypeSpecificationHandle
+    {
+        internal readonly int _value;
+
+        internal TypeSpecificationHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal TypeSpecificationHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.TypeSpecification || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.TypeSpecification) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is TypeSpecificationHandle)
+                return _value == ((TypeSpecificationHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(TypeSpecificationHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(TypeSpecificationHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public TypeSpecification GetTypeSpecification(MetadataReader reader)
+            => new TypeSpecification(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.TypeSpecification)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // TypeSpecificationHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct TypeVariableSignature
+    {
+        private readonly MetadataReader _reader;
+        private readonly TypeVariableSignatureHandle _handle;
+
+        internal TypeVariableSignature(MetadataReader reader, TypeVariableSignatureHandle handle)
+        {
+            _reader = reader;
+            _handle = handle;
+            uint offset = (uint)handle.Offset;
+            NativeReader streamReader = reader._streamReader;
+            offset = streamReader.Read(offset, out _number);
+        }
+
+        public TypeVariableSignatureHandle Handle => _handle;
+
+        public int Number => _number;
+        private readonly int _number;
+    } // TypeVariableSignature
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct TypeVariableSignatureHandle
+    {
+        internal readonly int _value;
+
+        internal TypeVariableSignatureHandle(Handle handle) : this(handle._value)
+        {
+        }
+
+        internal TypeVariableSignatureHandle(int value)
+        {
+            HandleType hType = (HandleType)((uint)value >> 25);
+            Debug.Assert(hType == HandleType.TypeVariableSignature || hType == HandleType.Null);
+            _value = (value & 0x01FFFFFF) | (((int)HandleType.TypeVariableSignature) << 25);
+            _Validate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is TypeVariableSignatureHandle)
+                return _value == ((TypeVariableSignatureHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(TypeVariableSignatureHandle handle) => _value == handle._value;
+
+        public bool Equals(Handle handle) => _value == handle._value;
+
+        public override int GetHashCode() => (int)_value;
+
+        public static implicit operator Handle(TypeVariableSignatureHandle handle)
+            => new Handle(handle._value);
+
+        internal int Offset => (_value & 0x01FFFFFF);
+
+        public TypeVariableSignature GetTypeVariableSignature(MetadataReader reader)
+            => new TypeVariableSignature(reader, this);
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((uint)_value >> 25) != HandleType.TypeVariableSignature)
+                throw new ArgumentException();
+        } // _Validate
+
+        #if DEBUG
+        public override string ToString() => string.Format("{0:X8}", _value);
+        #endif
+    } // TypeVariableSignatureHandle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct NamedArgumentHandleCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal NamedArgumentHandleCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private NamedArgumentHandle _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(NamedArgumentHandle);
+            }
+
+            public NamedArgumentHandle Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // NamedArgumentHandleCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct MethodSemanticsHandleCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal MethodSemanticsHandleCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private MethodSemanticsHandle _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(MethodSemanticsHandle);
+            }
+
+            public MethodSemanticsHandle Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // MethodSemanticsHandleCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct CustomAttributeHandleCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal CustomAttributeHandleCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private CustomAttributeHandle _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(CustomAttributeHandle);
+            }
+
+            public CustomAttributeHandle Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // CustomAttributeHandleCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ParameterHandleCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal ParameterHandleCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private ParameterHandle _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(ParameterHandle);
+            }
+
+            public ParameterHandle Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // ParameterHandleCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct GenericParameterHandleCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal GenericParameterHandleCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private GenericParameterHandle _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(GenericParameterHandle);
+            }
+
+            public GenericParameterHandle Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // GenericParameterHandleCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct TypeDefinitionHandleCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal TypeDefinitionHandleCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private TypeDefinitionHandle _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(TypeDefinitionHandle);
+            }
+
+            public TypeDefinitionHandle Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // TypeDefinitionHandleCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct TypeForwarderHandleCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal TypeForwarderHandleCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private TypeForwarderHandle _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(TypeForwarderHandle);
+            }
+
+            public TypeForwarderHandle Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // TypeForwarderHandleCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct NamespaceDefinitionHandleCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal NamespaceDefinitionHandleCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private NamespaceDefinitionHandle _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(NamespaceDefinitionHandle);
+            }
+
+            public NamespaceDefinitionHandle Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // NamespaceDefinitionHandleCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct MethodHandleCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal MethodHandleCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private MethodHandle _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(MethodHandle);
+            }
+
+            public MethodHandle Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // MethodHandleCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct FieldHandleCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal FieldHandleCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private FieldHandle _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(FieldHandle);
+            }
+
+            public FieldHandle Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // FieldHandleCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct PropertyHandleCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal PropertyHandleCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private PropertyHandle _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(PropertyHandle);
+            }
+
+            public PropertyHandle Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // PropertyHandleCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct EventHandleCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal EventHandleCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private EventHandle _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(EventHandle);
+            }
+
+            public EventHandle Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // EventHandleCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ScopeDefinitionHandleCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal ScopeDefinitionHandleCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private ScopeDefinitionHandle _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(ScopeDefinitionHandle);
+            }
+
+            public ScopeDefinitionHandle Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // ScopeDefinitionHandleCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct BooleanCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal BooleanCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private bool _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(bool);
+            }
+
+            public bool Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // BooleanCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct CharCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal CharCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private char _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(char);
+            }
+
+            public char Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // CharCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct ByteCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal ByteCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private byte _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(byte);
+            }
+
+            public byte Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // ByteCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct SByteCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal SByteCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private sbyte _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(sbyte);
+            }
+
+            public sbyte Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // SByteCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct Int16Collection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal Int16Collection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private short _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(short);
+            }
+
+            public short Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // Int16Collection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct UInt16Collection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal UInt16Collection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private ushort _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(ushort);
+            }
+
+            public ushort Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // UInt16Collection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct Int32Collection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal Int32Collection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private int _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(int);
+            }
+
+            public int Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // Int32Collection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct UInt32Collection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal UInt32Collection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private uint _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(uint);
+            }
+
+            public uint Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // UInt32Collection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct Int64Collection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal Int64Collection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private long _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(long);
+            }
+
+            public long Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // Int64Collection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct UInt64Collection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal UInt64Collection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private ulong _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(ulong);
+            }
+
+            public ulong Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // UInt64Collection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct SingleCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal SingleCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private float _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(float);
+            }
+
+            public float Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // SingleCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct DoubleCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal DoubleCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private double _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(double);
+            }
+
+            public double Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // DoubleCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct Handle
+    {
+        public ArraySignatureHandle ToArraySignatureHandle(MetadataReader reader)
+        {
+            return new ArraySignatureHandle(this);
+        } // ToArraySignatureHandle
+
+        public ByReferenceSignatureHandle ToByReferenceSignatureHandle(MetadataReader reader)
+        {
+            return new ByReferenceSignatureHandle(this);
+        } // ToByReferenceSignatureHandle
+
+        public ConstantBooleanArrayHandle ToConstantBooleanArrayHandle(MetadataReader reader)
+        {
+            return new ConstantBooleanArrayHandle(this);
+        } // ToConstantBooleanArrayHandle
+
+        public ConstantBooleanValueHandle ToConstantBooleanValueHandle(MetadataReader reader)
+        {
+            return new ConstantBooleanValueHandle(this);
+        } // ToConstantBooleanValueHandle
+
+        public ConstantByteArrayHandle ToConstantByteArrayHandle(MetadataReader reader)
+        {
+            return new ConstantByteArrayHandle(this);
+        } // ToConstantByteArrayHandle
+
+        public ConstantByteValueHandle ToConstantByteValueHandle(MetadataReader reader)
+        {
+            return new ConstantByteValueHandle(this);
+        } // ToConstantByteValueHandle
+
+        public ConstantCharArrayHandle ToConstantCharArrayHandle(MetadataReader reader)
+        {
+            return new ConstantCharArrayHandle(this);
+        } // ToConstantCharArrayHandle
+
+        public ConstantCharValueHandle ToConstantCharValueHandle(MetadataReader reader)
+        {
+            return new ConstantCharValueHandle(this);
+        } // ToConstantCharValueHandle
+
+        public ConstantDoubleArrayHandle ToConstantDoubleArrayHandle(MetadataReader reader)
+        {
+            return new ConstantDoubleArrayHandle(this);
+        } // ToConstantDoubleArrayHandle
+
+        public ConstantDoubleValueHandle ToConstantDoubleValueHandle(MetadataReader reader)
+        {
+            return new ConstantDoubleValueHandle(this);
+        } // ToConstantDoubleValueHandle
+
+        public ConstantEnumArrayHandle ToConstantEnumArrayHandle(MetadataReader reader)
+        {
+            return new ConstantEnumArrayHandle(this);
+        } // ToConstantEnumArrayHandle
+
+        public ConstantEnumValueHandle ToConstantEnumValueHandle(MetadataReader reader)
+        {
+            return new ConstantEnumValueHandle(this);
+        } // ToConstantEnumValueHandle
+
+        public ConstantHandleArrayHandle ToConstantHandleArrayHandle(MetadataReader reader)
+        {
+            return new ConstantHandleArrayHandle(this);
+        } // ToConstantHandleArrayHandle
+
+        public ConstantInt16ArrayHandle ToConstantInt16ArrayHandle(MetadataReader reader)
+        {
+            return new ConstantInt16ArrayHandle(this);
+        } // ToConstantInt16ArrayHandle
+
+        public ConstantInt16ValueHandle ToConstantInt16ValueHandle(MetadataReader reader)
+        {
+            return new ConstantInt16ValueHandle(this);
+        } // ToConstantInt16ValueHandle
+
+        public ConstantInt32ArrayHandle ToConstantInt32ArrayHandle(MetadataReader reader)
+        {
+            return new ConstantInt32ArrayHandle(this);
+        } // ToConstantInt32ArrayHandle
+
+        public ConstantInt32ValueHandle ToConstantInt32ValueHandle(MetadataReader reader)
+        {
+            return new ConstantInt32ValueHandle(this);
+        } // ToConstantInt32ValueHandle
+
+        public ConstantInt64ArrayHandle ToConstantInt64ArrayHandle(MetadataReader reader)
+        {
+            return new ConstantInt64ArrayHandle(this);
+        } // ToConstantInt64ArrayHandle
+
+        public ConstantInt64ValueHandle ToConstantInt64ValueHandle(MetadataReader reader)
+        {
+            return new ConstantInt64ValueHandle(this);
+        } // ToConstantInt64ValueHandle
+
+        public ConstantReferenceValueHandle ToConstantReferenceValueHandle(MetadataReader reader)
+        {
+            return new ConstantReferenceValueHandle(this);
+        } // ToConstantReferenceValueHandle
+
+        public ConstantSByteArrayHandle ToConstantSByteArrayHandle(MetadataReader reader)
+        {
+            return new ConstantSByteArrayHandle(this);
+        } // ToConstantSByteArrayHandle
+
+        public ConstantSByteValueHandle ToConstantSByteValueHandle(MetadataReader reader)
+        {
+            return new ConstantSByteValueHandle(this);
+        } // ToConstantSByteValueHandle
+
+        public ConstantSingleArrayHandle ToConstantSingleArrayHandle(MetadataReader reader)
+        {
+            return new ConstantSingleArrayHandle(this);
+        } // ToConstantSingleArrayHandle
+
+        public ConstantSingleValueHandle ToConstantSingleValueHandle(MetadataReader reader)
+        {
+            return new ConstantSingleValueHandle(this);
+        } // ToConstantSingleValueHandle
+
+        public ConstantStringArrayHandle ToConstantStringArrayHandle(MetadataReader reader)
+        {
+            return new ConstantStringArrayHandle(this);
+        } // ToConstantStringArrayHandle
+
+        public ConstantStringValueHandle ToConstantStringValueHandle(MetadataReader reader)
+        {
+            return new ConstantStringValueHandle(this);
+        } // ToConstantStringValueHandle
+
+        public ConstantUInt16ArrayHandle ToConstantUInt16ArrayHandle(MetadataReader reader)
+        {
+            return new ConstantUInt16ArrayHandle(this);
+        } // ToConstantUInt16ArrayHandle
+
+        public ConstantUInt16ValueHandle ToConstantUInt16ValueHandle(MetadataReader reader)
+        {
+            return new ConstantUInt16ValueHandle(this);
+        } // ToConstantUInt16ValueHandle
+
+        public ConstantUInt32ArrayHandle ToConstantUInt32ArrayHandle(MetadataReader reader)
+        {
+            return new ConstantUInt32ArrayHandle(this);
+        } // ToConstantUInt32ArrayHandle
+
+        public ConstantUInt32ValueHandle ToConstantUInt32ValueHandle(MetadataReader reader)
+        {
+            return new ConstantUInt32ValueHandle(this);
+        } // ToConstantUInt32ValueHandle
+
+        public ConstantUInt64ArrayHandle ToConstantUInt64ArrayHandle(MetadataReader reader)
+        {
+            return new ConstantUInt64ArrayHandle(this);
+        } // ToConstantUInt64ArrayHandle
+
+        public ConstantUInt64ValueHandle ToConstantUInt64ValueHandle(MetadataReader reader)
+        {
+            return new ConstantUInt64ValueHandle(this);
+        } // ToConstantUInt64ValueHandle
+
+        public CustomAttributeHandle ToCustomAttributeHandle(MetadataReader reader)
+        {
+            return new CustomAttributeHandle(this);
+        } // ToCustomAttributeHandle
+
+        public EventHandle ToEventHandle(MetadataReader reader)
+        {
+            return new EventHandle(this);
+        } // ToEventHandle
+
+        public FieldHandle ToFieldHandle(MetadataReader reader)
+        {
+            return new FieldHandle(this);
+        } // ToFieldHandle
+
+        public FieldSignatureHandle ToFieldSignatureHandle(MetadataReader reader)
+        {
+            return new FieldSignatureHandle(this);
+        } // ToFieldSignatureHandle
+
+        public FunctionPointerSignatureHandle ToFunctionPointerSignatureHandle(MetadataReader reader)
+        {
+            return new FunctionPointerSignatureHandle(this);
+        } // ToFunctionPointerSignatureHandle
+
+        public GenericParameterHandle ToGenericParameterHandle(MetadataReader reader)
+        {
+            return new GenericParameterHandle(this);
+        } // ToGenericParameterHandle
+
+        public MemberReferenceHandle ToMemberReferenceHandle(MetadataReader reader)
+        {
+            return new MemberReferenceHandle(this);
+        } // ToMemberReferenceHandle
+
+        public MethodHandle ToMethodHandle(MetadataReader reader)
+        {
+            return new MethodHandle(this);
+        } // ToMethodHandle
+
+        public MethodInstantiationHandle ToMethodInstantiationHandle(MetadataReader reader)
+        {
+            return new MethodInstantiationHandle(this);
+        } // ToMethodInstantiationHandle
+
+        public MethodSemanticsHandle ToMethodSemanticsHandle(MetadataReader reader)
+        {
+            return new MethodSemanticsHandle(this);
+        } // ToMethodSemanticsHandle
+
+        public MethodSignatureHandle ToMethodSignatureHandle(MetadataReader reader)
+        {
+            return new MethodSignatureHandle(this);
+        } // ToMethodSignatureHandle
+
+        public MethodTypeVariableSignatureHandle ToMethodTypeVariableSignatureHandle(MetadataReader reader)
+        {
+            return new MethodTypeVariableSignatureHandle(this);
+        } // ToMethodTypeVariableSignatureHandle
+
+        public ModifiedTypeHandle ToModifiedTypeHandle(MetadataReader reader)
+        {
+            return new ModifiedTypeHandle(this);
+        } // ToModifiedTypeHandle
+
+        public NamedArgumentHandle ToNamedArgumentHandle(MetadataReader reader)
+        {
+            return new NamedArgumentHandle(this);
+        } // ToNamedArgumentHandle
+
+        public NamespaceDefinitionHandle ToNamespaceDefinitionHandle(MetadataReader reader)
+        {
+            return new NamespaceDefinitionHandle(this);
+        } // ToNamespaceDefinitionHandle
+
+        public NamespaceReferenceHandle ToNamespaceReferenceHandle(MetadataReader reader)
+        {
+            return new NamespaceReferenceHandle(this);
+        } // ToNamespaceReferenceHandle
+
+        public ParameterHandle ToParameterHandle(MetadataReader reader)
+        {
+            return new ParameterHandle(this);
+        } // ToParameterHandle
+
+        public PointerSignatureHandle ToPointerSignatureHandle(MetadataReader reader)
+        {
+            return new PointerSignatureHandle(this);
+        } // ToPointerSignatureHandle
+
+        public PropertyHandle ToPropertyHandle(MetadataReader reader)
+        {
+            return new PropertyHandle(this);
+        } // ToPropertyHandle
+
+        public PropertySignatureHandle ToPropertySignatureHandle(MetadataReader reader)
+        {
+            return new PropertySignatureHandle(this);
+        } // ToPropertySignatureHandle
+
+        public QualifiedFieldHandle ToQualifiedFieldHandle(MetadataReader reader)
+        {
+            return new QualifiedFieldHandle(this);
+        } // ToQualifiedFieldHandle
+
+        public QualifiedMethodHandle ToQualifiedMethodHandle(MetadataReader reader)
+        {
+            return new QualifiedMethodHandle(this);
+        } // ToQualifiedMethodHandle
+
+        public SZArraySignatureHandle ToSZArraySignatureHandle(MetadataReader reader)
+        {
+            return new SZArraySignatureHandle(this);
+        } // ToSZArraySignatureHandle
+
+        public ScopeDefinitionHandle ToScopeDefinitionHandle(MetadataReader reader)
+        {
+            return new ScopeDefinitionHandle(this);
+        } // ToScopeDefinitionHandle
+
+        public ScopeReferenceHandle ToScopeReferenceHandle(MetadataReader reader)
+        {
+            return new ScopeReferenceHandle(this);
+        } // ToScopeReferenceHandle
+
+        public TypeDefinitionHandle ToTypeDefinitionHandle(MetadataReader reader)
+        {
+            return new TypeDefinitionHandle(this);
+        } // ToTypeDefinitionHandle
+
+        public TypeForwarderHandle ToTypeForwarderHandle(MetadataReader reader)
+        {
+            return new TypeForwarderHandle(this);
+        } // ToTypeForwarderHandle
+
+        public TypeInstantiationSignatureHandle ToTypeInstantiationSignatureHandle(MetadataReader reader)
+        {
+            return new TypeInstantiationSignatureHandle(this);
+        } // ToTypeInstantiationSignatureHandle
+
+        public TypeReferenceHandle ToTypeReferenceHandle(MetadataReader reader)
+        {
+            return new TypeReferenceHandle(this);
+        } // ToTypeReferenceHandle
+
+        public TypeSpecificationHandle ToTypeSpecificationHandle(MetadataReader reader)
+        {
+            return new TypeSpecificationHandle(this);
+        } // ToTypeSpecificationHandle
+
+        public TypeVariableSignatureHandle ToTypeVariableSignatureHandle(MetadataReader reader)
+        {
+            return new TypeVariableSignatureHandle(this);
+        } // ToTypeVariableSignatureHandle
+    } // Handle
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal readonly partial struct HandleCollection
+    {
+        private readonly NativeReader _reader;
+        private readonly uint _offset;
+
+        internal HandleCollection(NativeReader reader, uint offset)
+        {
+            _offset = offset;
+            _reader = reader;
+        }
+
+        public int Count
+        {
+            get
+            {
+                uint count;
+                _reader.DecodeUnsigned(_offset, out count);
+                return (int)count;
+            }
+        } // Count
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_reader, _offset);
+        } // GetEnumerator
+
+#if SYSTEM_PRIVATE_CORELIB
+        [CLSCompliant(false)]
+#endif
+        public struct Enumerator
+        {
+            private readonly NativeReader _reader;
+            private uint _offset;
+            private uint _remaining;
+            private Handle _current;
+
+            internal Enumerator(NativeReader reader, uint offset)
+            {
+                _reader = reader;
+                _offset = reader.DecodeUnsigned(offset, out _remaining);
+                _current = default(Handle);
+            }
+
+            public Handle Current
+            {
+                get
+                {
+                    return _current;
+                }
+            } // Current
+
+            public bool MoveNext()
+            {
+                if (_remaining == 0)
+                    return false;
+                _remaining--;
+                _offset = _reader.Read(_offset, out _current);
+                return true;
+            } // MoveNext
+
+            public void Dispose()
+            {
+            } // Dispose
+        } // Enumerator
+    } // HandleCollection
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal partial class MetadataReader
+    {
+        public ArraySignature GetArraySignature(ArraySignatureHandle handle)
+        {
+            return new ArraySignature(this, handle);
+        } // GetArraySignature
+
+        public ByReferenceSignature GetByReferenceSignature(ByReferenceSignatureHandle handle)
+        {
+            return new ByReferenceSignature(this, handle);
+        } // GetByReferenceSignature
+
+        public ConstantBooleanArray GetConstantBooleanArray(ConstantBooleanArrayHandle handle)
+        {
+            return new ConstantBooleanArray(this, handle);
+        } // GetConstantBooleanArray
+
+        public ConstantBooleanValue GetConstantBooleanValue(ConstantBooleanValueHandle handle)
+        {
+            return new ConstantBooleanValue(this, handle);
+        } // GetConstantBooleanValue
+
+        public ConstantByteArray GetConstantByteArray(ConstantByteArrayHandle handle)
+        {
+            return new ConstantByteArray(this, handle);
+        } // GetConstantByteArray
+
+        public ConstantByteValue GetConstantByteValue(ConstantByteValueHandle handle)
+        {
+            return new ConstantByteValue(this, handle);
+        } // GetConstantByteValue
+
+        public ConstantCharArray GetConstantCharArray(ConstantCharArrayHandle handle)
+        {
+            return new ConstantCharArray(this, handle);
+        } // GetConstantCharArray
+
+        public ConstantCharValue GetConstantCharValue(ConstantCharValueHandle handle)
+        {
+            return new ConstantCharValue(this, handle);
+        } // GetConstantCharValue
+
+        public ConstantDoubleArray GetConstantDoubleArray(ConstantDoubleArrayHandle handle)
+        {
+            return new ConstantDoubleArray(this, handle);
+        } // GetConstantDoubleArray
+
+        public ConstantDoubleValue GetConstantDoubleValue(ConstantDoubleValueHandle handle)
+        {
+            return new ConstantDoubleValue(this, handle);
+        } // GetConstantDoubleValue
+
+        public ConstantEnumArray GetConstantEnumArray(ConstantEnumArrayHandle handle)
+        {
+            return new ConstantEnumArray(this, handle);
+        } // GetConstantEnumArray
+
+        public ConstantEnumValue GetConstantEnumValue(ConstantEnumValueHandle handle)
+        {
+            return new ConstantEnumValue(this, handle);
+        } // GetConstantEnumValue
+
+        public ConstantHandleArray GetConstantHandleArray(ConstantHandleArrayHandle handle)
+        {
+            return new ConstantHandleArray(this, handle);
+        } // GetConstantHandleArray
+
+        public ConstantInt16Array GetConstantInt16Array(ConstantInt16ArrayHandle handle)
+        {
+            return new ConstantInt16Array(this, handle);
+        } // GetConstantInt16Array
+
+        public ConstantInt16Value GetConstantInt16Value(ConstantInt16ValueHandle handle)
+        {
+            return new ConstantInt16Value(this, handle);
+        } // GetConstantInt16Value
+
+        public ConstantInt32Array GetConstantInt32Array(ConstantInt32ArrayHandle handle)
+        {
+            return new ConstantInt32Array(this, handle);
+        } // GetConstantInt32Array
+
+        public ConstantInt32Value GetConstantInt32Value(ConstantInt32ValueHandle handle)
+        {
+            return new ConstantInt32Value(this, handle);
+        } // GetConstantInt32Value
+
+        public ConstantInt64Array GetConstantInt64Array(ConstantInt64ArrayHandle handle)
+        {
+            return new ConstantInt64Array(this, handle);
+        } // GetConstantInt64Array
+
+        public ConstantInt64Value GetConstantInt64Value(ConstantInt64ValueHandle handle)
+        {
+            return new ConstantInt64Value(this, handle);
+        } // GetConstantInt64Value
+
+        public ConstantReferenceValue GetConstantReferenceValue(ConstantReferenceValueHandle handle)
+        {
+            return new ConstantReferenceValue(this, handle);
+        } // GetConstantReferenceValue
+
+        public ConstantSByteArray GetConstantSByteArray(ConstantSByteArrayHandle handle)
+        {
+            return new ConstantSByteArray(this, handle);
+        } // GetConstantSByteArray
+
+        public ConstantSByteValue GetConstantSByteValue(ConstantSByteValueHandle handle)
+        {
+            return new ConstantSByteValue(this, handle);
+        } // GetConstantSByteValue
+
+        public ConstantSingleArray GetConstantSingleArray(ConstantSingleArrayHandle handle)
+        {
+            return new ConstantSingleArray(this, handle);
+        } // GetConstantSingleArray
+
+        public ConstantSingleValue GetConstantSingleValue(ConstantSingleValueHandle handle)
+        {
+            return new ConstantSingleValue(this, handle);
+        } // GetConstantSingleValue
+
+        public ConstantStringArray GetConstantStringArray(ConstantStringArrayHandle handle)
+        {
+            return new ConstantStringArray(this, handle);
+        } // GetConstantStringArray
+
+        public ConstantStringValue GetConstantStringValue(ConstantStringValueHandle handle)
+        {
+            return new ConstantStringValue(this, handle);
+        } // GetConstantStringValue
+
+        public ConstantUInt16Array GetConstantUInt16Array(ConstantUInt16ArrayHandle handle)
+        {
+            return new ConstantUInt16Array(this, handle);
+        } // GetConstantUInt16Array
+
+        public ConstantUInt16Value GetConstantUInt16Value(ConstantUInt16ValueHandle handle)
+        {
+            return new ConstantUInt16Value(this, handle);
+        } // GetConstantUInt16Value
+
+        public ConstantUInt32Array GetConstantUInt32Array(ConstantUInt32ArrayHandle handle)
+        {
+            return new ConstantUInt32Array(this, handle);
+        } // GetConstantUInt32Array
+
+        public ConstantUInt32Value GetConstantUInt32Value(ConstantUInt32ValueHandle handle)
+        {
+            return new ConstantUInt32Value(this, handle);
+        } // GetConstantUInt32Value
+
+        public ConstantUInt64Array GetConstantUInt64Array(ConstantUInt64ArrayHandle handle)
+        {
+            return new ConstantUInt64Array(this, handle);
+        } // GetConstantUInt64Array
+
+        public ConstantUInt64Value GetConstantUInt64Value(ConstantUInt64ValueHandle handle)
+        {
+            return new ConstantUInt64Value(this, handle);
+        } // GetConstantUInt64Value
+
+        public CustomAttribute GetCustomAttribute(CustomAttributeHandle handle)
+        {
+            return new CustomAttribute(this, handle);
+        } // GetCustomAttribute
+
+        public Event GetEvent(EventHandle handle)
+        {
+            return new Event(this, handle);
+        } // GetEvent
+
+        public Field GetField(FieldHandle handle)
+        {
+            return new Field(this, handle);
+        } // GetField
+
+        public FieldSignature GetFieldSignature(FieldSignatureHandle handle)
+        {
+            return new FieldSignature(this, handle);
+        } // GetFieldSignature
+
+        public FunctionPointerSignature GetFunctionPointerSignature(FunctionPointerSignatureHandle handle)
+        {
+            return new FunctionPointerSignature(this, handle);
+        } // GetFunctionPointerSignature
+
+        public GenericParameter GetGenericParameter(GenericParameterHandle handle)
+        {
+            return new GenericParameter(this, handle);
+        } // GetGenericParameter
+
+        public MemberReference GetMemberReference(MemberReferenceHandle handle)
+        {
+            return new MemberReference(this, handle);
+        } // GetMemberReference
+
+        public Method GetMethod(MethodHandle handle)
+        {
+            return new Method(this, handle);
+        } // GetMethod
+
+        public MethodInstantiation GetMethodInstantiation(MethodInstantiationHandle handle)
+        {
+            return new MethodInstantiation(this, handle);
+        } // GetMethodInstantiation
+
+        public MethodSemantics GetMethodSemantics(MethodSemanticsHandle handle)
+        {
+            return new MethodSemantics(this, handle);
+        } // GetMethodSemantics
+
+        public MethodSignature GetMethodSignature(MethodSignatureHandle handle)
+        {
+            return new MethodSignature(this, handle);
+        } // GetMethodSignature
+
+        public MethodTypeVariableSignature GetMethodTypeVariableSignature(MethodTypeVariableSignatureHandle handle)
+        {
+            return new MethodTypeVariableSignature(this, handle);
+        } // GetMethodTypeVariableSignature
+
+        public ModifiedType GetModifiedType(ModifiedTypeHandle handle)
+        {
+            return new ModifiedType(this, handle);
+        } // GetModifiedType
+
+        public NamedArgument GetNamedArgument(NamedArgumentHandle handle)
+        {
+            return new NamedArgument(this, handle);
+        } // GetNamedArgument
+
+        public NamespaceDefinition GetNamespaceDefinition(NamespaceDefinitionHandle handle)
+        {
+            return new NamespaceDefinition(this, handle);
+        } // GetNamespaceDefinition
+
+        public NamespaceReference GetNamespaceReference(NamespaceReferenceHandle handle)
+        {
+            return new NamespaceReference(this, handle);
+        } // GetNamespaceReference
+
+        public Parameter GetParameter(ParameterHandle handle)
+        {
+            return new Parameter(this, handle);
+        } // GetParameter
+
+        public PointerSignature GetPointerSignature(PointerSignatureHandle handle)
+        {
+            return new PointerSignature(this, handle);
+        } // GetPointerSignature
+
+        public Property GetProperty(PropertyHandle handle)
+        {
+            return new Property(this, handle);
+        } // GetProperty
+
+        public PropertySignature GetPropertySignature(PropertySignatureHandle handle)
+        {
+            return new PropertySignature(this, handle);
+        } // GetPropertySignature
+
+        public QualifiedField GetQualifiedField(QualifiedFieldHandle handle)
+        {
+            return new QualifiedField(this, handle);
+        } // GetQualifiedField
+
+        public QualifiedMethod GetQualifiedMethod(QualifiedMethodHandle handle)
+        {
+            return new QualifiedMethod(this, handle);
+        } // GetQualifiedMethod
+
+        public SZArraySignature GetSZArraySignature(SZArraySignatureHandle handle)
+        {
+            return new SZArraySignature(this, handle);
+        } // GetSZArraySignature
+
+        public ScopeDefinition GetScopeDefinition(ScopeDefinitionHandle handle)
+        {
+            return new ScopeDefinition(this, handle);
+        } // GetScopeDefinition
+
+        public ScopeReference GetScopeReference(ScopeReferenceHandle handle)
+        {
+            return new ScopeReference(this, handle);
+        } // GetScopeReference
+
+        public TypeDefinition GetTypeDefinition(TypeDefinitionHandle handle)
+        {
+            return new TypeDefinition(this, handle);
+        } // GetTypeDefinition
+
+        public TypeForwarder GetTypeForwarder(TypeForwarderHandle handle)
+        {
+            return new TypeForwarder(this, handle);
+        } // GetTypeForwarder
+
+        public TypeInstantiationSignature GetTypeInstantiationSignature(TypeInstantiationSignatureHandle handle)
+        {
+            return new TypeInstantiationSignature(this, handle);
+        } // GetTypeInstantiationSignature
+
+        public TypeReference GetTypeReference(TypeReferenceHandle handle)
+        {
+            return new TypeReference(this, handle);
+        } // GetTypeReference
+
+        public TypeSpecification GetTypeSpecification(TypeSpecificationHandle handle)
+        {
+            return new TypeSpecification(this, handle);
+        } // GetTypeSpecification
+
+        public TypeVariableSignature GetTypeVariableSignature(TypeVariableSignatureHandle handle)
+        {
+            return new TypeVariableSignature(this, handle);
+        } // GetTypeVariableSignature
+    } // MetadataReader
+} // Internal.Metadata.NativeFormat

--- a/src/Cosmos.Kernel.Core/Runtime/Internal/NativeFormat/Metadata/NativeMetadataReader.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Internal/NativeFormat/Metadata/NativeMetadataReader.cs
@@ -1,0 +1,251 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable 169
+#pragma warning disable 282 // There is no defined ordering between fields in multiple declarations of partial class or struct
+#pragma warning disable CA1066 // IEquatable<T> implementations aren't used
+
+using System;
+#pragma warning disable IDE0005 // Using directive is unnecessary.
+using System.IO;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+#pragma warning restore IDE0005 // Using directive is unnecessary.
+using Internal.NativeFormat;
+
+namespace Internal.Metadata.NativeFormat
+{
+    // This Enum matches CorMethodSemanticsAttr defined in CorHdr.h
+    [Flags]
+    internal enum MethodSemanticsAttributes
+    {
+        Setter = 0x0001,
+        Getter = 0x0002,
+        Other = 0x0004,
+        AddOn = 0x0008,
+        RemoveOn = 0x0010,
+        Fire = 0x0020,
+    }
+
+    // This Enum matches CorPInvokeMap defined in CorHdr.h
+    [Flags]
+    internal enum PInvokeAttributes
+    {
+        NoMangle = 0x0001,
+
+        CharSetMask = 0x0006,
+        CharSetNotSpec = 0x0000,
+        CharSetAnsi = 0x0002,
+        CharSetUnicode = 0x0004,
+        CharSetAuto = 0x0006,
+
+        BestFitUseAssem = 0x0000,
+        BestFitEnabled = 0x0010,
+        BestFitDisabled = 0x0020,
+        BestFitMask = 0x0030,
+
+        ThrowOnUnmappableCharUseAssem = 0x0000,
+        ThrowOnUnmappableCharEnabled = 0x1000,
+        ThrowOnUnmappableCharDisabled = 0x2000,
+        ThrowOnUnmappableCharMask = 0x3000,
+
+        SupportsLastError = 0x0040,
+
+        CallConvMask = 0x0700,
+        CallConvWinapi = 0x0100,
+        CallConvCdecl = 0x0200,
+        CallConvStdcall = 0x0300,
+        CallConvThiscall = 0x0400,
+        CallConvFastcall = 0x0500,
+
+        MaxValue = 0xFFFF,
+    }
+
+    internal readonly partial struct Handle
+    {
+        public override bool Equals(object obj)
+        {
+            if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        }
+
+        public bool Equals(Handle handle)
+        {
+            return _value == handle._value;
+        }
+
+        public override int GetHashCode()
+        {
+            return (int)_value;
+        }
+
+        internal Handle(int value)
+        {
+            _value = value;
+        }
+
+        internal void Validate(params HandleType[] permittedTypes)
+        {
+            var myHandleType = (HandleType)((uint)_value >> 25);
+            foreach (var hType in permittedTypes)
+            {
+                if (myHandleType == hType)
+                {
+                    return;
+                }
+            }
+            if (myHandleType == HandleType.Null)
+            {
+                return;
+            }
+            throw new ArgumentException("Invalid handle type");
+        }
+
+        public Handle(HandleType type, int offset)
+        {
+            _value = (int)type << 25 | (int)offset;
+        }
+
+        public HandleType HandleType => (HandleType)((uint)_value >> 25);
+
+        internal int Offset => _value & 0x01FFFFFF;
+
+        public bool IsNil => (_value & 0x01FFFFFF) == 0;
+
+        public int ToIntToken() => _value;
+
+        public static Handle FromIntToken(int value) => new Handle(value);
+
+        internal readonly int _value;
+
+#if DEBUG
+        public override string ToString()
+        {
+            return string.Format("{1} : {0,8:X8}", _value, Enum.GetName(typeof(HandleType), this.HandleType));
+        }
+#endif
+    }
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal static class NativeFormatReaderExtensions
+    {
+        public static string GetString(this MetadataReader reader, ConstantStringValueHandle handle)
+        {
+            return reader.GetConstantStringValue(handle).Value;
+        }
+    }
+
+    /// <summary>
+    /// ConstantReferenceValue can only be used to encapsulate null reference values,
+    /// and therefore does not actually store the value.
+    /// </summary>
+    internal readonly partial struct ConstantReferenceValue
+    {
+        /// Always returns null value.
+        public object Value
+        { get { return null; } }
+    } // ConstantReferenceValue
+
+    internal readonly partial struct ConstantStringValueHandle
+    {
+        public bool StringEquals(string value, MetadataReader reader)
+        {
+            return reader.StringEquals(this, value);
+        }
+    }
+
+    internal sealed partial class MetadataReader
+    {
+        private MetadataHeader _header;
+
+        internal NativeReader _streamReader;
+
+        // Creates a metadata reader on a memory-mapped file block
+        public unsafe MetadataReader(IntPtr pBuffer, int cbBuffer)
+        {
+            _streamReader = new NativeReader((byte*)pBuffer, (uint)cbBuffer);
+
+            _header = new MetadataHeader();
+            _header.Decode(_streamReader);
+        }
+
+        /// <summary>
+        /// Used as the root entrypoint for metadata, this is where all top-down
+        /// structural walks of metadata must start.
+        /// </summary>
+        public ScopeDefinitionHandleCollection ScopeDefinitions
+        {
+            get
+            {
+                return _header.ScopeDefinitions;
+            }
+        }
+
+        /// <summary>
+        /// Returns a Handle value representing the null value. Can be used
+        /// to test handle values of all types for null.
+        /// </summary>
+        public Handle NullHandle
+        {
+            get
+            {
+                return new Handle(((int)HandleType.Null) << 25);
+            }
+        }
+
+        /// <summary>
+        /// Returns true if handle is null.
+        /// </summary>
+        public bool IsNull(Handle handle)
+        {
+            return handle._value == NullHandle._value;
+        }
+
+        /// <summary>
+        /// Idempotent - simply returns the provided handle value. Exists for
+        /// consistency so that generated code does not need to handle this
+        /// as a special case.
+        /// </summary>
+        public Handle ToHandle(Handle handle)
+        {
+            return handle;
+        }
+
+        internal bool StringEquals(ConstantStringValueHandle handle, string value)
+        {
+            return _streamReader.StringEquals((uint)handle.Offset, value);
+        }
+
+        internal ReadOnlySpan<byte> ReadStringAsBytes(ConstantStringValueHandle handle)
+        {
+            if (handle.IsNil)
+            {
+                return [];
+            }
+
+            return _streamReader.ReadStringAsBytes((uint)handle.Offset);
+        }
+    }
+
+    internal sealed partial class MetadataHeader
+    {
+        public const uint Signature = 0xDEADDFFD;
+
+        /// <summary>
+        /// The set of ScopeDefinitions contained within this metadata resource.
+        /// </summary>
+        public ScopeDefinitionHandleCollection ScopeDefinitions;
+
+        public void Decode(NativeReader reader)
+        {
+            if (reader.ReadUInt32(0) != Signature)
+                NativeReader.ThrowBadImageFormatException();
+            reader.Read(4, out ScopeDefinitions);
+        }
+    }
+}

--- a/src/Cosmos.Kernel.Core/Runtime/Internal/NativeFormat/TypeHashingAlgorithms.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Internal/NativeFormat/TypeHashingAlgorithms.cs
@@ -1,0 +1,257 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// ---------------------------------------------------------------------------
+// Generic functions to compute the hashcode value of types
+// ---------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Internal.NativeFormat
+{
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+#endif
+    internal static class TypeHashingAlgorithms
+    {
+        public struct HashCodeBuilder
+        {
+            private int _hash1;
+            private int _hash2;
+            private int _numCharactersHashed;
+
+            public HashCodeBuilder(string seed)
+            {
+                _hash1 = 0x6DA3B944;
+                _hash2 = 0;
+                _numCharactersHashed = 0;
+
+                Append(seed);
+            }
+
+            public void Append(string src)
+            {
+                if (src.Length == 0)
+                    return;
+
+                int startIndex = 0;
+                if ((_numCharactersHashed & 1) == 1)
+                {
+                    _hash2 = (_hash2 + _rotl(_hash2, 5)) ^ src[0];
+                    startIndex = 1;
+                }
+
+                for (int i = startIndex; i < src.Length; i += 2)
+                {
+                    _hash1 = (_hash1 + _rotl(_hash1, 5)) ^ src[i];
+                    if ((i + 1) < src.Length)
+                        _hash2 = (_hash2 + _rotl(_hash2, 5)) ^ src[i + 1];
+                }
+
+                _numCharactersHashed += src.Length;
+            }
+
+            public int ToHashCode()
+            {
+                int hash1 = _hash1 + _rotl(_hash1, 8);
+                int hash2 = _hash2 + _rotl(_hash2, 8);
+
+                return hash1 ^ hash2;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int _rotl(int value, int shift)
+        {
+            return (int)(((uint)value << shift) | ((uint)value >> (32 - shift)));
+        }
+
+        //
+        // Returns the hashcode value of the 'src' string
+        //
+        public static int ComputeNameHashCode(string src)
+        {
+            int hash1 = 0x6DA3B944;
+            int hash2 = 0;
+
+            for (int i = 0; i < src.Length; i += 2)
+            {
+                hash1 = (hash1 + _rotl(hash1, 5)) ^ src[i];
+                if ((i + 1) < src.Length)
+                    hash2 = (hash2 + _rotl(hash2, 5)) ^ src[i + 1];
+            }
+
+            hash1 += _rotl(hash1, 8);
+            hash2 += _rotl(hash2, 8);
+
+            return hash1 ^ hash2;
+        }
+
+        public static unsafe int ComputeASCIINameHashCode(byte* data, int length, out bool isAscii)
+        {
+            int hash1 = 0x6DA3B944;
+            int hash2 = 0;
+            int asciiMask = 0;
+
+            for (int i = 0; i < length; i += 2)
+            {
+                int b1 = data[i];
+                asciiMask |= b1;
+                hash1 = (hash1 + _rotl(hash1, 5)) ^ b1;
+                if ((i + 1) < length)
+                {
+                    int b2 = data[i];
+                    asciiMask |= b2;
+                    hash2 = (hash2 + _rotl(hash2, 5)) ^ b2;
+                }
+            }
+
+            hash1 += _rotl(hash1, 8);
+            hash2 += _rotl(hash2, 8);
+
+            isAscii = (asciiMask & 0x80) == 0;
+
+            return hash1 ^ hash2;
+        }
+
+        // This function may be needed in a portion of the codebase which is too low level to use
+        // globalization, ergo, we cannot call ToString on the integer.
+        private static string IntToString(int arg)
+        {
+            // This IntToString function is only expected to be used for MDArrayRanks, and therefore is only for positive numbers
+            Debug.Assert(arg > 0);
+            StringBuilder sb = new StringBuilder(1);
+
+            while (arg != 0)
+            {
+                sb.Append((char)('0' + (arg % 10)));
+                arg /= 10;
+            }
+
+            // Reverse the string
+            int sbLen = sb.Length;
+            int pivot = sbLen / 2;
+            for (int i = 0; i < pivot; i++)
+            {
+                int iToSwapWith = sbLen - i - 1;
+                char temp = sb[i];
+                sb[i] = sb[iToSwapWith];
+                sb[iToSwapWith] = temp;
+            }
+
+            return sb.ToString();
+        }
+
+        public static int ComputeArrayTypeHashCode(int elementTypeHashCode, int rank)
+        {
+            // Arrays are treated as generic types in some parts of our system. The array hashcodes are
+            // carefully crafted to be the same as the hashcodes of their implementation generic types.
+
+            int hashCode;
+            if (rank == -1)
+            {
+                hashCode = unchecked((int)0xd5313557u);
+                Debug.Assert(hashCode == ComputeNameHashCode("System.Array`1"));
+            }
+            else
+            {
+                hashCode = ComputeNameHashCode("System.MDArrayRank" + IntToString(rank) + "`1");
+            }
+
+            hashCode = (hashCode + _rotl(hashCode, 13)) ^ elementTypeHashCode;
+            return (hashCode + _rotl(hashCode, 15));
+        }
+
+        public static int ComputeArrayTypeHashCode<T>(T elementType, int rank)
+        {
+            return ComputeArrayTypeHashCode(elementType.GetHashCode(), rank);
+        }
+
+
+        public static int ComputePointerTypeHashCode(int pointeeTypeHashCode)
+        {
+            return (pointeeTypeHashCode + _rotl(pointeeTypeHashCode, 5)) ^ 0x12D0;
+        }
+
+        public static int ComputePointerTypeHashCode<T>(T pointeeType)
+        {
+            return ComputePointerTypeHashCode(pointeeType.GetHashCode());
+        }
+
+
+        public static int ComputeByrefTypeHashCode(int parameterTypeHashCode)
+        {
+            return (parameterTypeHashCode + _rotl(parameterTypeHashCode, 7)) ^ 0x4C85;
+        }
+
+        public static int ComputeByrefTypeHashCode<T>(T parameterType)
+        {
+            return ComputeByrefTypeHashCode(parameterType.GetHashCode());
+        }
+
+
+        public static int ComputeNestedTypeHashCode(int enclosingTypeHashCode, int nestedTypeNameHash)
+        {
+            return (enclosingTypeHashCode + _rotl(enclosingTypeHashCode, 11)) ^ nestedTypeNameHash;
+        }
+
+
+        public static int ComputeGenericInstanceHashCode<ARG>(int genericDefinitionHashCode, ARG[] genericTypeArguments)
+        {
+            int hashcode = genericDefinitionHashCode;
+            for (int i = 0; i < genericTypeArguments.Length; i++)
+            {
+                int argumentHashCode = genericTypeArguments[i].GetHashCode();
+                hashcode = (hashcode + _rotl(hashcode, 13)) ^ argumentHashCode;
+            }
+            return (hashcode + _rotl(hashcode, 15));
+        }
+
+        public static int ComputeMethodSignatureHashCode<ARG>(int returnTypeHashCode, ARG[] parameters)
+        {
+            // We're not taking calling conventions into consideration here mostly because there's no
+            // exchange enum type that would define them. We could define one, but the amount of additional
+            // information it would bring (16 or so possibilities) is likely not worth it.
+            int hashcode = returnTypeHashCode;
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                int parameterHashCode = parameters[i].GetHashCode();
+                hashcode = (hashcode + _rotl(hashcode, 13)) ^ parameterHashCode;
+            }
+            return (hashcode + _rotl(hashcode, 15));
+        }
+
+        /// <summary>
+        /// Produce a hashcode for a specific method
+        /// </summary>
+        /// <param name="typeHashCode">HashCode of the type that owns the method</param>
+        /// <param name="nameOrNameAndGenericArgumentsHashCode">HashCode of either the name of the method (for non-generic methods) or the GenericInstanceHashCode of the name+generic arguments of the method.</param>
+        /// <returns></returns>
+        public static int ComputeMethodHashCode(int typeHashCode, int nameOrNameAndGenericArgumentsHashCode)
+        {
+            // TODO! This hash combining function isn't good, but it matches logic used in the past
+            // consider changing to a better combining function once all uses use this function
+            return typeHashCode ^ nameOrNameAndGenericArgumentsHashCode;
+        }
+
+        /// <summary>
+        /// Produce a hashcode for a generic signature variable
+        /// </summary>
+        /// <param name="index">zero based index</param>
+        /// <param name="method">true if the signature variable describes a method</param>
+        public static int ComputeSignatureVariableHashCode(int index, bool method)
+        {
+            if (method)
+            {
+                return index * 0x7822381 + 0x54872645;
+            }
+            else
+            {
+                return index * 0x5498341 + 0x832424;
+            }
+        }
+    }
+}

--- a/src/Cosmos.Kernel.Core/Runtime/Internal/Runtime/ExceptionIDs.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Internal/Runtime/ExceptionIDs.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime
+{
+    internal enum ExceptionIDs
+    {
+        OutOfMemory = 1,
+        Arithmetic = 2,
+        ArrayTypeMismatch = 3,
+        DivideByZero = 4,
+        IndexOutOfRange = 5,
+        InvalidCast = 6,
+        Overflow = 7,
+        NullReference = 8,
+        AccessViolation = 9,
+        DataMisaligned = 10,
+        EntrypointNotFound = 11,
+        AmbiguousImplementation = 12,
+        IllegalInstruction = 13,
+        PrivilegedInstruction = 14,
+        InPageError = 15,
+    }
+}

--- a/src/Cosmos.Kernel.Core/Runtime/Internal/Runtime/ReadyToRunHeader.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Internal/Runtime/ReadyToRunHeader.cs
@@ -42,12 +42,7 @@ namespace Internal.Runtime
     // This list should be kept in sync with the runtime version at
     // https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/readytorun.h
     //
-#if SYSTEM_PRIVATE_CORELIB
-    internal
-#else
-    public
-#endif
-    enum ReadyToRunSectionType
+    internal enum ReadyToRunSectionType
     {
         //
         // CoreCLR ReadyToRun sections

--- a/src/Cosmos.Kernel.Core/Runtime/Internal/Runtime/ReadyToRunHeader.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Internal/Runtime/ReadyToRunHeader.cs
@@ -18,7 +18,7 @@ namespace Internal.Runtime
     }
 
 #pragma warning disable 0169
-    public struct ReadyToRunHeader
+    internal struct ReadyToRunHeader
     {
         internal uint Signature;      // ReadyToRunHeaderConstants.Signature
         internal ushort MajorVersion;

--- a/src/Cosmos.Kernel.Core/Runtime/Internal/Runtime/TypeManagerHandle.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Internal/Runtime/TypeManagerHandle.cs
@@ -6,7 +6,7 @@ namespace Internal.Runtime
     /// TypeManagerHandle represents an AOT module in MRT based runtimes.
     /// These handles are a pointer to a TypeManager
     /// </summary>
-    public readonly unsafe partial struct TypeManagerHandle(TypeManager* handleValue)
+    internal readonly unsafe partial struct TypeManagerHandle(TypeManager* handleValue)
     {
         internal readonly TypeManager* _handleValue = handleValue;
 
@@ -21,7 +21,7 @@ namespace Internal.Runtime
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    public unsafe struct TypeManager
+    internal unsafe struct TypeManager
     {
         public IntPtr OsHandle;
         public ReadyToRunHeader* Header;
@@ -77,7 +77,7 @@ namespace Internal.Runtime
         }
     }
 
-    public enum ClassLibFunctionId
+    internal enum ClassLibFunctionId
     {
         GetRuntimeException = 0,
         FailFast = 1,

--- a/src/Cosmos.Kernel.Core/Runtime/Memory.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Memory.cs
@@ -10,7 +10,7 @@ using Internal.Runtime;
 namespace Cosmos.Kernel.Core.Runtime;
 
 
-public static unsafe class Memory
+internal static unsafe class Memory
 {
     [RuntimeExport("RhNewArray")]
     internal static unsafe void* RhNewArray(MethodTable* pEEType, int length)

--- a/src/Cosmos.Kernel.Core/Runtime/MetaTable.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/MetaTable.cs
@@ -9,7 +9,7 @@ namespace Cosmos.Kernel.Core.Runtime;
 /// <summary>
 /// Contains runtime exports for various metadata and dispatch operations
 /// </summary>
-public unsafe class MetaTable
+internal unsafe class MetaTable
 {
     [RuntimeExport("RhGetModuleFileName")]
     internal static int RhGetModuleFileName(IntPtr moduleHandle, out byte* moduleName)

--- a/src/Cosmos.Kernel.Core/Runtime/ResourceManager.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/ResourceManager.cs
@@ -6,7 +6,7 @@ using Internal.Runtime;
 
 namespace Cosmos.Kernel.Core.Runtime;
 
-public static class ResourceManager
+internal static class ResourceManager
 {
     public static unsafe UnmanagedMemoryStream? GetResourceStream(string resourceName)
     {

--- a/src/Cosmos.Kernel.Core/Runtime/StackTraceMetadata.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/StackTraceMetadata.cs
@@ -7,7 +7,7 @@ using Internal.StackTraceMetadata;
 
 namespace Cosmos.Kernel.Core.Runtime
 {
-    public static class StackTraceMetadata
+    internal static class StackTraceMetadata
     {
         /// <summary>
         /// Indicates whether stack trace metadata support is enabled.

--- a/src/Cosmos.Kernel.Core/Runtime/Stdllib.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Stdllib.cs
@@ -16,11 +16,11 @@ namespace System
             Optimized
         }
 
-        public sealed class RuntimeExportAttribute(string entry) : Attribute
+        internal sealed class RuntimeExportAttribute(string entry) : Attribute
         {
         }
 
-        public sealed class RuntimeImportAttribute : Attribute
+        internal sealed class RuntimeImportAttribute : Attribute
         {
             public string DllName { get; }
             public string EntryPoint { get; }

--- a/src/Cosmos.Kernel.Core/Runtime/Thread.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/Thread.cs
@@ -7,7 +7,7 @@ using Cosmos.Kernel.Core.Scheduler;
 
 namespace Cosmos.Kernel.Core.Runtime;
 
-public class Thread
+internal class Thread
 {
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
     private static object[][] s_threadData;

--- a/src/Cosmos.Kernel.Core/Scheduler/AlarmSystem.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/AlarmSystem.cs
@@ -13,7 +13,7 @@ namespace Cosmos.Kernel.Core.Scheduler;
 /// primitives. Requires the scheduler; resolution is bounded by the scheduler
 /// tick.
 /// </summary>
-public static class AlarmSystem
+internal static class AlarmSystem
 {
     /// <summary>
     /// The method invoked when an alarm fires.

--- a/src/Cosmos.Kernel.Core/Scheduler/ConditionVariable.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/ConditionVariable.cs
@@ -8,7 +8,7 @@ namespace Cosmos.Kernel.Core.Scheduler;
 /// <summary>
 /// A condition variable primitive for coordinating scheduler threads around state changes.
 /// </summary>
-public class ConditionVariable : IDisposable
+internal class ConditionVariable : IDisposable
 {
     /// <summary>
     /// Protects access to the condition variable internal state.

--- a/src/Cosmos.Kernel.Core/Scheduler/ContextSwitch.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/ContextSwitch.cs
@@ -8,7 +8,7 @@ namespace Cosmos.Kernel.Core.Scheduler;
 /// Low-level context switch operations.
 /// Native imports live in Cosmos.Kernel.Core/Bridge/Import/ContextSwitchNative.cs.
 /// </summary>
-public static class ContextSwitch
+internal static class ContextSwitch
 {
     /// <summary>
     /// Requests a context switch to the specified thread.

--- a/src/Cosmos.Kernel.Core/Scheduler/Experimentals.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/Experimentals.cs
@@ -1,0 +1,19 @@
+namespace Cosmos.Kernel.Core.Scheduler;
+
+/// <summary>
+/// Diagnostic IDs of the experimental API seams exposed by
+/// Cosmos.Kernel.Core. An experimental API is usable today but carries no
+/// compatibility promise; referencing one produces an error with the ID
+/// below until the caller suppresses it, which is the caller's
+/// acknowledgement of that contract.
+/// </summary>
+internal static class Experimentals
+{
+    /// <summary>
+    /// The scheduler policy seam: <see cref="IScheduler"/>,
+    /// <see cref="SchedulerManager"/>, <see cref="Thread"/>,
+    /// <see cref="PerCpuState"/>, <see cref="SchedulerExtensible"/>, and
+    /// the <see cref="ThreadState"/>/<see cref="ThreadFlags"/> enums.
+    /// </summary>
+    internal const string SchedulerSeamDiagId = "COSMOS0001";
+}

--- a/src/Cosmos.Kernel.Core/Scheduler/IScheduler.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/IScheduler.cs
@@ -1,9 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Cosmos.Kernel.Core.Scheduler;
 
 /// <summary>
 /// Interface for pluggable scheduling algorithms.
 /// Inspired by Ekiben's EkibenScheduler trait.
 /// </summary>
+[Experimental(Experimentals.SchedulerSeamDiagId)]
 public interface IScheduler
 {
     // ========== Identity ==========
@@ -117,5 +120,5 @@ public interface IScheduler
     /// Get a thread from the run queue by index.
     /// Returns null if index is out of range.
     /// </summary>
-    Thread GetRunQueueThread(PerCpuState cpuState, int index);
+    Thread? GetRunQueueThread(PerCpuState cpuState, int index);
 }

--- a/src/Cosmos.Kernel.Core/Scheduler/InterruptEvent.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/InterruptEvent.cs
@@ -22,7 +22,7 @@ namespace Cosmos.Kernel.Core.Scheduler;
 /// two parked waiters wake both, and signals arriving while no consumer
 /// waits are consumed one per subsequent <see cref="Wait"/>.</para>
 /// </summary>
-public class InterruptEvent
+internal class InterruptEvent
 {
     /// <summary>Initial waiter-list capacity: pre-sized so Wait's first Add doesn't heap-allocate under the IRQ-off spinlock; driver flows park at most one or two waiters.</summary>
     private const int InitialWaiterCapacity = 4;

--- a/src/Cosmos.Kernel.Core/Scheduler/InterruptMaskScope.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/InterruptMaskScope.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics.CodeAnalysis;
+using Cosmos.Kernel.Core.CPU;
+
+namespace Cosmos.Kernel.Core.Scheduler;
+
+/// <summary>
+/// Masks maskable interrupts on the current CPU for the lifetime of the
+/// scope and restores the previous interrupt state on dispose. Obtained
+/// from <see cref="SchedulerManager.MaskInterrupts"/>; use it in a
+/// <see langword="using"/> statement around scheduler entry points the
+/// manager does not already guard (diagnostics reads, tuning setters), so
+/// the timer tick cannot observe a half-mutated run structure.
+/// </summary>
+[Experimental(Experimentals.SchedulerSeamDiagId)]
+public ref struct InterruptMaskScope
+{
+    private InternalCpu.InterruptScope _scope;
+
+    internal InterruptMaskScope(InternalCpu.InterruptScope scope)
+    {
+        _scope = scope;
+    }
+
+    /// <summary>
+    /// Restores the interrupt state captured when the scope was taken.
+    /// </summary>
+    public void Dispose() => _scope.Dispose();
+}

--- a/src/Cosmos.Kernel.Core/Scheduler/Monitor.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/Monitor.cs
@@ -9,7 +9,7 @@ namespace Cosmos.Kernel.Core.Scheduler;
 /// This monitor combines a <see cref="Mutex"/> and a <see cref="ConditionVariable"/> to provide
 /// acquire/release semantics and wait/signal behavior for the scheduler.
 /// </remarks>
-public class Monitor : IDisposable
+internal class Monitor : IDisposable
 {
     /// <summary>
     /// Mutex used to protect the monitor's critical section.

--- a/src/Cosmos.Kernel.Core/Scheduler/Mutex.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/Mutex.cs
@@ -10,7 +10,7 @@ namespace Cosmos.Kernel.Core.Scheduler;
 /// <remarks>
 /// This mutex supports recursive locking by the same thread.
 /// </remarks>
-public class Mutex : IDisposable
+internal class Mutex : IDisposable
 {
     /// <summary>Initial capacity of the wait queue, pre-sized so the first Add in Acquire allocates nothing under the IRQ-off state lock (mirrors InterruptEvent._waiters).</summary>
     private const int InitialWaitQueueCapacity = 4;

--- a/src/Cosmos.Kernel.Core/Scheduler/PerCpuState.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/PerCpuState.cs
@@ -42,5 +42,5 @@ public class PerCpuState : SchedulerExtensible
     internal bool _needReschedule;
 
     // ===== Synchronization =====
-    internal SpinLock Lock;
+    internal SpinLock _lock;
 }

--- a/src/Cosmos.Kernel.Core/Scheduler/PerCpuState.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/PerCpuState.cs
@@ -1,18 +1,38 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Cosmos.Kernel.Core.Scheduler;
 
 /// <summary>
 /// Per-CPU scheduling state.
 /// </summary>
+[Experimental(Experimentals.SchedulerSeamDiagId)]
 public class PerCpuState : SchedulerExtensible
 {
     // ===== Identity =====
-    public uint CpuId { get; set; }
+
+    /// <summary>
+    /// ID of the CPU this state belongs to.
+    /// </summary>
+    public uint CpuId { get; internal set; }
 
     // ===== Current Execution =====
+
+    /// <summary>
+    /// Thread currently executing on this CPU, or <see langword="null"/>
+    /// before the scheduler has run.
+    /// </summary>
     public Thread? CurrentThread { get; internal set; }
+
+    /// <summary>
+    /// This CPU's idle thread, scheduled when no other thread is runnable.
+    /// </summary>
     public Thread? IdleThread { get; internal set; }
 
     // ===== Timing =====
+
+    /// <summary>
+    /// Timestamp of the last timer tick processed on this CPU.
+    /// </summary>
     public ulong LastTickAt { get; internal set; }
 
     // Set by ReadyThread when it wakes a thread (typically an ISR-side
@@ -22,5 +42,5 @@ public class PerCpuState : SchedulerExtensible
     internal bool _needReschedule;
 
     // ===== Synchronization =====
-    public SpinLock Lock;
+    internal SpinLock Lock;
 }

--- a/src/Cosmos.Kernel.Core/Scheduler/SchedulerExtensible.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/SchedulerExtensible.cs
@@ -1,15 +1,22 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Cosmos.Kernel.Core.Scheduler;
 
 /// <summary>
 /// Base class for objects that can hold scheduler-specific extension data.
 /// </summary>
+[Experimental(Experimentals.SchedulerSeamDiagId)]
 public abstract class SchedulerExtensible
 {
     /// <summary>
-    /// Scheduler-specific data. Each scheduler defines its own class
-    /// and stores an instance here.
+    /// Scheduler-specific data. Each scheduler defines its own class and
+    /// stores an instance here from its <see cref="IScheduler"/> lifecycle
+    /// hooks (<see cref="IScheduler.InitializeCpu"/>,
+    /// <see cref="IScheduler.OnThreadCreate"/>), and clears it again in
+    /// <see cref="IScheduler.ShutdownCpu"/> and
+    /// <see cref="IScheduler.OnThreadExit"/>.
     /// </summary>
-    public object? SchedulerData { get; internal set; }
+    public object? SchedulerData { get; set; }
 
     /// <summary>
     /// Type-safe accessor for extension data.

--- a/src/Cosmos.Kernel.Core/Scheduler/SchedulerManager.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/SchedulerManager.cs
@@ -13,6 +13,7 @@ namespace Cosmos.Kernel.Core.Scheduler;
 /// <summary>
 /// Manages scheduler lifecycle and dispatches to current scheduler.
 /// </summary>
+[Experimental(Experimentals.SchedulerSeamDiagId)]
 public static class SchedulerManager
 {
 
@@ -79,7 +80,7 @@ public static class SchedulerManager
 
     // ========== Initialization ==========
 
-    public static void Initialize(uint cpuCount)
+    internal static void Initialize(uint cpuCount)
     {
         ThrowIfDisabled();
 
@@ -100,6 +101,12 @@ public static class SchedulerManager
         Cosmos.Kernel.Core.Runtime.DebugLiveMemorySnapshot.Initialize();
     }
 
+    /// <summary>
+    /// Installs a scheduling policy. The previous scheduler, if any, is
+    /// shut down on every CPU (<see cref="IScheduler.ShutdownCpu"/>) before
+    /// the new one is initialized (<see cref="IScheduler.InitializeCpu"/>).
+    /// </summary>
+    /// <param name="scheduler">Scheduler to install.</param>
     public static void SetScheduler(IScheduler scheduler)
     {
         ThrowIfCpuStateNotInitialized();
@@ -130,15 +137,34 @@ public static class SchedulerManager
 
     // ========== Accessors ==========
 
+    /// <summary>
+    /// The installed scheduler, or <see langword="null"/> before
+    /// <see cref="SetScheduler"/> has run.
+    /// </summary>
     public static IScheduler? Current => s_currentScheduler;
+
+    /// <summary>
+    /// Number of CPUs the scheduler manages.
+    /// </summary>
     public static uint CpuCount => s_cpuCount;
+
+    /// <summary>
+    /// Returns the scheduling state of a CPU, or <see langword="null"/>
+    /// before initialization.
+    /// </summary>
+    /// <param name="cpuId">CPU to look up, from 0 to <see cref="CpuCount"/> exclusive.</param>
     public static PerCpuState? GetCpuState(uint cpuId) => s_cpuStates?[cpuId];
+
+    /// <summary>
+    /// Returns the per-CPU state array, or <see langword="null"/> before
+    /// initialization.
+    /// </summary>
     public static PerCpuState[]? GetAllCpuStates() => s_cpuStates;
 
     /// <summary>
     /// Sets up the idle thread for a CPU. Should only be called during initialization.
     /// </summary>
-    public static void SetupIdleThread(uint cpuId, Thread idleThread)
+    internal static void SetupIdleThread(uint cpuId, Thread idleThread)
     {
         ThrowIfCpuStateNotInitialized();
 
@@ -154,13 +180,13 @@ public static class SchedulerManager
     public static bool Enabled
     {
         get => s_enabled;
-        set => s_enabled = value;
+        internal set => s_enabled = value;
     }
 
     /// <summary>
     /// Allocates a new unique thread ID.
     /// </summary>
-    public static uint AllocateThreadId() => s_nextThreadId++;
+    internal static uint AllocateThreadId() => s_nextThreadId++;
 
     // ========== Thread Entry Dispatch ==========
     [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "StartThread")]
@@ -179,7 +205,7 @@ public static class SchedulerManager
     /// the exit path ever races with a context switch.
     /// </summary>
     /// <param name="parameter">Generic parameter of the Thread Start, it is decoded based on the <see cref="ThreadFlags"/> set in the thread.</param>
-    public static void InvokeCurrentThreadStart(IntPtr parameter)
+    internal static void InvokeCurrentThreadStart(IntPtr parameter)
     {
         PerCpuState? cpuState = GetCpuState(GetCurrentCpuId());
         Thread? currentThread = cpuState?.CurrentThread;
@@ -310,10 +336,10 @@ public static class SchedulerManager
         return sum;
     }
 
-    public static nint OnThreadExitCallback
+    internal static nint OnThreadExitCallback
     {
         get;
-        internal set
+        set
         {
             Serial.WriteString("[SCHED] Setting thread exit callback: ");
             Serial.WriteHexWithPrefix((ulong)value);
@@ -325,7 +351,7 @@ public static class SchedulerManager
     /// <summary>
     /// Registers a thread in the global registry. Called during thread creation.
     /// </summary>
-    public static void RegisterThread(Thread thread)
+    internal static void RegisterThread(Thread thread)
     {
         if (s_allThreads == null)
         {
@@ -360,7 +386,7 @@ public static class SchedulerManager
     /// <summary>
     /// Unregisters a thread from the global registry. Called during thread exit.
     /// </summary>
-    public static void UnregisterThread(Thread thread)
+    internal static void UnregisterThread(Thread thread)
     {
         if (s_allThreads == null)
         {
@@ -403,7 +429,7 @@ public static class SchedulerManager
 
     // ========== Thread Operations ==========
 
-    public static void CreateThread(uint cpuId, Thread thread)
+    internal static void CreateThread(uint cpuId, Thread thread)
     {
         ThrowIfDisabled();
         ThrowIfCpuStateNotInitialized();
@@ -419,7 +445,7 @@ public static class SchedulerManager
         Serial.WriteString("[SCHED] CreateThread: done\n");
     }
 
-    public static void ReadyThread(uint cpuId, Thread thread)
+    internal static void ReadyThread(uint cpuId, Thread thread)
     {
         ThrowIfDisabled();
         ThrowIfCpuStateNotInitialized();
@@ -452,7 +478,7 @@ public static class SchedulerManager
         }
     }
 
-    public static void BlockThread(uint cpuId, Thread thread)
+    internal static void BlockThread(uint cpuId, Thread thread)
     {
         ThrowIfCpuStateNotInitialized();
         ThrowIfSchedulerNotSet();
@@ -476,7 +502,7 @@ public static class SchedulerManager
         }
     }
 
-    public static void ExitThread(uint cpuId, Thread thread)
+    internal static void ExitThread(uint cpuId, Thread thread)
     {
         ThrowIfCpuStateNotInitialized();
         ThrowIfSchedulerNotSet();
@@ -525,7 +551,7 @@ public static class SchedulerManager
         }
     }
 
-    public static void YieldThread(uint cpuId, Thread thread)
+    internal static void YieldThread(uint cpuId, Thread thread)
     {
         ThrowIfCpuStateNotInitialized();
         ThrowIfSchedulerNotSet();
@@ -545,7 +571,7 @@ public static class SchedulerManager
     /// <param name="cpuId">CPU ID of the thread.</param>
     /// <param name="thread">Thread to sleep.</param>
     /// <param name="timeoutMs">Timeout in milliseconds. 0 means indefinite sleep (until signaled).</param>
-    public static void Sleep(uint cpuId, Thread thread, uint timeoutMs)
+    internal static void Sleep(uint cpuId, Thread thread, uint timeoutMs)
     {
         MarkSleeping(cpuId, thread, timeoutMs);
 
@@ -565,7 +591,7 @@ public static class SchedulerManager
     /// <param name="cpuId">CPU ID of the thread.</param>
     /// <param name="thread">Thread to sleep.</param>
     /// <param name="timeoutMs">Timeout in milliseconds. 0 means indefinite sleep (until signaled).</param>
-    public static void MarkSleeping(uint cpuId, Thread thread, uint timeoutMs)
+    internal static void MarkSleeping(uint cpuId, Thread thread, uint timeoutMs)
     {
         ThrowIfCpuStateNotInitialized();
         ThrowIfSchedulerNotSet();
@@ -591,7 +617,7 @@ public static class SchedulerManager
     /// Puts the current thread to sleep with a timeout.
     /// </summary>
     /// <param name="timeoutMs">Timeout in milliseconds. 0 means indefinite sleep.</param>
-    public static void Sleep(uint timeoutMs)
+    internal static void Sleep(uint timeoutMs)
     {
         Thread? currentThread = GetCpuState(GetCurrentCpuId())?.CurrentThread;
         if (currentThread != null)
@@ -602,7 +628,7 @@ public static class SchedulerManager
 
     // ========== Scheduling ==========
 
-    public static bool OnTick(uint cpuId, ulong elapsedNs)
+    internal static bool OnTick(uint cpuId, ulong elapsedNs)
     {
         ThrowIfCpuStateNotInitialized();
         ThrowIfSchedulerNotSet();
@@ -611,7 +637,7 @@ public static class SchedulerManager
         return s_currentScheduler.OnTick(state, state.CurrentThread, elapsedNs);
     }
 
-    public static void Schedule(uint cpuId)
+    internal static void Schedule(uint cpuId)
     {
         ThrowIfCpuStateNotInitialized();
         ThrowIfSchedulerNotSet();
@@ -643,6 +669,14 @@ public static class SchedulerManager
         }
     }
 
+    /// <summary>
+    /// Changes a thread's priority through the installed scheduler
+    /// (<see cref="IScheduler.SetPriority"/>). Interpretation is
+    /// scheduler-specific.
+    /// </summary>
+    /// <param name="cpuId">CPU whose state guards the update.</param>
+    /// <param name="thread">Thread to reprioritize.</param>
+    /// <param name="priority">New priority value.</param>
     public static void SetPriority(uint cpuId, Thread thread, long priority)
     {
         ThrowIfCpuStateNotInitialized();
@@ -660,6 +694,11 @@ public static class SchedulerManager
         }
     }
 
+    /// <summary>
+    /// Returns a thread's priority as reported by the installed scheduler
+    /// (<see cref="IScheduler.GetPriority"/>).
+    /// </summary>
+    /// <param name="thread">Thread to query.</param>
     public static long GetPriority(Thread thread)
     {
         ThrowIfSchedulerNotSet();
@@ -669,6 +708,12 @@ public static class SchedulerManager
 
     // ========== Load Balancing ==========
 
+    /// <summary>
+    /// Asks the installed scheduler to pick the best CPU for a new or
+    /// migrating thread (<see cref="IScheduler.SelectCpu"/>).
+    /// </summary>
+    /// <param name="thread">Thread being placed.</param>
+    /// <param name="currentCpu">CPU the thread is currently on.</param>
     public static uint SelectCpu(Thread thread, uint currentCpu)
     {
         ThrowIfSchedulerNotSet();
@@ -676,6 +721,11 @@ public static class SchedulerManager
         return s_currentScheduler.SelectCpu(thread, currentCpu, s_cpuCount);
     }
 
+    /// <summary>
+    /// Gives the installed scheduler a load-balancing opportunity for one
+    /// CPU (<see cref="IScheduler.Balance"/>).
+    /// </summary>
+    /// <param name="cpuId">CPU to balance.</param>
     public static void Balance(uint cpuId)
     {
         ThrowIfCpuStateNotInitialized();
@@ -697,7 +747,7 @@ public static class SchedulerManager
     /// <param name="cpuId">Current CPU ID.</param>
     /// <param name="currentRsp">Current RSP from IRQ context (pointer to saved context).</param>
     /// <param name="elapsedNs">Nanoseconds since last tick.</param>
-    public static void OnTimerInterrupt(uint cpuId, nuint currentRsp, ulong elapsedNs)
+    internal static void OnTimerInterrupt(uint cpuId, nuint currentRsp, ulong elapsedNs)
     {
         s_tickCount++;
 
@@ -797,7 +847,7 @@ public static class SchedulerManager
     /// </summary>
     /// <param name="cpuId">Current CPU ID.</param>
     /// <param name="currentRsp">Current RSP (pointer to saved context on stack).</param>
-    public static void ReschedulePendingFromIrq(uint cpuId, nuint currentRsp)
+    internal static void ReschedulePendingFromIrq(uint cpuId, nuint currentRsp)
     {
         if (!s_enabled || s_currentScheduler == null || s_cpuStates == null || cpuId >= s_cpuCount)
         {
@@ -826,7 +876,7 @@ public static class SchedulerManager
     /// </summary>
     /// <param name="cpuId">Current CPU ID.</param>
     /// <param name="currentRsp">Current RSP (pointer to saved context on stack).</param>
-    public static void ScheduleFromInterrupt(uint cpuId, nuint currentRsp)
+    internal static void ScheduleFromInterrupt(uint cpuId, nuint currentRsp)
     {
         ThrowIfCpuStateNotInitialized();
         ThrowIfSchedulerNotSet();

--- a/src/Cosmos.Kernel.Core/Scheduler/SchedulerManager.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/SchedulerManager.cs
@@ -538,9 +538,9 @@ public static class SchedulerManager
             {
                 unsafe
                 {
-                    ulong unused = (ulong)(thread.AllocContext.AllocLimit - thread.AllocContext.AllocPtr);
+                    ulong unused = (ulong)(thread._allocContext.AllocLimit - thread._allocContext.AllocPtr);
                     GarbageCollector.AddDeadThreadNonAllocBytes(unused);
-                    GarbageCollector.ReturnAllocContext(ref thread.AllocContext);
+                    GarbageCollector.ReturnAllocContext(ref thread._allocContext);
                 }
             }
 
@@ -643,14 +643,14 @@ public static class SchedulerManager
         ThrowIfSchedulerNotSet();
 
         var state = s_cpuStates[cpuId];
-        state.Lock.Acquire();
+        state._lock.Acquire();
 
         var prev = state.CurrentThread;
         var next = s_currentScheduler.PickNext(state) ?? state.IdleThread;
 
         if (next == null)
         {
-            state.Lock.Release();
+            state._lock.Release();
             return;
         }
 
@@ -660,12 +660,12 @@ public static class SchedulerManager
             next.State = ThreadState.Running;
             next.LastScheduledAt = GetTimestamp();
 
-            state.Lock.Release();
+            state._lock.Release();
             DoContextSwitch(prev, next);
         }
         else
         {
-            state.Lock.Release();
+            state._lock.Release();
         }
     }
 
@@ -683,14 +683,14 @@ public static class SchedulerManager
         ThrowIfSchedulerNotSet();
 
         var state = s_cpuStates[cpuId];
-        state.Lock.Acquire();
+        state._lock.Acquire();
         try
         {
             s_currentScheduler.SetPriority(state, thread, priority);
         }
         finally
         {
-            state.Lock.Release();
+            state._lock.Release();
         }
     }
 

--- a/src/Cosmos.Kernel.Core/Scheduler/SchedulerManager.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/SchedulerManager.cs
@@ -722,6 +722,15 @@ public static class SchedulerManager
     }
 
     /// <summary>
+    /// Masks maskable interrupts on the current CPU until the returned
+    /// scope is disposed. Schedulers use this around entry points the
+    /// manager does not already guard, such as their run-queue diagnostics
+    /// hooks and any tuning setters they expose; the manager-invoked
+    /// lifecycle and tick hooks are already called with interrupts masked.
+    /// </summary>
+    public static InterruptMaskScope MaskInterrupts() => new(InternalCpu.DisableInterruptsScope());
+
+    /// <summary>
     /// Gives the installed scheduler a load-balancing opportunity for one
     /// CPU (<see cref="IScheduler.Balance"/>).
     /// </summary>

--- a/src/Cosmos.Kernel.Core/Scheduler/SpinLock.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/SpinLock.cs
@@ -14,7 +14,7 @@ namespace Cosmos.Kernel.Core.Scheduler;
 /// CPU holding the plain lock when the ISR fires will spin forever waiting
 /// for itself.</para>
 /// </summary>
-public struct SpinLock
+internal struct SpinLock
 {
     private int _locked;
 
@@ -60,7 +60,7 @@ public struct SpinLock
 /// the lock must be released before interrupts are re-enabled so an ISR
 /// firing immediately after restore never sees the lock held.
 /// </summary>
-public ref struct IrqLockScope
+internal ref struct IrqLockScope
 {
     private InternalCpu.InterruptScope _irq;
     private readonly ref SpinLock _lock;

--- a/src/Cosmos.Kernel.Core/Scheduler/Stride/StrideCpuData.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/Stride/StrideCpuData.cs
@@ -21,7 +21,12 @@ internal class StrideCpuData
     public ulong LastPassUpdate { get; internal set; }
 
     /// <summary>
-    /// Run queue sorted by Pass value (ascending).
+    /// Run queue sorted by Pass value (ascending). Pre-sized to the thread
+    /// registry limit: InsertByPass runs in interrupt context (the tick's
+    /// OnThreadYield and the sleep-expiry OnThreadReady), and a List growth
+    /// there is an allocation inside the tick — the case the plugging guide
+    /// forbids. Mutex and InterruptEvent pre-size their wait lists for the
+    /// same reason.
     /// </summary>
-    public List<Thread> RunQueue { get; } = new();
+    public List<Thread> RunQueue { get; } = new(Thread.MaxThreadCount);
 }

--- a/src/Cosmos.Kernel.Core/Scheduler/Stride/StrideCpuData.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/Stride/StrideCpuData.cs
@@ -3,7 +3,7 @@ namespace Cosmos.Kernel.Core.Scheduler.Stride;
 /// <summary>
 /// Stride scheduler per-CPU extension data.
 /// </summary>
-public class StrideCpuData
+internal class StrideCpuData
 {
     /// <summary>
     /// Sum of tickets in run queue.

--- a/src/Cosmos.Kernel.Core/Scheduler/Stride/StrideScheduler.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/Stride/StrideScheduler.cs
@@ -6,7 +6,7 @@ namespace Cosmos.Kernel.Core.Scheduler.Stride;
 /// <summary>
 /// Stride scheduler with interactive process support.
 /// </summary>
-public class StrideScheduler : IScheduler
+internal class StrideScheduler : IScheduler
 {
     public string Name => "Stride";
 

--- a/src/Cosmos.Kernel.Core/Scheduler/Stride/StrideScheduler.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/Stride/StrideScheduler.cs
@@ -30,6 +30,20 @@ internal class StrideScheduler : IScheduler
     /// </summary>
     private const ulong WakeupBoostDecayNs = 5_000_000;
 
+    /// <summary>
+    /// Nanoseconds per second, for converting the Stopwatch frequency into
+    /// the tick count of a quantum.
+    /// </summary>
+    private const ulong NanosecondsPerSecond = 1_000_000_000;
+
+    /// <summary>
+    /// Largest catch-up, in quanta, a single global-pass update may account
+    /// for. Bounds both the virtual-time jump and the multiply in
+    /// <see cref="UpdateGlobalPass"/> when the timestamp delta is not a real
+    /// elapsed time.
+    /// </summary>
+    private const ulong MaxCatchUpQuanta = 1000;
+
     // ========== Lifecycle ==========
 
     public void InitializeCpu(PerCpuState cpuState)
@@ -417,7 +431,35 @@ internal class StrideScheduler : IScheduler
         ulong now = GetTimestamp();
         ulong elapsed = now - cpuData.LastPassUpdate;
         ulong globalStride = Stride1 / cpuData.TotalTickets;
-        cpuData.GlobalPass += (globalStride * elapsed) / SchedulerManager.DefaultQuantumNs;
+
+        // The elapsed delta is in Stopwatch ticks, not nanoseconds (multi-GHz
+        // TSC on x64, 62.5 MHz generic timer on ARM64), so the quantum divisor
+        // must be in ticks too — the same conversion MarkSleeping needs for
+        // WakeupTime. Dividing ticks by DefaultQuantumNs advanced GlobalPass
+        // several times too fast on x64, and the OnThreadYield anti-starvation
+        // floor then snapped every spinner up to GlobalPass, flattening ticket
+        // ratios into equal shares.
+        ulong ticksPerQuantum =
+            (ulong)Stopwatch.Frequency * SchedulerManager.DefaultQuantumNs / NanosecondsPerSecond;
+        if (ticksPerQuantum == 0)
+        {
+            ticksPerQuantum = 1;
+        }
+
+        // Bound the catch-up. Two deltas are not a real elapsed time: the very
+        // first update, where LastPassUpdate is still 0 and the delta is the
+        // whole timestamp, and the multi-million-second CNTPCT_EL0 readings
+        // QEMU TCG produces on ARM64 (the test runner clamps those for the
+        // same reason). Either one both explodes GlobalPass — the yield floor
+        // then snaps every thread up to it, flattening ticket ratios — and can
+        // overflow the multiply below.
+        ulong maxElapsed = ticksPerQuantum * MaxCatchUpQuanta;
+        if (elapsed > maxElapsed)
+        {
+            elapsed = maxElapsed;
+        }
+
+        cpuData.GlobalPass += (globalStride * elapsed) / ticksPerQuantum;
         cpuData.LastPassUpdate = now;
     }
 

--- a/src/Cosmos.Kernel.Core/Scheduler/Stride/StrideThreadData.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/Stride/StrideThreadData.cs
@@ -3,7 +3,7 @@ namespace Cosmos.Kernel.Core.Scheduler.Stride;
 /// <summary>
 /// Stride scheduler per-thread extension data.
 /// </summary>
-public class StrideThreadData
+internal class StrideThreadData
 {
     /// <summary>
     /// Resource weight (higher = more CPU time).

--- a/src/Cosmos.Kernel.Core/Scheduler/Thread.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/Thread.cs
@@ -83,7 +83,7 @@ public unsafe class Thread : SchedulerExtensible
     public ulong WakeupTime { get; internal set; }
 
     // ===== GC Allocation Context (TLAB) =====
-    internal AllocContext AllocContext;
+    internal AllocContext _allocContext;
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
     private object[][] _threadStaticStorage;
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.

--- a/src/Cosmos.Kernel.Core/Scheduler/Thread.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/Thread.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Cosmos.Kernel.Core.Memory.GarbageCollector;
 
 namespace Cosmos.Kernel.Core.Scheduler;
@@ -5,30 +6,84 @@ namespace Cosmos.Kernel.Core.Scheduler;
 /// <summary>
 /// Thread Control Block for scheduling.
 /// </summary>
+[Experimental(Experimentals.SchedulerSeamDiagId)]
 public unsafe class Thread : SchedulerExtensible
 {
     // ===== Identity =====
-    public uint Id { get; set; }
-    public uint CpuId { get; set; }
+
+    /// <summary>
+    /// Unique thread identifier. The idle thread has ID 0.
+    /// </summary>
+    public uint Id { get; internal set; }
+
+    /// <summary>
+    /// CPU this thread is assigned to.
+    /// </summary>
+    public uint CpuId { get; internal set; }
 
     // ===== State =====
-    public ThreadState State { get; set; }
-    public ThreadFlags Flags { get; set; }
+
+    /// <summary>
+    /// Current lifecycle state. State transitions are performed by
+    /// <see cref="SchedulerManager"/>; schedulers observe the state but do
+    /// not change it.
+    /// </summary>
+    public ThreadState State { get; internal set; }
+
+    /// <summary>
+    /// Thread attribute flags.
+    /// </summary>
+    public ThreadFlags Flags { get; internal set; }
 
     // ===== Context (architecture-specific values) =====
+
+    /// <summary>
+    /// Saved stack pointer while the thread is not running.
+    /// </summary>
     public nuint StackPointer { get; internal set; }
+
+    /// <summary>
+    /// Entry point address the thread was created with.
+    /// </summary>
     public nuint InstructionPointer { get; internal set; }
+
+    /// <summary>
+    /// Lowest address of the thread's stack allocation.
+    /// </summary>
     public nuint StackBase { get; internal set; }
+
+    /// <summary>
+    /// Size of the thread's stack in bytes.
+    /// </summary>
     public nuint StackSize { get; internal set; }
 
     // ===== Generic Timing =====
-    public ulong CreatedAt { get; set; }
+
+    /// <summary>
+    /// Timestamp at which the thread was created.
+    /// </summary>
+    public ulong CreatedAt { get; internal set; }
+
+    /// <summary>
+    /// Accumulated CPU time in nanoseconds. The active scheduler charges
+    /// elapsed time to the current thread from its
+    /// <see cref="IScheduler.OnTick"/> hook.
+    /// </summary>
     public ulong TotalRuntime { get; set; }
-    public ulong LastScheduledAt { get; set; }
-    public ulong WakeupTime { get; set; }
+
+    /// <summary>
+    /// Timestamp at which the thread last became the current thread.
+    /// </summary>
+    public ulong LastScheduledAt { get; internal set; }
+
+    /// <summary>
+    /// Deadline of the current timed wait, in timestamp ticks. Zero when
+    /// the thread is not sleeping.
+    /// </summary>
+    public ulong WakeupTime { get; internal set; }
 
     // ===== GC Allocation Context (TLAB) =====
-    public AllocContext AllocContext;
+    internal AllocContext AllocContext;
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
     private object[][] _threadStaticStorage;
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
@@ -56,7 +111,7 @@ public unsafe class Thread : SchedulerExtensible
     /// <param name="codeSegment">Code segment selector (CS).</param>
     /// <param name="arg">Optional argument passed to entry point.</param>
     /// <param name="stackSize">Stack size in bytes.</param>
-    public void InitializeStack(nuint entryPoint, ushort codeSegment, nuint arg = 0, nuint stackSize = DefaultStackSize)
+    internal void InitializeStack(nuint entryPoint, ushort codeSegment, nuint arg = 0, nuint stackSize = DefaultStackSize)
     {
         // Allocate stack memory
         StackSize = stackSize;
@@ -92,7 +147,7 @@ public unsafe class Thread : SchedulerExtensible
         State = ThreadState.Created;
     }
 
-    public ref object[][] GetThreadStaticStorage()
+    internal ref object[][] GetThreadStaticStorage()
     {
         return ref _threadStaticStorage;
     }
@@ -101,7 +156,7 @@ public unsafe class Thread : SchedulerExtensible
     /// Gets a pointer to the thread's saved context.
     /// Only valid when thread is not running.
     /// </summary>
-    public ThreadContext* GetContext()
+    internal ThreadContext* GetContext()
     {
         return (ThreadContext*)StackPointer;
     }

--- a/src/Cosmos.Kernel.Core/Scheduler/ThreadContext.ARM64.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/ThreadContext.ARM64.cs
@@ -9,7 +9,7 @@ namespace Cosmos.Kernel.Core.Scheduler;
 /// - IRQContext (GPRs + system regs) at offset 512
 /// </summary>
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public unsafe struct ThreadContext
+internal unsafe struct ThreadContext
 {
     // NEON/SIMD registers Q0-Q31 (32 * 16 = 512 bytes)
     public fixed byte Neon[512];

--- a/src/Cosmos.Kernel.Core/Scheduler/ThreadContext.X64.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/ThreadContext.X64.cs
@@ -8,7 +8,7 @@ namespace Cosmos.Kernel.Core.Scheduler;
 /// RSP points to the start of this structure after save.
 /// </summary>
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public unsafe struct ThreadContext
+internal unsafe struct ThreadContext
 {
     // XMM registers (256 bytes) - SSE/SIMD state
     public fixed byte Xmm[256];

--- a/src/Cosmos.Kernel.Core/Scheduler/ThreadState.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/ThreadState.cs
@@ -1,8 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Cosmos.Kernel.Core.Scheduler;
 
 /// <summary>
 /// Thread execution state.
 /// </summary>
+[Experimental(Experimentals.SchedulerSeamDiagId)]
 public enum ThreadState : byte
 {
     Created,    // Just created, not yet scheduled
@@ -17,6 +20,7 @@ public enum ThreadState : byte
 /// Thread flags.
 /// </summary>
 [Flags]
+[Experimental(Experimentals.SchedulerSeamDiagId)]
 public enum ThreadFlags : ushort
 {
     /// <summary>

--- a/src/Cosmos.Kernel.Core/Scheduler/ThreadState.cs
+++ b/src/Cosmos.Kernel.Core/Scheduler/ThreadState.cs
@@ -8,12 +8,23 @@ namespace Cosmos.Kernel.Core.Scheduler;
 [Experimental(Experimentals.SchedulerSeamDiagId)]
 public enum ThreadState : byte
 {
-    Created,    // Just created, not yet scheduled
-    Ready,      // Can be scheduled
-    Running,    // Currently executing on a CPU
-    Blocked,    // Waiting for I/O, lock, etc.
-    Sleeping,   // Timed wait
-    Dead        // Terminated, awaiting cleanup
+    /// <summary>Just created, not yet scheduled.</summary>
+    Created,
+
+    /// <summary>Can be scheduled.</summary>
+    Ready,
+
+    /// <summary>Currently executing on a CPU.</summary>
+    Running,
+
+    /// <summary>Waiting for I/O, a lock, or another wake signal.</summary>
+    Blocked,
+
+    /// <summary>In a timed wait.</summary>
+    Sleeping,
+
+    /// <summary>Terminated, awaiting cleanup.</summary>
+    Dead
 }
 
 /// <summary>

--- a/src/Cosmos.Kernel.Core/Utilities/ArgvParser.cs
+++ b/src/Cosmos.Kernel.Core/Utilities/ArgvParser.cs
@@ -12,7 +12,7 @@ namespace Cosmos.Kernel.Core.Utilities;
 /// <summary>
 /// Utility class that expose helpers to parse cmdlines.
 /// </summary>
-public static unsafe class ArgvParser
+internal static unsafe class ArgvParser
 {
     private const byte DoubleQuote = (byte)'"';
     private const byte Backslash = (byte)'\\';

--- a/src/Cosmos.Kernel.Core/Utilities/SimpleDictionary.cs
+++ b/src/Cosmos.Kernel.Core/Utilities/SimpleDictionary.cs
@@ -1,6 +1,6 @@
 namespace Cosmos.Kernel.Core.Utilities;
 
-public class SimpleDictionary<TKey, TValue> where TKey : notnull
+internal class SimpleDictionary<TKey, TValue> where TKey : notnull
 {
     private const int InitialCapacity = 16;
     private Entry[] _buckets;

--- a/src/Cosmos.Kernel.HAL.ARM64/Cosmos.Kernel.HAL.ARM64.csproj
+++ b/src/Cosmos.Kernel.HAL.ARM64/Cosmos.Kernel.HAL.ARM64.csproj
@@ -19,4 +19,11 @@
     <ProjectReference Include="..\Cosmos.Kernel.HAL\Cosmos.Kernel.HAL.csproj" />
     <ProjectReference Include="..\Cosmos.Build.Analyzer.Patcher\Cosmos.Build.Analyzer.Patcher.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- DateTime/Stopwatch plugs read the RTC driver singleton. -->
+    <InternalsVisibleTo Include="Cosmos.Kernel.Plugs" />
+    <!-- White-box timer suite exercises the generic timer and RTC directly. -->
+    <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Timer" />
+  </ItemGroup>
 </Project>

--- a/src/Cosmos.Kernel.HAL.ARM64/Cosmos.Kernel.HAL.ARM64.csproj
+++ b/src/Cosmos.Kernel.HAL.ARM64/Cosmos.Kernel.HAL.ARM64.csproj
@@ -9,6 +9,8 @@
     <PackageProjectUrl>https://github.com/valentinbreiz/nativeaot-patcher</PackageProjectUrl>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <DefineConstants>$(DefineConstants);ARCH_ARM64</DefineConstants>
+    <!-- The generic timer feeds ticks into the experimental scheduler seam (COSMOS0001). -->
+    <NoWarn>$(NoWarn);COSMOS0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cosmos.Kernel.Core\Cosmos.Kernel.Core.csproj" />

--- a/src/Cosmos.Kernel.HAL.ARM64/Devices/Clock/RTC.cs
+++ b/src/Cosmos.Kernel.HAL.ARM64/Devices/Clock/RTC.cs
@@ -18,7 +18,7 @@ namespace Cosmos.Kernel.HAL.ARM64.Devices.Clock;
 /// PL031 RTCDR register provides Unix time (seconds since 1970-01-01 UTC).
 /// QEMU virt machine maps PL031 at physical address 0x09010000.
 /// </summary>
-public class RTC : Device
+internal class RTC : Device
 {
     /// <summary>Singleton instance of the RTC.</summary>
     public static RTC? Instance { get; private set; }

--- a/src/Cosmos.Kernel.HAL.ARM64/Devices/Timer/GenericTimer.cs
+++ b/src/Cosmos.Kernel.HAL.ARM64/Devices/Timer/GenericTimer.cs
@@ -15,7 +15,7 @@ namespace Cosmos.Kernel.HAL.ARM64.Devices.Timer;
 /// Uses the physical timer (CNTP_*) for scheduling interrupts.
 /// Native imports live in Cosmos.Kernel.Core.ARM64/Bridge/Import/GenericTimerNative.cs.
 /// </summary>
-public class GenericTimer : TimerDevice
+internal class GenericTimer : TimerDevice
 {
     /// <summary>
     /// Singleton instance of the Generic Timer.

--- a/src/Cosmos.Kernel.HAL.ARM64/EagerStaticClassConstructionAttribute.cs
+++ b/src/Cosmos.Kernel.HAL.ARM64/EagerStaticClassConstructionAttribute.cs
@@ -1,6 +1,6 @@
 namespace System.Runtime.CompilerServices;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
-public class EagerStaticClassConstructionAttribute : Attribute
+internal class EagerStaticClassConstructionAttribute : Attribute
 {
 }

--- a/src/Cosmos.Kernel.HAL.Interfaces/Cosmos.Kernel.HAL.Interfaces.csproj
+++ b/src/Cosmos.Kernel.HAL.Interfaces/Cosmos.Kernel.HAL.Interfaces.csproj
@@ -5,6 +5,10 @@
         <LangVersion>latestmajor</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+
+        <!-- Public surface tracked in PublicAPI.Shipped/Unshipped.txt (see Directory.Build.props):
+             the device and platform contracts. -->
+        <CosmosTrackPublicApi>true</CosmosTrackPublicApi>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Cosmos.Kernel.HAL.Interfaces/Devices/IBlockDevice.cs
+++ b/src/Cosmos.Kernel.HAL.Interfaces/Devices/IBlockDevice.cs
@@ -4,7 +4,7 @@ namespace Cosmos.Kernel.HAL.Interfaces.Devices;
 
 /// <summary>
 /// Interface for block storage devices (SATA, NVMe, virtio-blk, etc.).
-/// Block-level read/write only — partitioning and filesystems sit above this.
+/// Block-level read/write only; partitioning and filesystems sit above this.
 ///
 /// <para>Error contract: <see cref="ReadBlock"/>, <see cref="WriteBlock"/>
 /// and <see cref="Flush"/> throw on failure (device error, timeout,

--- a/src/Cosmos.Kernel.HAL.Interfaces/Devices/Network/MACAddress.cs
+++ b/src/Cosmos.Kernel.HAL.Interfaces/Devices/Network/MACAddress.cs
@@ -1,10 +1,16 @@
 namespace Cosmos.Kernel.HAL.Devices.Network;
 
+/// <summary>
+/// A 48-bit Ethernet MAC address.
+/// </summary>
 public class MACAddress : IComparable
 {
     private static MACAddress? s_broadcast;
     private static MACAddress? s_none;
 
+    /// <summary>
+    /// The broadcast address (FF:FF:FF:FF:FF:FF).
+    /// </summary>
     public static MACAddress Broadcast
     {
         get
@@ -17,6 +23,9 @@ public class MACAddress : IComparable
         }
     }
 
+    /// <summary>
+    /// The all-zero address (00:00:00:00:00:00), used when no address is assigned.
+    /// </summary>
     public static MACAddress None
     {
         get
@@ -29,8 +38,15 @@ public class MACAddress : IComparable
         }
     }
 
+    /// <summary>
+    /// The six address bytes, most significant first.
+    /// </summary>
     public readonly byte[] bytes = new byte[6];
 
+    /// <summary>
+    /// Create a MAC address from a 6-byte array.
+    /// </summary>
+    /// <param name="address">The six address bytes, most significant first.</param>
     public MACAddress(byte[] address)
     {
         if (address == null || address.Length != 6)
@@ -67,17 +83,32 @@ public class MACAddress : IComparable
         bytes[5] = buffer[offset + 5];
     }
 
+    /// <summary>
+    /// Create a copy of an existing MAC address.
+    /// </summary>
+    /// <param name="m">MAC address to copy.</param>
     public MACAddress(MACAddress m)
         : this(m.bytes)
     {
     }
 
 
+    /// <summary>
+    /// Check that the address holds six bytes.
+    /// </summary>
+    /// <returns>True if the address is 6 bytes long.</returns>
     public bool IsValid()
     {
         return bytes.Length == 6;
     }
 
+    /// <summary>
+    /// Compare this address to another MAC address, byte by byte from the
+    /// most significant byte.
+    /// </summary>
+    /// <param name="obj">MAC address to compare against.</param>
+    /// <returns>Negative, zero, or positive following the ordering of the first differing byte.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="obj"/> is not a <see cref="MACAddress"/>.</exception>
     public int CompareTo(object? obj)
     {
         if (obj is MACAddress)
@@ -128,6 +159,12 @@ public class MACAddress : IComparable
         }
     }
 
+    /// <summary>
+    /// Check whether another MAC address has the same six bytes.
+    /// </summary>
+    /// <param name="obj">MAC address to compare against.</param>
+    /// <returns>True if all six bytes are equal.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="obj"/> is not a <see cref="MACAddress"/>.</exception>
     public override bool Equals(object? obj)
     {
         if (obj is MACAddress)
@@ -147,11 +184,20 @@ public class MACAddress : IComparable
         }
     }
 
+    /// <summary>
+    /// Get a hash code derived from the type name and the string form of the address.
+    /// </summary>
+    /// <returns>Hash code for this address.</returns>
     public override int GetHashCode()
     {
         return (GetType().AssemblyQualifiedName + "|" + ToString()).GetHashCode();
     }
 
+    /// <summary>
+    /// Combine the address bytes into a single unsigned number,
+    /// most significant byte first.
+    /// </summary>
+    /// <returns>The address as a number.</returns>
     public ulong ToNumber()
     {
         // TODO check shifting of bytes byte[0] and byte[1]
@@ -166,6 +212,11 @@ public class MACAddress : IComparable
         aChars[aIndex + 1] = xChars[aByte & 0xF];
     }
 
+    /// <summary>
+    /// Combine the address bytes into a 32-bit unsigned number,
+    /// most significant byte first. Used as the <see cref="Hash"/> value.
+    /// </summary>
+    /// <returns>The address as a 32-bit number.</returns>
     public uint To32BitNumber()
     {
         // TODO check shifting of bytes byte[0] and byte[1]
@@ -190,6 +241,11 @@ public class MACAddress : IComparable
         }
     }
 
+    /// <summary>
+    /// Format the address as six colon-separated hex byte pairs
+    /// (e.g. "52:54:00:12:34:56").
+    /// </summary>
+    /// <returns>The address in colon-separated hex notation.</returns>
     public override string ToString()
     {
         // mac address consists of 6 2chars pairs, delimited by :

--- a/src/Cosmos.Kernel.HAL.Interfaces/IPlatformInitializer.cs
+++ b/src/Cosmos.Kernel.HAL.Interfaces/IPlatformInitializer.cs
@@ -14,10 +14,30 @@ namespace Cosmos.Kernel.HAL.Interfaces;
 /// </summary>
 public interface IPlatformInitializer
 {
+    /// <summary>
+    /// Human-readable platform name (e.g. "x86-64", "ARM64").
+    /// </summary>
     string PlatformName { get; }
+
+    /// <summary>
+    /// Architecture this initializer targets.
+    /// </summary>
     PlatformArchitecture Architecture { get; }
+
+    /// <summary>
+    /// Creates the platform-specific port I/O implementation.
+    /// </summary>
     IPortIO CreatePortIO();
+
+    /// <summary>
+    /// Creates the platform-specific CPU operations (halt, interrupt
+    /// enable/disable, etc.).
+    /// </summary>
     ICpuOps CreateCpuOps();
+
+    /// <summary>
+    /// Creates the platform-specific power operations (shutdown, reboot).
+    /// </summary>
     IPowerOps CreatePowerOps();
 
     /// <summary>
@@ -54,7 +74,7 @@ public interface IPlatformInitializer
 
     /// <summary>
     /// Busy-waits for at least <paramref name="microseconds"/> µs without
-    /// depending on interrupts or the scheduler — usable from phase-3
+    /// depending on interrupts or the scheduler, so it is usable from phase-3
     /// device init. x64 paces on legacy port-0x80 reads (~1 µs each);
     /// ARM64 polls the generic timer (CNTVCT/CNTFRQ).
     /// </summary>

--- a/src/Cosmos.Kernel.HAL.Interfaces/PublicAPI.Shipped.txt
+++ b/src/Cosmos.Kernel.HAL.Interfaces/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Cosmos.Kernel.HAL.Interfaces/PublicAPI.Unshipped.txt
+++ b/src/Cosmos.Kernel.HAL.Interfaces/PublicAPI.Unshipped.txt
@@ -1,0 +1,105 @@
+#nullable enable
+Cosmos.Kernel.HAL.Devices.Network.MACAddress
+Cosmos.Kernel.HAL.Devices.Network.MACAddress.CompareTo(object? obj) -> int
+Cosmos.Kernel.HAL.Devices.Network.MACAddress.Hash.get -> uint
+Cosmos.Kernel.HAL.Devices.Network.MACAddress.IsValid() -> bool
+Cosmos.Kernel.HAL.Devices.Network.MACAddress.MACAddress(byte[]! address) -> void
+Cosmos.Kernel.HAL.Devices.Network.MACAddress.MACAddress(byte[]! buffer, int offset) -> void
+Cosmos.Kernel.HAL.Devices.Network.MACAddress.MACAddress(Cosmos.Kernel.HAL.Devices.Network.MACAddress! m) -> void
+Cosmos.Kernel.HAL.Devices.Network.MACAddress.To32BitNumber() -> uint
+Cosmos.Kernel.HAL.Devices.Network.MACAddress.ToNumber() -> ulong
+Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice
+Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice.BlockCount.get -> ulong
+Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice.BlockSize.get -> ulong
+Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice.Flush() -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice.Name.get -> string!
+Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice.ReadBlock(ulong blockNo, ulong blockCount, System.Span<byte> data) -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice.WriteBlock(ulong blockNo, ulong blockCount, System.ReadOnlySpan<byte> data) -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IGraphicDevice
+Cosmos.Kernel.HAL.Interfaces.Devices.IGraphicDevice.ClearScreen(uint color) -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IGraphicDevice.CopyBuffer(System.ReadOnlyMemory<int> pixels, int x, int y, int width, int height) -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IGraphicDevice.CopyBuffer(System.ReadOnlyMemory<uint> pixels, int x, int y, int width, int height) -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IGraphicDevice.DrawPixel(uint color, int x, int y) -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IGraphicDevice.GetPixel(int x, int y) -> uint
+Cosmos.Kernel.HAL.Interfaces.Devices.IGraphicDevice.GetVRAM(int sourceByteOffset, int[]! dest, int destIndex, int count) -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IGraphicDevice.Initialize() -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IGraphicDevice.Swap() -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IKeyboardDevice
+Cosmos.Kernel.HAL.Interfaces.Devices.IKeyboardDevice.Disable() -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IKeyboardDevice.Enable() -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IKeyboardDevice.Initialize() -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IKeyboardDevice.KeyAvailable.get -> bool
+Cosmos.Kernel.HAL.Interfaces.Devices.IKeyboardDevice.OnKeyPressed.get -> Cosmos.Kernel.HAL.Interfaces.Devices.KeyPressedHandler?
+Cosmos.Kernel.HAL.Interfaces.Devices.IKeyboardDevice.OnKeyPressed.set -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IKeyboardDevice.Poll() -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IKeyboardDevice.UpdateLeds() -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IMouseDevice
+Cosmos.Kernel.HAL.Interfaces.Devices.IMouseDevice.DataAvailable.get -> bool
+Cosmos.Kernel.HAL.Interfaces.Devices.IMouseDevice.Disable() -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IMouseDevice.Enable() -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IMouseDevice.Initialize() -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IMouseDevice.LeftButton.get -> bool
+Cosmos.Kernel.HAL.Interfaces.Devices.IMouseDevice.MiddleButton.get -> bool
+Cosmos.Kernel.HAL.Interfaces.Devices.IMouseDevice.Poll() -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.IMouseDevice.RightButton.get -> bool
+Cosmos.Kernel.HAL.Interfaces.Devices.IMouseDevice.ScrollDelta.get -> int
+Cosmos.Kernel.HAL.Interfaces.Devices.IMouseDevice.X.get -> int
+Cosmos.Kernel.HAL.Interfaces.Devices.IMouseDevice.Y.get -> int
+Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice
+Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice.Disable() -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice.Enable() -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice.Initialize() -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice.LinkUp.get -> bool
+Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice.MacAddress.get -> Cosmos.Kernel.HAL.Devices.Network.MACAddress!
+Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice.Name.get -> string!
+Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice.OnPacketReceived.get -> Cosmos.Kernel.HAL.Interfaces.Devices.PacketReceivedHandler?
+Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice.OnPacketReceived.set -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice.Ready.get -> bool
+Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice.Send(byte[]! data, int length) -> bool
+Cosmos.Kernel.HAL.Interfaces.Devices.ITimerDevice
+Cosmos.Kernel.HAL.Interfaces.Devices.ITimerDevice.Frequency.get -> uint
+Cosmos.Kernel.HAL.Interfaces.Devices.ITimerDevice.Initialize() -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.ITimerDevice.OnTick.get -> Cosmos.Kernel.HAL.Interfaces.Devices.TimerTickHandler?
+Cosmos.Kernel.HAL.Interfaces.Devices.ITimerDevice.OnTick.set -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.ITimerDevice.RegisterTimer(Cosmos.Kernel.HAL.Interfaces.Devices.SoftwareTimer! timer) -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.ITimerDevice.SetFrequency(uint frequency) -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.ITimerDevice.UnregisterTimer(Cosmos.Kernel.HAL.Interfaces.Devices.SoftwareTimer! timer) -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.ITimerDevice.Wait(uint ms) -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.KeyPressedHandler
+Cosmos.Kernel.HAL.Interfaces.Devices.PacketReceivedHandler
+Cosmos.Kernel.HAL.Interfaces.Devices.SoftwareTimer
+Cosmos.Kernel.HAL.Interfaces.Devices.SoftwareTimer.Invoke() -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.SoftwareTimer.IsActive.get -> bool
+Cosmos.Kernel.HAL.Interfaces.Devices.SoftwareTimer.Recurring.get -> bool
+Cosmos.Kernel.HAL.Interfaces.Devices.SoftwareTimer.SetActive(bool active) -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.SoftwareTimer.SoftwareTimer(System.Action! callback, ulong timeoutNs, bool recurring) -> void
+Cosmos.Kernel.HAL.Interfaces.Devices.SoftwareTimer.Tick(ulong elapsedNs) -> bool
+Cosmos.Kernel.HAL.Interfaces.Devices.SoftwareTimer.TimeoutNs.get -> ulong
+Cosmos.Kernel.HAL.Interfaces.Devices.TimerTickHandler
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer.Architecture.get -> Cosmos.Build.API.Enum.PlatformArchitecture
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer.CreateCpuOps() -> Cosmos.Kernel.Core.CPU.ICpuOps!
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer.CreateInterruptController() -> Cosmos.Kernel.Core.CPU.IInterruptController!
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer.CreatePortIO() -> Cosmos.Kernel.Core.IO.IPortIO!
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer.CreatePowerOps() -> Cosmos.Kernel.Core.Power.IPowerOps!
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer.CreateTimer() -> Cosmos.Kernel.HAL.Interfaces.Devices.ITimerDevice!
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer.DelayMicroseconds(uint microseconds) -> void
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer.DmaBarrier() -> void
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer.EnsureMmioMapped(ulong physBase) -> void
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer.GetCpuCount() -> uint
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer.GetKeyboardDevices() -> Cosmos.Kernel.HAL.Interfaces.Devices.IKeyboardDevice![]!
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer.GetMouseDevices() -> Cosmos.Kernel.HAL.Interfaces.Devices.IMouseDevice![]!
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer.GetNetworkDevice() -> Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice?
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer.InitializeHardware() -> void
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer.PlatformName.get -> string!
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer.PreparePciMapping(ulong ecamBase) -> void
+Cosmos.Kernel.HAL.Interfaces.IPlatformInitializer.StartSchedulerTimer(uint quantumMs) -> void
+override Cosmos.Kernel.HAL.Devices.Network.MACAddress.Equals(object? obj) -> bool
+override Cosmos.Kernel.HAL.Devices.Network.MACAddress.GetHashCode() -> int
+override Cosmos.Kernel.HAL.Devices.Network.MACAddress.ToString() -> string!
+readonly Cosmos.Kernel.HAL.Devices.Network.MACAddress.bytes -> byte[]!
+static Cosmos.Kernel.HAL.Devices.Network.MACAddress.Broadcast.get -> Cosmos.Kernel.HAL.Devices.Network.MACAddress!
+static Cosmos.Kernel.HAL.Devices.Network.MACAddress.None.get -> Cosmos.Kernel.HAL.Devices.Network.MACAddress!
+virtual Cosmos.Kernel.HAL.Interfaces.Devices.KeyPressedHandler.Invoke(byte scanCode, bool released) -> void
+virtual Cosmos.Kernel.HAL.Interfaces.Devices.PacketReceivedHandler.Invoke(byte[]! data, int length) -> void
+virtual Cosmos.Kernel.HAL.Interfaces.Devices.TimerTickHandler.Invoke() -> void

--- a/src/Cosmos.Kernel.HAL.X64/Cosmos.Kernel.HAL.X64.csproj
+++ b/src/Cosmos.Kernel.HAL.X64/Cosmos.Kernel.HAL.X64.csproj
@@ -18,4 +18,11 @@
     <ProjectReference Include="..\Cosmos.Kernel.HAL\Cosmos.Kernel.HAL.csproj" />
     <ProjectReference Include="..\Cosmos.Build.Analyzer.Patcher\Cosmos.Build.Analyzer.Patcher.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- DateTime/Stopwatch plugs read the RTC driver singleton. -->
+    <InternalsVisibleTo Include="Cosmos.Kernel.Plugs" />
+    <!-- White-box timer suite exercises PIT and RTC directly. -->
+    <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Timer" />
+  </ItemGroup>
 </Project>

--- a/src/Cosmos.Kernel.HAL.X64/Devices/Clock/RTC.cs
+++ b/src/Cosmos.Kernel.HAL.X64/Devices/Clock/RTC.cs
@@ -13,7 +13,7 @@ namespace Cosmos.Kernel.HAL.X64.Devices.Clock;
 /// CMOS Real-Time Clock (RTC) device for x64.
 /// Reads date/time from the hardware RTC.
 /// </summary>
-public class RTC : Device
+internal class RTC : Device
 {
     /// <summary>
     /// Singleton instance of the RTC.

--- a/src/Cosmos.Kernel.HAL.X64/Devices/Input/PS2Controller.cs
+++ b/src/Cosmos.Kernel.HAL.X64/Devices/Input/PS2Controller.cs
@@ -11,7 +11,7 @@ namespace Cosmos.Kernel.HAL.X64.Devices.Input;
 /// <summary>
 /// PS/2 Controller driver for managing keyboard and mouse devices.
 /// </summary>
-public class PS2Controller : Device
+internal class PS2Controller : Device
 {
     private enum Command : byte
     {

--- a/src/Cosmos.Kernel.HAL.X64/Devices/Input/PS2Keyboard.cs
+++ b/src/Cosmos.Kernel.HAL.X64/Devices/Input/PS2Keyboard.cs
@@ -11,7 +11,7 @@ namespace Cosmos.Kernel.HAL.X64.Devices.Input;
 /// <summary>
 /// PS/2 Keyboard driver.
 /// </summary>
-public class PS2Keyboard : KeyboardDevice
+internal class PS2Keyboard : KeyboardDevice
 {
     private enum Command : byte
     {

--- a/src/Cosmos.Kernel.HAL.X64/Devices/Input/PS2Mouse.cs
+++ b/src/Cosmos.Kernel.HAL.X64/Devices/Input/PS2Mouse.cs
@@ -10,7 +10,7 @@ namespace Cosmos.Kernel.HAL.X64.Devices.Input;
 /// <summary>
 /// PS/2 Mouse driver.
 /// </summary>
-public class PS2Mouse : MouseDevice
+internal class PS2Mouse : MouseDevice
 {
     private enum Command : byte
     {

--- a/src/Cosmos.Kernel.HAL.X64/Devices/Network/E1000E.cs
+++ b/src/Cosmos.Kernel.HAL.X64/Devices/Network/E1000E.cs
@@ -16,7 +16,7 @@ namespace Cosmos.Kernel.HAL.X64.Devices.Network;
 /// Intel 82574 (E1000E) Gigabit Ethernet Controller Driver.
 /// Supports MSI-X interrupts.
 /// </summary>
-public class E1000E : PciDevice, INetworkDevice
+internal class E1000E : PciDevice, INetworkDevice
 {
     // E1000E Register Offsets
     private const uint REG_CTRL = 0x0000;        // Device Control

--- a/src/Cosmos.Kernel.HAL.X64/Devices/Timer/PIT.cs
+++ b/src/Cosmos.Kernel.HAL.X64/Devices/Timer/PIT.cs
@@ -13,7 +13,7 @@ namespace Cosmos.Kernel.HAL.X64.Devices.Timer;
 /// Handles the Programmable Interval Timer (PIT). Software timers registered
 /// via <see cref="TimerDevice.RegisterTimer"/> are driven by the channel 0 IRQ.
 /// </summary>
-public class PIT : TimerDevice
+internal class PIT : TimerDevice
 {
     /// <summary>
     /// Singleton instance of the PIT.

--- a/src/Cosmos.Kernel.HAL.X64/EagerStaticClassConstructionAttribute.cs
+++ b/src/Cosmos.Kernel.HAL.X64/EagerStaticClassConstructionAttribute.cs
@@ -1,6 +1,6 @@
 namespace System.Runtime.CompilerServices;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
-public class EagerStaticClassConstructionAttribute : Attribute
+internal class EagerStaticClassConstructionAttribute : Attribute
 {
 }

--- a/src/Cosmos.Kernel.HAL/Acpi/Acpi.cs
+++ b/src/Cosmos.Kernel.HAL/Acpi/Acpi.cs
@@ -11,7 +11,7 @@ namespace Cosmos.Kernel.HAL;
 /// table to extract the PCI ECAM base address. This class just retrieves the result.
 /// Native import lives in Cosmos.Kernel.Core/Bridge/Import/AcpiNative.cs.
 /// </summary>
-public static unsafe class AcpiMcfg
+internal static unsafe class AcpiMcfg
 {
     /// <summary>
     /// Mirrors the C struct acpi_mcfg_info_t from ACPI/acpi_wrapper.c.

--- a/src/Cosmos.Kernel.HAL/CompatibilitySuppressions.xml
+++ b/src/Cosmos.Kernel.HAL/CompatibilitySuppressions.xml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <!-- PKV0001 "no compile time asset for net10.0": intentional. The multi-arch
+       package ships only runtimes/linux-{x64,arm64}/lib/ assemblies; the
+       build/{PackageId}.props selects the reference by RID at build time
+       (Directory.MultiArch.targets), so there is no RID-agnostic lib/ asset. -->
+  <Suppression>
+    <DiagnosticId>PKV0001</DiagnosticId>
+    <Target>net10.0</Target>
+  </Suppression>
+</Suppressions>

--- a/src/Cosmos.Kernel.HAL/Cosmos.Kernel.HAL.csproj
+++ b/src/Cosmos.Kernel.HAL/Cosmos.Kernel.HAL.csproj
@@ -12,6 +12,10 @@
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <!-- NVMe I/O waits block and wake threads through the experimental scheduler seam (COSMOS0001). -->
     <NoWarn>$(NoWarn);COSMOS0001</NoWarn>
+
+    <!-- Public surface tracked in PublicAPI.Shipped/Unshipped.txt (see Directory.Build.props):
+         the VFS contract types only. -->
+    <CosmosTrackPublicApi>true</CosmosTrackPublicApi>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cosmos.Build.API\Cosmos.Build.API.csproj" />

--- a/src/Cosmos.Kernel.HAL/Cosmos.Kernel.HAL.csproj
+++ b/src/Cosmos.Kernel.HAL/Cosmos.Kernel.HAL.csproj
@@ -41,12 +41,14 @@
     <!-- White-box suites over HAL internals: SVGAII FIFO wire format
          (Graphic), MSI-X tables (Interrupts), PCI discovery (Pci),
          platform power ops (Power), AHCI/NVMe registers (Storage),
-         virtio transports (Virtio). -->
+         the TimerDevice base and its software timers (Timer), virtio
+         transports (Virtio). -->
     <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Graphic" />
     <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Interrupts" />
     <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Pci" />
     <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Power" />
     <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Storage" />
+    <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Timer" />
     <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Virtio" />
   </ItemGroup>
 </Project>

--- a/src/Cosmos.Kernel.HAL/Cosmos.Kernel.HAL.csproj
+++ b/src/Cosmos.Kernel.HAL/Cosmos.Kernel.HAL.csproj
@@ -24,5 +24,26 @@
 
   <!-- Multi-arch packaging support -->
   <Import Project="../Directory.MultiArch.targets" />
+
+  <ItemGroup>
+    <!-- System's internal canvases and managers sit directly on the HAL
+         drivers (GOP/SVGAII, AHCI/NVMe, PS/2 mouse, PCI discovery). -->
+    <InternalsVisibleTo Include="Cosmos.Kernel.System" />
+    <!-- The aggregator initializes PlatformHAL from its library initializer. -->
+    <InternalsVisibleTo Include="Cosmos.Kernel" />
+    <!-- Arch HALs implement the driver base classes and register devices. -->
+    <InternalsVisibleTo Include="Cosmos.Kernel.HAL.X64" />
+    <InternalsVisibleTo Include="Cosmos.Kernel.HAL.ARM64" />
+    <!-- White-box suites over HAL internals: SVGAII FIFO wire format
+         (Graphic), MSI-X tables (Interrupts), PCI discovery (Pci),
+         platform power ops (Power), AHCI/NVMe registers (Storage),
+         virtio transports (Virtio). -->
+    <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Graphic" />
+    <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Interrupts" />
+    <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Pci" />
+    <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Power" />
+    <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Storage" />
+    <InternalsVisibleTo Include="Cosmos.Kernel.Tests.Virtio" />
+  </ItemGroup>
 </Project>
 

--- a/src/Cosmos.Kernel.HAL/Cosmos.Kernel.HAL.csproj
+++ b/src/Cosmos.Kernel.HAL/Cosmos.Kernel.HAL.csproj
@@ -10,6 +10,8 @@
     <RepositoryUrl>https://github.com/valentinbreiz/nativeaot-patcher</RepositoryUrl>
     <PackageProjectUrl>https://github.com/valentinbreiz/nativeaot-patcher</PackageProjectUrl>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+    <!-- NVMe I/O waits block and wake threads through the experimental scheduler seam (COSMOS0001). -->
+    <NoWarn>$(NoWarn);COSMOS0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cosmos.Build.API\Cosmos.Build.API.csproj" />

--- a/src/Cosmos.Kernel.HAL/Cpu/Enums/EFlagsEnum.cs
+++ b/src/Cosmos.Kernel.HAL/Cpu/Enums/EFlagsEnum.cs
@@ -7,7 +7,7 @@ namespace Cosmos.Kernel.HAL.Cpu.Enums;
 /// <summary>
 /// EFlags Enum.
 /// </summary>
-public enum EFlagsEnum : uint
+internal enum EFlagsEnum : uint
 {
     /// <summary>
     /// Set by arithmetic instructions, can be carry or borrow.

--- a/src/Cosmos.Kernel.HAL/DebugInfo.cs
+++ b/src/Cosmos.Kernel.HAL/DebugInfo.cs
@@ -5,7 +5,7 @@ using Cosmos.Kernel.Core.IO;
 
 namespace Cosmos.Kernel.HAL;
 
-public static class DebugInfo
+internal static class DebugInfo
 {
     private const string Dash = " --- ";
     private const string NewLine = "\n";

--- a/src/Cosmos.Kernel.HAL/Devices/Clock/EfiRtc.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Clock/EfiRtc.cs
@@ -11,7 +11,7 @@ namespace Cosmos.Kernel.HAL.Devices.Clock;
 /// Works on any UEFI platform (x64 or ARM64) after ExitBootServices because
 /// EFI Runtime Services remain valid indefinitely.
 /// </summary>
-public static class EfiRtc
+internal static class EfiRtc
 {
     /// <summary>
     /// Attempts to read the current wall-clock time via EFI Runtime Services.

--- a/src/Cosmos.Kernel.HAL/Devices/Device.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Device.cs
@@ -5,6 +5,6 @@ namespace Cosmos.Kernel.HAL.Devices;
 /// <summary>
 /// Base class for all hardware devices.
 /// </summary>
-public abstract class Device
+internal abstract class Device
 {
 }

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/GopDriver.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/GopDriver.cs
@@ -9,7 +9,7 @@ namespace Cosmos.Kernel.HAL.Devices.Graphic;
 /// UEFI GOP Video Driver.
 /// Provides video output via UEFI framebuffer.
 /// </summary>
-public unsafe class GopDriver : GraphicDevice
+internal unsafe class GopDriver : GraphicDevice
 {
     /// <summary>
     /// Returns true if the device was successfully initialized.

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/GraphicDevice.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/GraphicDevice.cs
@@ -8,7 +8,7 @@ namespace Cosmos.Kernel.HAL.Devices.Graphic;
 /// <summary>
 /// Abstract base class for all graphic devices.
 /// </summary>
-public abstract class GraphicDevice : Device, IGraphicDevice
+internal abstract class GraphicDevice : Device, IGraphicDevice
 {
     /// <summary>
     /// Initialize the graphic device.

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/Capability.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/Capability.cs
@@ -3,7 +3,7 @@ using System;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [Flags]
-public enum Capability
+internal enum Capability
 {
     /// <summary>
     /// None.

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/ClearFlags.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/ClearFlags.cs
@@ -3,7 +3,7 @@ using System;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [Flags]
-public enum ClearFlags : uint
+internal enum ClearFlags : uint
 {
     Color = 0x1,
     Depth = 0x2,

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/DeclMethod.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/DeclMethod.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
-public enum SVGA3dDeclMethod
+internal enum SVGA3dDeclMethod
 {
     SVGA3D_DECLMETHOD_DEFAULT = 0,
     SVGA3D_DECLMETHOD_PARTIALU,

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/DeclType.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/DeclType.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
-public enum SVGA3dDeclType
+internal enum SVGA3dDeclType
 {
     SVGA3D_DECLTYPE_FLOAT1 = 0,
     SVGA3D_DECLTYPE_FLOAT2 = 1,

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/DeclUsage.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/DeclUsage.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
-public enum SVGA3dDeclUsage
+internal enum SVGA3dDeclUsage
 {
     SVGA3D_DECLUSAGE_POSITION = 0,
     SVGA3D_DECLUSAGE_BLENDWEIGHT,

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/FIFO.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/FIFO.cs
@@ -3,7 +3,7 @@ namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 /// <summary>
 /// FIFO values.
 /// </summary>
-public enum FIFO : uint
+internal enum FIFO : uint
 {   // values are multiplied by 4 to access the array by byte index
     /// <summary>
     /// Min.

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/FIFOCommand.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/FIFOCommand.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
-public enum FIFOCommand
+internal enum FIFOCommand
 {
     /// <summary>
     /// Update.

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/Face.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/Face.cs
@@ -3,7 +3,7 @@ namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 /// <summary>
 /// ID values.
 /// </summary>
-public enum Face : uint
+internal enum Face : uint
 {
     SVGA3D_FACE_INVALID = 0,
     SVGA3D_FACE_NONE = 1,

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/ID.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/ID.cs
@@ -3,7 +3,7 @@ namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 /// <summary>
 /// ID values.
 /// </summary>
-public enum ID : uint
+internal enum ID : uint
 {
     /// <summary>
     /// Magic starting point.

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/IOPortOffset.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/IOPortOffset.cs
@@ -3,7 +3,7 @@ namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 /// <summary>
 /// IO port offset.
 /// </summary>
-public enum IOPortOffset : byte
+internal enum IOPortOffset : byte
 {
     /// <summary>
     /// Index.

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/LightType.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/LightType.cs
@@ -3,7 +3,7 @@ namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 /// <summary>
 /// ID values.
 /// </summary>
-public enum LightType : uint
+internal enum LightType : uint
 {
     SVGA3D_LIGHTTYPE_INVALID = 0,
     SVGA3D_LIGHTTYPE_POINT = 1,

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/PrimitiveType.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/PrimitiveType.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
-public enum SVGA3dPrimitiveType
+internal enum SVGA3dPrimitiveType
 {
     SVGA3D_PRIMITIVE_INVALID = 0,
     SVGA3D_PRIMITIVE_TRIANGLELIST = 1,

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/Register.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/Register.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
-public enum Register : ushort
+internal enum Register : ushort
 {
     Enable3D = 0x20,
     Guest3DScratchSize = 0x21,
@@ -44,7 +44,7 @@ public enum Register : ushort
     FifoNumRegisters = 293
 }
 
-public enum Register3D
+internal enum Register3D
 {
     SVGA_FIFO_MIN = 0,
     SVGA_FIFO_MAX,       /* The distance from MIN to MAX must be at least 10K */

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/RenderStateName.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/RenderStateName.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
-public enum SVGA3dRenderStateName : uint
+internal enum SVGA3dRenderStateName : uint
 {
     SVGA3D_RS_INVALID = 0,
     SVGA3D_RS_ZENABLE = 1,     /* SVGA3dBool */

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/RenderTargetType.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/RenderTargetType.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
-public enum SVGA3dRenderTargetType : uint
+internal enum SVGA3dRenderTargetType : uint
 {
     Color = 2,
     Depth = 0,

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/ShaderConstType.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/ShaderConstType.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
-public enum SVGA3dShaderConstType
+internal enum SVGA3dShaderConstType
 {
     SVGA3D_CONST_TYPE_FLOAT = 0,
     SVGA3D_CONST_TYPE_INT = 1,

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/ShaderType.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/ShaderType.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
-public enum SVGA3dShaderType
+internal enum SVGA3dShaderType
 {
     SVGA3D_SHADERTYPE_VS = 1,
     SVGA3D_SHADERTYPE_PS = 2,

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/SurfaceFlags.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/SurfaceFlags.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
-public enum SVGA3dSurfaceFlags : uint
+internal enum SVGA3dSurfaceFlags : uint
 {
     SVGA3D_SURFACE_CUBEMAP = (1 << 0),
     SVGA3D_SURFACE_HINT_STATIC = (1 << 1),

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/SurfaceFormat.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/SurfaceFormat.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
-public enum SVGA3dSurfaceFormat : uint
+internal enum SVGA3dSurfaceFormat : uint
 {
     SVGA3D_FORMAT_INVALID = 0,
 

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/TextureStateName.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/TextureStateName.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
-public enum SVGA3dTextureStateName : uint
+internal enum SVGA3dTextureStateName : uint
 {
     SVGA3D_TS_INVALID = 0,
     SVGA3D_TS_BIND_TEXTURE = 1,    /* SVGA3dSurfaceId */

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/TransferType.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/TransferType.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
-public enum SVGA3dTransferType
+internal enum SVGA3dTransferType
 {
     SVGA3D_WRITE_HOST_VRAM = 1,
     SVGA3D_READ_HOST_VRAM = 2,

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/TransformType.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Enums/TransformType.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
-public enum SVGA3dTransformType
+internal enum SVGA3dTransformType
 {
     SVGA3D_TRANSFORM_INVALID = 0,
     SVGA3D_TRANSFORM_WORLD = 1,

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Array.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Array.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dArray
+internal struct SVGA3dArray
 {
     public uint surfaceId;
     public uint offset;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/ArrayRangeHint.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/ArrayRangeHint.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dArrayRangeHint
+internal struct SVGA3dArrayRangeHint
 {
     public uint first;
     public uint last;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdClear.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdClear.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCmdClear
+internal struct SVGA3dCmdClear
 {
     public uint cid;
     public ClearFlags flag;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdDefineContext.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdDefineContext.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCmdDefineContext
+internal struct SVGA3dCmdDefineContext
 {
     public uint cid;
 }

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdDefineShader.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdDefineShader.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCmdDefineShader
+internal struct SVGA3dCmdDefineShader
 {
     public uint cid;
     public uint shid;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdDefineSurface.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdDefineSurface.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public unsafe struct SVGA3dCmdDefineSurface
+internal unsafe struct SVGA3dCmdDefineSurface
 {
     public uint sid;
     public SVGA3dSurfaceFlags flags;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdDestroyShader.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdDestroyShader.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCmdDestroyShader
+internal struct SVGA3dCmdDestroyShader
 {
     public uint cid;
     public uint shid;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdDrawPrimitives.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdDrawPrimitives.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCmdDrawPrimitives
+internal struct SVGA3dCmdDrawPrimitives
 {
     public uint cid;
     public uint numVertexDecls;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdHeader.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdHeader.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCmdHeader
+internal struct SVGA3dCmdHeader
 {
     public uint id;
     public uint size;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdPresent.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdPresent.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCmdPresent
+internal struct SVGA3dCmdPresent
 {
     public uint sid;
 }

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetLightData.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetLightData.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCmdSetLightData
+internal struct SVGA3dCmdSetLightData
 {
     public uint cid;
     public uint index;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetLightEnabled.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetLightEnabled.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCmdSetLightEnabled
+internal struct SVGA3dCmdSetLightEnabled
 {
     public uint cid;
     public uint index;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetMaterial.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetMaterial.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCmdSetMaterial
+internal struct SVGA3dCmdSetMaterial
 {
     public uint cid;
     public Face face;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetRenderState.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetRenderState.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCmdSetRenderState
+internal struct SVGA3dCmdSetRenderState
 {
     public uint cid;
 }

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetRenderTarget.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetRenderTarget.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCmdSetRenderTarget
+internal struct SVGA3dCmdSetRenderTarget
 {
     public uint cid;
     public SVGA3dRenderTargetType type;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetShader.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetShader.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCmdSetShader
+internal struct SVGA3dCmdSetShader
 {
     public uint cid;
     public SVGA3dShaderType type;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetShaderConst.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetShaderConst.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public unsafe struct SVGA3dCmdSetShaderConst
+internal unsafe struct SVGA3dCmdSetShaderConst
 {
     public uint cid;
     public uint reg;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetTextureState.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetTextureState.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCmdSetTextureState
+internal struct SVGA3dCmdSetTextureState
 {
     public uint cid;
 }

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetTransform.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetTransform.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public unsafe struct SVGA3dCmdSetTransform
+internal unsafe struct SVGA3dCmdSetTransform
 {
     public uint cid;
     public SVGA3dTransformType type;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetViewport.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetViewport.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCmdSetViewport
+internal struct SVGA3dCmdSetViewport
 {
     public uint cid;
     public SVGA3dRect rect;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetZRange.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSetZRange.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCmdSetZRange
+internal struct SVGA3dCmdSetZRange
 {
     public uint cid;
     public SVGA3dZRange range;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSurfaceDMA.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Commands/CmdSurfaceDMA.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCmdSurfaceDMA
+internal struct SVGA3dCmdSurfaceDMA
 {
     public SVGA3dGuestImage guest;
     public SVGA3dSurfaceImageId host;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/CopyBox.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/CopyBox.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCopyBox
+internal struct SVGA3dCopyBox
 {
     public uint x;
     public uint y;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/CopyRect.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/CopyRect.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dCopyRect
+internal struct SVGA3dCopyRect
 {
     public uint x;
     public uint y;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/GuestImage.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/GuestImage.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dGuestImage
+internal struct SVGA3dGuestImage
 {
     public SVGAGuestPtr ptr;
     public float pitch;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/GuestPtr.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/GuestPtr.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGAGuestPtr
+internal struct SVGAGuestPtr
 {
     public uint gmrId;
     public uint offset;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/LightData.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/LightData.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dLightData
+internal struct SVGA3dLightData
 {
     public LightType type;
     public uint inWorldSpace;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Material.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Material.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dMaterial
+internal struct SVGA3dMaterial
 {
     public Vector4 diffuse;
     public Vector4 ambient;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/PrimitiveRange.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/PrimitiveRange.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dPrimitiveRange
+internal struct SVGA3dPrimitiveRange
 {
     public SVGA3dPrimitiveType primType;
     public uint primitiveCount;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Rect.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Rect.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dRect
+internal struct SVGA3dRect
 {
     public uint x;
     public uint y;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/RenderState.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/RenderState.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Explicit, Pack = 1)]
-public struct SVGA3dRenderState
+internal struct SVGA3dRenderState
 {
     [FieldOffset(0)]
     public SVGA3dRenderStateName state;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Size.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/Size.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dSize
+internal struct SVGA3dSize
 {
     public uint width;
     public uint height;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/SurfaceImageId.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/SurfaceImageId.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dSurfaceImageId
+internal struct SVGA3dSurfaceImageId
 {
     public uint sid;
     public uint face;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/TextureState.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/TextureState.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Explicit, Pack = 1)]
-public struct SVGA3dTextureState
+internal struct SVGA3dTextureState
 {
     [FieldOffset(0)]
     public uint stage;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/VertexArrayIdentity.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/VertexArrayIdentity.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dVertexArrayIdentity
+internal struct SVGA3dVertexArrayIdentity
 {
     public SVGA3dDeclType type;
     public SVGA3dDeclMethod method;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/VertexDecl.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/VertexDecl.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dVertexDecl
+internal struct SVGA3dVertexDecl
 {
     public SVGA3dVertexArrayIdentity identity;
     public SVGA3dArray array;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/ZRange.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/Structs/ZRange.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct SVGA3dZRange
+internal struct SVGA3dZRange
 {
     public float min;
     public float max;

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/SvgaIIDriver.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/SvgaIIDriver.cs
@@ -15,7 +15,7 @@ namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 /// Update through the FIFO. The SVGA3D command layer is
 /// <see cref="VMWareSVGAII3D"/>, built on top of this driver.
 /// </summary>
-public unsafe class SvgaIIDriver : GraphicDevice
+internal unsafe class SvgaIIDriver : GraphicDevice
 {
     /// <summary>
     /// Video memory block.

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/VMwareSvgaII3D.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/SVGAII/VMwareSvgaII3D.cs
@@ -10,7 +10,7 @@ namespace Cosmos.Kernel.HAL.Devices.Graphic.SVGAII;
 /// support (<see cref="SvgaIIDriver.Is3DEnabled"/>) — QEMU's vmware-svga
 /// exposes no 3D capability, so this layer is only exercised on real VMware.
 /// </summary>
-public unsafe class VMWareSVGAII3D
+internal unsafe class VMWareSVGAII3D
 {
     private readonly SvgaIIDriver _driver;
 

--- a/src/Cosmos.Kernel.HAL/Devices/Input/KeyboardDevice.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Input/KeyboardDevice.cs
@@ -7,7 +7,7 @@ namespace Cosmos.Kernel.HAL.Devices.Input;
 /// <summary>
 /// Abstract base class for all keyboard devices.
 /// </summary>
-public abstract class KeyboardDevice : Device, IKeyboardDevice
+internal abstract class KeyboardDevice : Device, IKeyboardDevice
 {
     /// <summary>
     /// Event handler invoked when a key is pressed or released.

--- a/src/Cosmos.Kernel.HAL/Devices/Input/MouseDevice.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Input/MouseDevice.cs
@@ -12,12 +12,12 @@ namespace Cosmos.Kernel.HAL.Devices.Input;
 /// <param name="leftButton">Left button state.</param>
 /// <param name="rightButton">Right button state.</param>
 /// <param name="middleButton">Middle button state.</param>
-public delegate void MouseEventHandler(int deltaX, int deltaY, int deltaZ, bool leftButton, bool rightButton, bool middleButton);
+internal delegate void MouseEventHandler(int deltaX, int deltaY, int deltaZ, bool leftButton, bool rightButton, bool middleButton);
 
 /// <summary>
 /// Abstract base class for all mouse devices.
 /// </summary>
-public abstract class MouseDevice : Device, IMouseDevice
+internal abstract class MouseDevice : Device, IMouseDevice
 {
     /// <summary>
     /// Event handler invoked when mouse state changes.

--- a/src/Cosmos.Kernel.HAL/Devices/Input/VirtioKeyboard.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Input/VirtioKeyboard.cs
@@ -10,7 +10,7 @@ namespace Cosmos.Kernel.HAL.Devices.Input;
 /// Virtio-input keyboard driver. Transport-agnostic: works over virtio MMIO
 /// (QEMU virt) and virtio PCI (q35 virtio-keyboard-pci) alike.
 /// </summary>
-public unsafe class VirtioKeyboard : KeyboardDevice
+internal unsafe class VirtioKeyboard : KeyboardDevice
 {
     // Queue size
     private const uint QueueSize = 64;

--- a/src/Cosmos.Kernel.HAL/Devices/Input/VirtioMouse.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Input/VirtioMouse.cs
@@ -10,7 +10,7 @@ namespace Cosmos.Kernel.HAL.Devices.Input;
 /// Virtio-input mouse driver. Transport-agnostic: works over virtio MMIO
 /// (QEMU virt) and virtio PCI (q35 virtio-mouse-pci) alike.
 /// </summary>
-public unsafe class VirtioMouse : MouseDevice
+internal unsafe class VirtioMouse : MouseDevice
 {
     // Linux mouse button codes
     private const ushort BTN_LEFT = 0x110;

--- a/src/Cosmos.Kernel.HAL/Devices/Network/NetworkDevice.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Network/NetworkDevice.cs
@@ -7,7 +7,7 @@ namespace Cosmos.Kernel.HAL.Devices.Network;
 /// <summary>
 /// Abstract base class for all network devices.
 /// </summary>
-public abstract class NetworkDevice : Device, INetworkDevice
+internal abstract class NetworkDevice : Device, INetworkDevice
 {
     /// <summary>
     /// Event handler for packet received events.

--- a/src/Cosmos.Kernel.HAL/Devices/Network/VirtioNet.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Network/VirtioNet.cs
@@ -13,7 +13,7 @@ namespace Cosmos.Kernel.HAL.Devices.Network;
 /// VirtIO network device driver. Transport-agnostic: works over virtio MMIO
 /// (QEMU virt virtio-net-device) and virtio PCI (virtio-net-pci) alike.
 /// </summary>
-public unsafe class VirtioNet : INetworkDevice
+internal unsafe class VirtioNet : INetworkDevice
 {
     // --- Constants ---
 

--- a/src/Cosmos.Kernel.HAL/Devices/Storage/Ahci.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Storage/Ahci.cs
@@ -15,7 +15,7 @@ namespace Cosmos.Kernel.HAL.Devices.Storage;
 /// <see cref="AhciController"/> instances and all of their attached SATA
 /// drives show up in <see cref="Ports"/>.
 /// </summary>
-public static class Ahci
+internal static class Ahci
 {
     private static List<AhciController>? s_controllers;
     private static List<BlockDevice>? s_ports;

--- a/src/Cosmos.Kernel.HAL/Devices/Storage/AhciController.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Storage/AhciController.cs
@@ -18,7 +18,7 @@ namespace Cosmos.Kernel.HAL.Devices.Storage;
 /// <see cref="AhciController"/> per match, so a system with two HBAs gets
 /// two instances and all of their ports show up in <see cref="Ahci.Ports"/>.
 /// </summary>
-public unsafe class AhciController
+internal unsafe class AhciController
 {
     /// <summary>Stride between consecutive ports' command lists inside the command region (1 KiB; AHCI's CLB alignment).</summary>
     private const uint PortStrideCLB = 0x400;

--- a/src/Cosmos.Kernel.HAL/Devices/Storage/AhciEnums.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Storage/AhciEnums.cs
@@ -5,7 +5,7 @@ namespace Cosmos.Kernel.HAL.Devices.Storage;
 /// <summary>
 /// Port type enumeration.
 /// </summary>
-public enum PortType
+internal enum PortType
 {
     Nothing = 0x00,
     Sata = 0x01,
@@ -17,7 +17,7 @@ public enum PortType
 /// <summary>
 /// FIS (Frame Information Structure) type enumeration.
 /// </summary>
-public enum FisType : byte
+internal enum FisType : byte
 {
     RegisterH2D = 0x27,  // Register FIS: Host to Device
     RegisterD2H = 0x34,  // Register FIS: Device to Host
@@ -32,7 +32,7 @@ public enum FisType : byte
 /// <summary>
 /// AHCI drive signature to identify what drive is plugged to Port.
 /// </summary>
-public enum AhciSignature : uint
+internal enum AhciSignature : uint
 {
     Sata = 0x0000,
     PortMultiplier = 0x9669,
@@ -44,7 +44,7 @@ public enum AhciSignature : uint
 /// <summary>
 /// SATA Status: Interface Power Management Status.
 /// </summary>
-public enum InterfacePowerManagementStatus : uint
+internal enum InterfacePowerManagementStatus : uint
 {
     NotPresent = 0x00,
     Active = 0x01,
@@ -56,7 +56,7 @@ public enum InterfacePowerManagementStatus : uint
 /// <summary>
 /// SATA Status: Current Interface Speed.
 /// </summary>
-public enum CurrentInterfaceSpeedStatus : uint
+internal enum CurrentInterfaceSpeedStatus : uint
 {
     NotPresent = 0x00,
     Gen1Rate = 0x01,
@@ -67,7 +67,7 @@ public enum CurrentInterfaceSpeedStatus : uint
 /// <summary>
 /// SATA Status: Device Detection Status.
 /// </summary>
-public enum DeviceDetectionStatus : uint
+internal enum DeviceDetectionStatus : uint
 {
     NotDetected = 0x00,
     DeviceDetectedNoPhy = 0x01,
@@ -78,7 +78,7 @@ public enum DeviceDetectionStatus : uint
 /// <summary>
 /// ATA Device Status bits.
 /// </summary>
-public enum AtaDeviceStatus : uint
+internal enum AtaDeviceStatus : uint
 {
     Busy = 0x80,
     DRQ = 0x08
@@ -87,7 +87,7 @@ public enum AtaDeviceStatus : uint
 /// <summary>
 /// Command and Status register bits.
 /// </summary>
-public enum CommandAndStatus : uint
+internal enum CommandAndStatus : uint
 {
     ICC_Reserved0 = 0x0000000F,
     // PxCMD.ICC lives in bits 31:28 (AHCI 1.3.1 s3.3.7) — the values are
@@ -128,7 +128,7 @@ public enum CommandAndStatus : uint
 /// <summary>
 /// Interrupt Status bits.
 /// </summary>
-public enum InterruptStatus : int
+internal enum InterruptStatus : int
 {
     ColdPortDetectStatus = 01 << 31,
     TaskFileErrorStatus = 01 << 30,
@@ -153,7 +153,7 @@ public enum InterruptStatus : int
 /// <summary>
 /// ATA Commands.
 /// </summary>
-public enum AtaCommands : byte
+internal enum AtaCommands : byte
 {
     ReadDma = 0xC8,
     ReadDmaExt = 0x25,

--- a/src/Cosmos.Kernel.HAL/Devices/Storage/AhciRegisters.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Storage/AhciRegisters.cs
@@ -7,7 +7,7 @@ namespace Cosmos.Kernel.HAL.Devices.Storage;
 /// <summary>
 /// AHCI Generic Host Control Registers.
 /// </summary>
-public class GenericRegisters
+internal class GenericRegisters
 {
     /// <summary>CAP - Host Capabilities register offset (AHCI spec 3.1.1).</summary>
     private const ulong CapabilitiesOffset = 0x00;
@@ -122,7 +122,7 @@ public class GenericRegisters
 /// command issue, port reset) can reach controller state without going
 /// through globals.
 /// </summary>
-public class PortRegisters
+internal class PortRegisters
 {
     /// <summary>Size of one port register bank in bytes; port N starts at 0x100 + N * 0x80 (AHCI spec 3.3).</summary>
     private const uint PortRegisterSpanBytes = 0x80;
@@ -336,7 +336,7 @@ public class PortRegisters
 /// <summary>
 /// HBA Command Header structure.
 /// </summary>
-public class HbaCommandHeader
+internal class HbaCommandHeader
 {
     /// <summary>Size of one command header in bytes; slot N starts at CLB + N * 32 (AHCI spec 4.2.2).</summary>
     private const uint CommandHeaderSizeBytes = 32;
@@ -433,7 +433,7 @@ public class HbaCommandHeader
 /// HBA itself addresses this table via the physical CTBA written into the
 /// owning <see cref="HbaCommandHeader"/>.
 /// </summary>
-public class HbaCommandTable
+internal class HbaCommandTable
 {
     /// <summary>Offset of the PRDT within the command table; the CFIS, ACMD and reserved areas occupy the first 0x80 bytes (AHCI spec 4.2.3).</summary>
     private const int PrdtOffsetBytes = 0x80;
@@ -467,7 +467,7 @@ public class HbaCommandTable
 /// <summary>
 /// HBA PRDT Entry.
 /// </summary>
-public class HbaPrdtEntry
+internal class HbaPrdtEntry
 {
     /// <summary>Size of one PRDT entry in bytes; entry N starts at PRDT base + N * 0x10 (AHCI spec 4.2.3.3).</summary>
     private const uint PrdtEntrySizeBytes = 0x10;
@@ -533,7 +533,7 @@ public class HbaPrdtEntry
 /// <summary>
 /// FIS Register Host to Device.
 /// </summary>
-public class FisRegisterH2D
+internal class FisRegisterH2D
 {
     /// <summary>Number of 32-bit dwords in a Register H2D FIS (20 bytes / 4, SATA spec 10.5.4). Internal so <see cref="Sata"/> programs it into the command header CFL field.</summary>
     internal const int FisDwordCount = 5;

--- a/src/Cosmos.Kernel.HAL/Devices/Storage/BlockDevice.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Storage/BlockDevice.cs
@@ -7,7 +7,7 @@ namespace Cosmos.Kernel.HAL.Devices.Storage;
 /// <summary>
 /// Abstract base class for all block storage devices.
 /// </summary>
-public abstract class BlockDevice : Device, IBlockDevice
+internal abstract class BlockDevice : Device, IBlockDevice
 {
     /// <inheritdoc />
     public ulong BlockCount { get; protected set; }

--- a/src/Cosmos.Kernel.HAL/Devices/Storage/Nvme.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Storage/Nvme.cs
@@ -14,7 +14,7 @@ namespace Cosmos.Kernel.HAL.Devices.Storage;
 /// <see cref="NvmeController"/> instances and all their namespaces show up
 /// in <see cref="Namespaces"/>.
 /// </summary>
-public static class Nvme
+internal static class Nvme
 {
     private static List<NvmeController>? s_controllers;
     private static List<NvmeNamespace>? s_namespaces;

--- a/src/Cosmos.Kernel.HAL/Devices/Storage/NvmeCommands.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Storage/NvmeCommands.cs
@@ -5,7 +5,7 @@ using Cosmos.Kernel.Core;
 namespace Cosmos.Kernel.HAL.Devices.Storage;
 
 /// <summary>NVMe admin opcodes (NVM Express 1.4 §5.x).</summary>
-public static class NvmeAdminOp
+internal static class NvmeAdminOp
 {
     public const byte DeleteIoSq = 0x00;
     public const byte CreateIoSq = 0x01;
@@ -17,7 +17,7 @@ public static class NvmeAdminOp
 }
 
 /// <summary>NVMe NVM-command-set IO opcodes (NVM Express 1.4 §6.x).</summary>
-public static class NvmeIoOp
+internal static class NvmeIoOp
 {
     public const byte Flush = 0x00;
     public const byte Write = 0x01;
@@ -25,7 +25,7 @@ public static class NvmeIoOp
 }
 
 /// <summary>Identify CNS values (NVM Express 1.4 §5.15).</summary>
-public static class NvmeCns
+internal static class NvmeCns
 {
     public const byte Namespace = 0x00;
     public const byte Controller = 0x01;
@@ -38,7 +38,7 @@ public static class NvmeCns
 /// the layout stays exactly as the controller expects regardless of
 /// runtime padding).
 /// </summary>
-public unsafe struct NvmeSqe
+internal unsafe struct NvmeSqe
 {
     /// <summary>Submission Queue Entry size in 64-bit words (64 bytes / 8).</summary>
     private const int SqeSizeQwords = 8;
@@ -120,7 +120,7 @@ public unsafe struct NvmeSqe
 /// NVMe Completion Queue Entry (16 bytes). Reads only — the controller
 /// writes these.
 /// </summary>
-public unsafe struct NvmeCqe
+internal unsafe struct NvmeCqe
 {
     /// <summary>Byte offset of DW0 (command-specific result) within the CQE.</summary>
     private const ulong CommandSpecificOffset = 0x00;

--- a/src/Cosmos.Kernel.HAL/Devices/Storage/NvmeController.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Storage/NvmeController.cs
@@ -39,7 +39,7 @@ namespace Cosmos.Kernel.HAL.Devices.Storage;
 /// discovery.</item>
 /// </list>
 /// </summary>
-public unsafe class NvmeController
+internal unsafe class NvmeController
 {
     private const uint AdminQueueDepth = 8;
     private const uint IoQueueDepth = 8;

--- a/src/Cosmos.Kernel.HAL/Devices/Storage/NvmeNamespace.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Storage/NvmeNamespace.cs
@@ -11,7 +11,7 @@ namespace Cosmos.Kernel.HAL.Devices.Storage;
 /// concurrent callers on the same namespace) execute in parallel up to
 /// the controller's I/O queue depth minus one (the NVMe queue-full rule).
 /// </summary>
-public unsafe class NvmeNamespace : BlockDevice
+internal unsafe class NvmeNamespace : BlockDevice
 {
     private readonly NvmeController _controller;
     private readonly uint _nsid;

--- a/src/Cosmos.Kernel.HAL/Devices/Storage/NvmeRegisters.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Storage/NvmeRegisters.cs
@@ -11,7 +11,7 @@ namespace Cosmos.Kernel.HAL.Devices.Storage;
 ///
 /// Layout follows NVM Express 1.4 §3.1.
 /// </summary>
-public class NvmeRegisters
+internal class NvmeRegisters
 {
     /// <summary>CAP — Controller Capabilities register offset (RO, 64-bit, NVMe 1.4 §3.1.1).</summary>
     private const ulong CapOffset = 0x00;

--- a/src/Cosmos.Kernel.HAL/Devices/Storage/Sata.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Storage/Sata.cs
@@ -18,7 +18,7 @@ namespace Cosmos.Kernel.HAL.Devices.Storage;
 /// contents. All I/O on a port is serialized by an internal lock — the
 /// port owns a single bounce buffer.</para>
 /// </summary>
-public class Sata : BlockDevice
+internal class Sata : BlockDevice
 {
     /// <summary>
     /// Regular sector size (512 bytes).

--- a/src/Cosmos.Kernel.HAL/Devices/Timer/TimerDevice.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Timer/TimerDevice.cs
@@ -9,7 +9,7 @@ namespace Cosmos.Kernel.HAL.Devices.Timer;
 /// Abstract base class for all timer devices. Maintains the software timer
 /// registry that is advanced on each hardware tick of the device.
 /// </summary>
-public abstract class TimerDevice : Device, ITimerDevice
+internal abstract class TimerDevice : Device, ITimerDevice
 {
     /// <summary>Nanoseconds in one millisecond.</summary>
     protected const ulong NanosecondsPerMillisecond = 1_000_000;

--- a/src/Cosmos.Kernel.HAL/Devices/Virtio/VirtioDevice.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Virtio/VirtioDevice.cs
@@ -18,7 +18,7 @@ namespace Cosmos.Kernel.HAL.Devices.Virtio;
 /// </summary>
 // Note: This class is eagerly constructed at startup because accessing s_devices causes issues otherwise.
 [EagerStaticClassConstruction]
-public static class VirtioDevice
+internal static class VirtioDevice
 {
     private const int MaxDevices = 32;
 

--- a/src/Cosmos.Kernel.HAL/Devices/Virtio/VirtioDma.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Virtio/VirtioDma.cs
@@ -11,7 +11,7 @@ namespace Cosmos.Kernel.HAL.Devices.Virtio;
 /// works with HHDM virtual addresses; register windows are accessed through
 /// their HHDM alias so the per-arch device-memory attributes apply.
 /// </summary>
-public static class VirtioDma
+internal static class VirtioDma
 {
     /// <summary>
     /// Converts a kernel virtual address (HHDM) to a guest physical address for DMA.

--- a/src/Cosmos.Kernel.HAL/Devices/Virtio/VirtioMmioTransport.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Virtio/VirtioMmioTransport.cs
@@ -15,7 +15,7 @@ namespace Cosmos.Kernel.HAL.Devices.Virtio;
 /// layout), so the platform initializer supplies the window address, the
 /// interrupt line, and the line-interrupt wiring callback.
 /// </summary>
-public sealed class VirtioMmioTransport : VirtioTransport
+internal sealed class VirtioMmioTransport : VirtioTransport
 {
     /// <summary>Virtio MMIO magic value ("virt" in little endian).</summary>
     public const uint Magic = 0x74726976;

--- a/src/Cosmos.Kernel.HAL/Devices/Virtio/VirtioPciTransport.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Virtio/VirtioPciTransport.cs
@@ -18,7 +18,7 @@ namespace Cosmos.Kernel.HAL.Devices.Virtio;
 /// virtio-pci devices (I/O BAR interface, no vendor capabilities) are not
 /// supported.
 /// </summary>
-public sealed class VirtioPciTransport : VirtioTransport
+internal sealed class VirtioPciTransport : VirtioTransport
 {
     /// <summary>PCI vendor ID of all virtio devices (Red Hat).</summary>
     public const ushort VirtioVendorId = 0x1AF4;

--- a/src/Cosmos.Kernel.HAL/Devices/Virtio/VirtioTransport.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Virtio/VirtioTransport.cs
@@ -11,14 +11,14 @@ namespace Cosmos.Kernel.HAL.Devices.Virtio;
 /// (<see cref="VirtioTransport.IsrQueue"/> / <see cref="VirtioTransport.IsrConfig"/>);
 /// the transport has already acknowledged the interrupt.
 /// </summary>
-public delegate void VirtioInterruptHandler(uint isrStatus);
+internal delegate void VirtioInterruptHandler(uint isrStatus);
 
 /// <summary>
 /// Wires a platform line interrupt (e.g. a GIC SPI) to a transport dispatch
 /// handler. Supplied by the platform initializer that owns the bus, so the
 /// shared transport stays free of per-arch interrupt-controller calls.
 /// </summary>
-public delegate void VirtioIrqEnable(uint intid, InterruptManager.IrqDelegate handler);
+internal delegate void VirtioIrqEnable(uint intid, InterruptManager.IrqDelegate handler);
 
 /// <summary>
 /// Transport-independent core of a virtio device (virtio spec 1.x): device
@@ -28,7 +28,7 @@ public delegate void VirtioIrqEnable(uint intid, InterruptManager.IrqDelegate ha
 /// <see cref="VirtioMmioTransport"/> and <see cref="VirtioPciTransport"/>
 /// implement the per-transport register access.
 /// </summary>
-public abstract class VirtioTransport
+internal abstract class VirtioTransport
 {
     // Virtio device types (virtio spec section 5).
     public const uint DeviceTypeNetwork = 1;

--- a/src/Cosmos.Kernel.HAL/Devices/Virtio/Virtqueue.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Virtio/Virtqueue.cs
@@ -14,7 +14,7 @@ namespace Cosmos.Kernel.HAL.Devices.Virtio;
 /// - Used ring: buffers returned by device
 /// The layout is transport-independent; the same rings work over MMIO and PCI.
 /// </summary>
-public unsafe class Virtqueue
+internal unsafe class Virtqueue
 {
     // Descriptor flags
     public const ushort VRING_DESC_F_NEXT = 1;      // Buffer continues via next field

--- a/src/Cosmos.Kernel.HAL/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
+++ b/src/Cosmos.Kernel.HAL/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
@@ -17,7 +17,7 @@ namespace Internal.Runtime.CompilerHelpers
     /// <summary>
     /// This class is responsible for initializing the library and its dependencies. It is called by the runtime before any managed code is executed.
     /// </summary>
-    public class LibraryInitializer
+    internal class LibraryInitializer
     {
         /// <summary>
         /// Initialize HAL, interrupts, PCI, and platform-specific hardware. This method is called by the runtime before any managed code is executed.

--- a/src/Cosmos.Kernel.HAL/Pci/DeviceString.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/DeviceString.cs
@@ -2,7 +2,7 @@
 
 namespace Cosmos.Kernel.HAL.Pci;
 
-public static class DeviceString
+internal static class DeviceString
 {
     public static string GetDeviceString(this PciDevice device)
     {

--- a/src/Cosmos.Kernel.HAL/Pci/Enums/ClassId.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/Enums/ClassId.cs
@@ -2,7 +2,7 @@
 
 namespace Cosmos.Kernel.HAL.Pci.Enums;
 
-public enum ClassId
+internal enum ClassId
 {
     PciDevice20 = 0x00,
     MassStorageController = 0x01,

--- a/src/Cosmos.Kernel.HAL/Pci/Enums/Config.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/Enums/Config.cs
@@ -1,6 +1,6 @@
 namespace Cosmos.Kernel.HAL.Pci.Enums;
 
-public enum Config : byte
+internal enum Config : byte
 {
     VendorId = 0,
     DeviceId = 2,

--- a/src/Cosmos.Kernel.HAL/Pci/Enums/DeviceID.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/Enums/DeviceID.cs
@@ -2,7 +2,7 @@
 
 namespace Cosmos.Kernel.HAL.Pci.Enums;
 
-public enum DeviceId
+internal enum DeviceId
 {
     SvgaiiAdapter = 0x0405,
     Pcnetii = 0x2000,

--- a/src/Cosmos.Kernel.HAL/Pci/Enums/PCIBist.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/Enums/PCIBist.cs
@@ -1,6 +1,6 @@
 namespace Cosmos.Kernel.HAL.Pci.Enums;
 
-public enum PciBist : byte
+internal enum PciBist : byte
 {
     CocdMask = 0x0f, /* Return result */
     Start = 0x40, /* 1 to start BIST, 2 secs or less */

--- a/src/Cosmos.Kernel.HAL/Pci/Enums/PCICommand.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/Enums/PCICommand.cs
@@ -2,7 +2,7 @@
 
 namespace Cosmos.Kernel.HAL.Pci.Enums;
 
-public enum PciCommand : short
+internal enum PciCommand : short
 {
     Io = 0x1, /* Enable response in I/O space */
     Memory = 0x2, /* Enable response in Memory space */

--- a/src/Cosmos.Kernel.HAL/Pci/Enums/PCIHeaderType.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/Enums/PCIHeaderType.cs
@@ -2,7 +2,7 @@
 
 namespace Cosmos.Kernel.HAL.Pci.Enums;
 
-public enum PciHeaderType : byte
+internal enum PciHeaderType : byte
 {
     Normal = 0x00,
     Bridge = 0x01,

--- a/src/Cosmos.Kernel.HAL/Pci/Enums/PCIInterruptPIN.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/Enums/PCIInterruptPIN.cs
@@ -2,7 +2,7 @@
 
 namespace Cosmos.Kernel.HAL.Pci.Enums;
 
-public enum PciInterruptPin : byte
+internal enum PciInterruptPin : byte
 {
     None = 0x00,
     Inta = 0x01,

--- a/src/Cosmos.Kernel.HAL/Pci/Enums/ProgramIF.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/Enums/ProgramIF.cs
@@ -2,7 +2,7 @@
 
 namespace Cosmos.Kernel.HAL.Pci.Enums;
 
-public enum ProgramIf
+internal enum ProgramIf
 {
     // MassStorageController:
     SataVendorSpecific = 0x00,

--- a/src/Cosmos.Kernel.HAL/Pci/Enums/SubclassId.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/Enums/SubclassId.cs
@@ -2,7 +2,7 @@
 
 namespace Cosmos.Kernel.HAL.Pci.Enums;
 
-public enum SubclassId
+internal enum SubclassId
 {
     // MassStorageController:
     ScsiStorageController = 0x00,

--- a/src/Cosmos.Kernel.HAL/Pci/Enums/VendorID.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/Enums/VendorID.cs
@@ -2,7 +2,7 @@
 
 namespace Cosmos.Kernel.HAL.Pci.Enums;
 
-public enum VendorId
+internal enum VendorId
 {
     Intel = 0x8086,
     Amd = 0x1022,

--- a/src/Cosmos.Kernel.HAL/Pci/MsiX.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/MsiX.cs
@@ -15,7 +15,7 @@ namespace Cosmos.Kernel.HAL.Pci;
 /// table programming works whether interrupts ultimately land on an x64
 /// LAPIC or an ARM64 GICv3 ITS.
 /// </summary>
-public static class MsiX
+internal static class MsiX
 {
     public const byte CapId = 0x11;
 
@@ -179,7 +179,7 @@ public static class MsiX
 /// state (e.g. ARM64 ITS DeviceID + ITT pointer) so subsequent
 /// <see cref="MsiX.SetEntry"/> calls can route through the same context.
 /// </summary>
-public readonly struct MsiXContext
+internal readonly struct MsiXContext
 {
     public ulong TableVirt { get; }
     public int EntryCount { get; }

--- a/src/Cosmos.Kernel.HAL/Pci/PCIDeviceBridge.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/PCIDeviceBridge.cs
@@ -2,7 +2,7 @@
 
 namespace Cosmos.Kernel.HAL.Pci;
 
-public class PciDeviceBridge : PciDevice
+internal class PciDeviceBridge : PciDevice
 {
     public PciBaseAddressBar[] BaseAddresses { get; private set; }
 

--- a/src/Cosmos.Kernel.HAL/Pci/PCIDeviceCardbus.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/PCIDeviceCardbus.cs
@@ -2,7 +2,7 @@
 
 namespace Cosmos.Kernel.HAL.Pci;
 
-public class PciDeviceCardBus : PciDevice
+internal class PciDeviceCardBus : PciDevice
 {
     public uint CardBusBaseAddress { get; private set; }
 

--- a/src/Cosmos.Kernel.HAL/Pci/PCIDeviceNormal.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/PCIDeviceNormal.cs
@@ -2,7 +2,7 @@
 
 namespace Cosmos.Kernel.HAL.Pci;
 
-public class PciDeviceNormal : PciDevice
+internal class PciDeviceNormal : PciDevice
 {
     public PciBaseAddressBar[] BaseAddresses { get; private set; }
 

--- a/src/Cosmos.Kernel.HAL/Pci/PciBaseAddressBar.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/PciBaseAddressBar.cs
@@ -1,6 +1,6 @@
 namespace Cosmos.Kernel.HAL.Pci;
 
-public class PciBaseAddressBar
+internal class PciBaseAddressBar
 {
     private ushort _prefetchable;
     private ushort _type;

--- a/src/Cosmos.Kernel.HAL/Pci/PciDevice.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/PciDevice.cs
@@ -8,7 +8,7 @@ using Cosmos.Kernel.HAL.Pci.Enums;
 
 namespace Cosmos.Kernel.HAL.Pci;
 
-public class PciDevice : Device
+internal class PciDevice : Device
 {
     public readonly uint Bus;
     public readonly uint Slot;

--- a/src/Cosmos.Kernel.HAL/Pci/PciManager.cs
+++ b/src/Cosmos.Kernel.HAL/Pci/PciManager.cs
@@ -6,7 +6,7 @@ using Cosmos.Kernel.HAL.Pci.Enums;
 
 namespace Cosmos.Kernel.HAL.Pci;
 
-public class PciManager
+internal class PciManager
 {
     /// <summary>Maximum number of PCI devices tracked in the device cache.</summary>
     private const int MaxDevices = 64;

--- a/src/Cosmos.Kernel.HAL/PlatformHAL.cs
+++ b/src/Cosmos.Kernel.HAL/PlatformHAL.cs
@@ -11,7 +11,7 @@ namespace Cosmos.Kernel.HAL;
 /// <summary>
 /// Platform HAL manager - provides access to platform-specific hardware.
 /// </summary>
-public static class PlatformHAL
+internal static class PlatformHAL
 {
     /// <summary>
     /// Legacy POST diagnostic I/O port (0x80); a read takes ~1 µs on PC chipsets,

--- a/src/Cosmos.Kernel.HAL/PublicAPI.Shipped.txt
+++ b/src/Cosmos.Kernel.HAL/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Cosmos.Kernel.HAL/PublicAPI.Unshipped.txt
+++ b/src/Cosmos.Kernel.HAL/PublicAPI.Unshipped.txt
@@ -1,0 +1,112 @@
+#nullable enable
+Cosmos.Kernel.HAL.Vfs.IFileOperations
+Cosmos.Kernel.HAL.Vfs.IFileOperations.Fsync(Cosmos.Kernel.HAL.Vfs.IVfsOpenFile! openFile) -> bool
+Cosmos.Kernel.HAL.Vfs.IFileOperations.Read(Cosmos.Kernel.HAL.Vfs.IVfsOpenFile! openFile, System.Span<byte> buffer) -> long
+Cosmos.Kernel.HAL.Vfs.IFileOperations.Release(Cosmos.Kernel.HAL.Vfs.IVfsOpenFile! openFile) -> void
+Cosmos.Kernel.HAL.Vfs.IFileOperations.Seek(Cosmos.Kernel.HAL.Vfs.IVfsOpenFile! openFile, long offset, Cosmos.Kernel.HAL.Vfs.SeekWhence whence, out long newPosition) -> bool
+Cosmos.Kernel.HAL.Vfs.IFileOperations.Write(Cosmos.Kernel.HAL.Vfs.IVfsOpenFile! openFile, System.ReadOnlySpan<byte> buffer) -> long
+Cosmos.Kernel.HAL.Vfs.IInodeOperations
+Cosmos.Kernel.HAL.Vfs.IInodeOperations.Create(Cosmos.Kernel.HAL.Vfs.IVfsInode! dir, System.ReadOnlySpan<char> name, Cosmos.Kernel.HAL.Vfs.ModeEnum mode, out Cosmos.Kernel.HAL.Vfs.IVfsInode? inode) -> bool
+Cosmos.Kernel.HAL.Vfs.IInodeOperations.GetAttr(Cosmos.Kernel.HAL.Vfs.IVfsInode! inode, out Cosmos.Kernel.HAL.Vfs.VfsStat stat) -> bool
+Cosmos.Kernel.HAL.Vfs.IInodeOperations.Lookup(Cosmos.Kernel.HAL.Vfs.IVfsInode! dir, System.ReadOnlySpan<char> name, out Cosmos.Kernel.HAL.Vfs.IVfsInode? child) -> bool
+Cosmos.Kernel.HAL.Vfs.IInodeOperations.Mkdir(Cosmos.Kernel.HAL.Vfs.IVfsInode! dir, System.ReadOnlySpan<char> name, Cosmos.Kernel.HAL.Vfs.ModeEnum mode, out Cosmos.Kernel.HAL.Vfs.IVfsInode? inode) -> bool
+Cosmos.Kernel.HAL.Vfs.IInodeOperations.ReadDir(Cosmos.Kernel.HAL.Vfs.IVfsInode! dir, out System.Collections.Generic.IReadOnlyList<Cosmos.Kernel.HAL.Vfs.IVfsInode!>! entries) -> bool
+Cosmos.Kernel.HAL.Vfs.IInodeOperations.Rename(Cosmos.Kernel.HAL.Vfs.IVfsInode! oldParent, System.ReadOnlySpan<char> oldName, Cosmos.Kernel.HAL.Vfs.IVfsInode! newParent, System.ReadOnlySpan<char> newName) -> bool
+Cosmos.Kernel.HAL.Vfs.IInodeOperations.Rmdir(Cosmos.Kernel.HAL.Vfs.IVfsInode! dir, System.ReadOnlySpan<char> name) -> bool
+Cosmos.Kernel.HAL.Vfs.IInodeOperations.SetAttr(Cosmos.Kernel.HAL.Vfs.IVfsInode! inode, Cosmos.Kernel.HAL.Vfs.SetAttrFlags flags, in Cosmos.Kernel.HAL.Vfs.VfsStat attributes) -> bool
+Cosmos.Kernel.HAL.Vfs.IInodeOperations.Symlink(Cosmos.Kernel.HAL.Vfs.IVfsInode! dir, System.ReadOnlySpan<char> name, System.ReadOnlySpan<char> target, out Cosmos.Kernel.HAL.Vfs.IVfsInode? inode) -> bool
+Cosmos.Kernel.HAL.Vfs.IInodeOperations.Unlink(Cosmos.Kernel.HAL.Vfs.IVfsInode! dir, System.ReadOnlySpan<char> name) -> bool
+Cosmos.Kernel.HAL.Vfs.ISuperblockOperations
+Cosmos.Kernel.HAL.Vfs.ISuperblockOperations.Drop(Cosmos.Kernel.HAL.Vfs.IVfsSuperblock! superblock) -> void
+Cosmos.Kernel.HAL.Vfs.ISuperblockOperations.StatFs(Cosmos.Kernel.HAL.Vfs.IVfsSuperblock! superblock, out Cosmos.Kernel.HAL.Vfs.VfsStatFs statFs) -> bool
+Cosmos.Kernel.HAL.Vfs.ISuperblockOperations.Sync(Cosmos.Kernel.HAL.Vfs.IVfsSuperblock! superblock) -> bool
+Cosmos.Kernel.HAL.Vfs.IVfsFilesystemType
+Cosmos.Kernel.HAL.Vfs.IVfsFilesystemType.TryDestroy(System.ReadOnlySpan<char> source) -> bool
+Cosmos.Kernel.HAL.Vfs.IVfsFilesystemType.TryFormat(System.ReadOnlySpan<char> source, Cosmos.Kernel.HAL.Vfs.IVfsFormatOptions? options) -> bool
+Cosmos.Kernel.HAL.Vfs.IVfsFilesystemType.TryMount(System.ReadOnlySpan<char> source, Cosmos.Kernel.HAL.Vfs.MountFlags flags, out Cosmos.Kernel.HAL.Vfs.IVfsSuperblock? superblock) -> bool
+Cosmos.Kernel.HAL.Vfs.IVfsFormatOptions
+Cosmos.Kernel.HAL.Vfs.IVfsInode
+Cosmos.Kernel.HAL.Vfs.IVfsInode.FileOperations.get -> Cosmos.Kernel.HAL.Vfs.IFileOperations?
+Cosmos.Kernel.HAL.Vfs.IVfsInode.InodeOperations.get -> Cosmos.Kernel.HAL.Vfs.IInodeOperations!
+Cosmos.Kernel.HAL.Vfs.IVfsInode.Name.get -> string!
+Cosmos.Kernel.HAL.Vfs.IVfsOpenFile
+Cosmos.Kernel.HAL.Vfs.IVfsOpenFile.Inode.get -> Cosmos.Kernel.HAL.Vfs.IVfsInode!
+Cosmos.Kernel.HAL.Vfs.IVfsOpenFile.Operations.get -> Cosmos.Kernel.HAL.Vfs.IFileOperations!
+Cosmos.Kernel.HAL.Vfs.IVfsOpenFile.Position.get -> long
+Cosmos.Kernel.HAL.Vfs.IVfsOpenFile.Position.set -> void
+Cosmos.Kernel.HAL.Vfs.IVfsSuperblock
+Cosmos.Kernel.HAL.Vfs.IVfsSuperblock.BlockSize.get -> long
+Cosmos.Kernel.HAL.Vfs.IVfsSuperblock.MaxNameLength.get -> ulong
+Cosmos.Kernel.HAL.Vfs.IVfsSuperblock.Root.get -> Cosmos.Kernel.HAL.Vfs.IVfsInode!
+Cosmos.Kernel.HAL.Vfs.IVfsSuperblock.SuperOperations.get -> Cosmos.Kernel.HAL.Vfs.ISuperblockOperations!
+Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.BlockDevice = Cosmos.Kernel.HAL.Vfs.ModeEnum.CharacterDevice | Cosmos.Kernel.HAL.Vfs.ModeEnum.Directory -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.CharacterDevice = 8192 -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.Directory = 16384 -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.FileTypeMask = Cosmos.Kernel.HAL.Vfs.ModeEnum.NamedPipe | Cosmos.Kernel.HAL.Vfs.ModeEnum.CharacterDevice | Cosmos.Kernel.HAL.Vfs.ModeEnum.Socket -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.GroupExecute = 8 -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.GroupRead = 32 -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.GroupWrite = 16 -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.NamedPipe = 4096 -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.OtherExecute = 1 -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.OtherRead = 4 -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.OtherWrite = 2 -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.OwnerExecute = 64 -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.OwnerRead = 256 -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.OwnerWrite = 128 -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.PermissionMask = Cosmos.Kernel.HAL.Vfs.ModeEnum.OtherExecute | Cosmos.Kernel.HAL.Vfs.ModeEnum.OtherWrite | Cosmos.Kernel.HAL.Vfs.ModeEnum.OtherRead | Cosmos.Kernel.HAL.Vfs.ModeEnum.GroupExecute | Cosmos.Kernel.HAL.Vfs.ModeEnum.GroupWrite | Cosmos.Kernel.HAL.Vfs.ModeEnum.GroupRead | Cosmos.Kernel.HAL.Vfs.ModeEnum.OwnerExecute | Cosmos.Kernel.HAL.Vfs.ModeEnum.OwnerWrite | Cosmos.Kernel.HAL.Vfs.ModeEnum.OwnerRead -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.RegularFile = 32768 -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.SetGroupId = 1024 -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.SetUserId = 2048 -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.Socket = Cosmos.Kernel.HAL.Vfs.ModeEnum.Directory | Cosmos.Kernel.HAL.Vfs.ModeEnum.RegularFile -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.Sticky = 512 -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.ModeEnum.SymbolicLink = Cosmos.Kernel.HAL.Vfs.ModeEnum.CharacterDevice | Cosmos.Kernel.HAL.Vfs.ModeEnum.RegularFile -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.MountFlags
+Cosmos.Kernel.HAL.Vfs.MountFlags.NoDev = 4 -> Cosmos.Kernel.HAL.Vfs.MountFlags
+Cosmos.Kernel.HAL.Vfs.MountFlags.NoExec = 8 -> Cosmos.Kernel.HAL.Vfs.MountFlags
+Cosmos.Kernel.HAL.Vfs.MountFlags.None = 0 -> Cosmos.Kernel.HAL.Vfs.MountFlags
+Cosmos.Kernel.HAL.Vfs.MountFlags.NoSuid = 2 -> Cosmos.Kernel.HAL.Vfs.MountFlags
+Cosmos.Kernel.HAL.Vfs.MountFlags.ReadOnly = 1 -> Cosmos.Kernel.HAL.Vfs.MountFlags
+Cosmos.Kernel.HAL.Vfs.SeekWhence
+Cosmos.Kernel.HAL.Vfs.SeekWhence.Cur = 1 -> Cosmos.Kernel.HAL.Vfs.SeekWhence
+Cosmos.Kernel.HAL.Vfs.SeekWhence.End = 2 -> Cosmos.Kernel.HAL.Vfs.SeekWhence
+Cosmos.Kernel.HAL.Vfs.SeekWhence.Set = 0 -> Cosmos.Kernel.HAL.Vfs.SeekWhence
+Cosmos.Kernel.HAL.Vfs.SetAttrFlags
+Cosmos.Kernel.HAL.Vfs.SetAttrFlags.Atime = 16 -> Cosmos.Kernel.HAL.Vfs.SetAttrFlags
+Cosmos.Kernel.HAL.Vfs.SetAttrFlags.Ctime = 64 -> Cosmos.Kernel.HAL.Vfs.SetAttrFlags
+Cosmos.Kernel.HAL.Vfs.SetAttrFlags.Gid = 4 -> Cosmos.Kernel.HAL.Vfs.SetAttrFlags
+Cosmos.Kernel.HAL.Vfs.SetAttrFlags.Mode = 1 -> Cosmos.Kernel.HAL.Vfs.SetAttrFlags
+Cosmos.Kernel.HAL.Vfs.SetAttrFlags.Mtime = 32 -> Cosmos.Kernel.HAL.Vfs.SetAttrFlags
+Cosmos.Kernel.HAL.Vfs.SetAttrFlags.None = 0 -> Cosmos.Kernel.HAL.Vfs.SetAttrFlags
+Cosmos.Kernel.HAL.Vfs.SetAttrFlags.Size = 8 -> Cosmos.Kernel.HAL.Vfs.SetAttrFlags
+Cosmos.Kernel.HAL.Vfs.SetAttrFlags.Uid = 2 -> Cosmos.Kernel.HAL.Vfs.SetAttrFlags
+Cosmos.Kernel.HAL.Vfs.VfsStat
+Cosmos.Kernel.HAL.Vfs.VfsStat.Atime -> Cosmos.Kernel.HAL.Vfs.VfsTimespec
+Cosmos.Kernel.HAL.Vfs.VfsStat.BlkSize -> long
+Cosmos.Kernel.HAL.Vfs.VfsStat.Blocks -> ulong
+Cosmos.Kernel.HAL.Vfs.VfsStat.Ctime -> Cosmos.Kernel.HAL.Vfs.VfsTimespec
+Cosmos.Kernel.HAL.Vfs.VfsStat.Gid -> uint
+Cosmos.Kernel.HAL.Vfs.VfsStat.Ino -> ulong
+Cosmos.Kernel.HAL.Vfs.VfsStat.Mode -> Cosmos.Kernel.HAL.Vfs.ModeEnum
+Cosmos.Kernel.HAL.Vfs.VfsStat.Mtime -> Cosmos.Kernel.HAL.Vfs.VfsTimespec
+Cosmos.Kernel.HAL.Vfs.VfsStat.NLink -> uint
+Cosmos.Kernel.HAL.Vfs.VfsStat.Rdev -> ulong
+Cosmos.Kernel.HAL.Vfs.VfsStat.Size -> ulong
+Cosmos.Kernel.HAL.Vfs.VfsStat.Uid -> uint
+Cosmos.Kernel.HAL.Vfs.VfsStat.VfsStat() -> void
+Cosmos.Kernel.HAL.Vfs.VfsStatFs
+Cosmos.Kernel.HAL.Vfs.VfsStatFs.Bavail -> ulong
+Cosmos.Kernel.HAL.Vfs.VfsStatFs.Bfree -> ulong
+Cosmos.Kernel.HAL.Vfs.VfsStatFs.Blocks -> ulong
+Cosmos.Kernel.HAL.Vfs.VfsStatFs.BlockSize -> ulong
+Cosmos.Kernel.HAL.Vfs.VfsStatFs.Ffree -> ulong
+Cosmos.Kernel.HAL.Vfs.VfsStatFs.Files -> ulong
+Cosmos.Kernel.HAL.Vfs.VfsStatFs.Frsize -> ulong
+Cosmos.Kernel.HAL.Vfs.VfsStatFs.NameMax -> ulong
+Cosmos.Kernel.HAL.Vfs.VfsStatFs.Type -> ulong
+Cosmos.Kernel.HAL.Vfs.VfsStatFs.VfsStatFs() -> void
+Cosmos.Kernel.HAL.Vfs.VfsTimespec
+Cosmos.Kernel.HAL.Vfs.VfsTimespec.TvNsec -> long
+Cosmos.Kernel.HAL.Vfs.VfsTimespec.TvSec -> long
+Cosmos.Kernel.HAL.Vfs.VfsTimespec.VfsTimespec() -> void
+Cosmos.Kernel.HAL.Vfs.VfsTimespec.VfsTimespec(long tvSec, long tvNsec) -> void

--- a/src/Cosmos.Kernel.HAL/Vfs/IFileOperations.cs
+++ b/src/Cosmos.Kernel.HAL/Vfs/IFileOperations.cs
@@ -13,9 +13,30 @@ public interface IFileOperations
     /// <summary>Bytes written.</summary>
     long Write(IVfsOpenFile openFile, ReadOnlySpan<byte> buffer);
 
+    /// <summary>
+    /// Compute and apply a new file position from <paramref name="offset"/>
+    /// relative to <paramref name="whence"/>. Positions beyond end-of-file
+    /// are valid; a later write zero-fills the gap.
+    /// </summary>
+    /// <param name="openFile">Open file whose position is moved.</param>
+    /// <param name="offset">Byte offset relative to <paramref name="whence"/>.</param>
+    /// <param name="whence">Origin the offset is applied to.</param>
+    /// <param name="newPosition">Resulting absolute position; 0 on failure.</param>
+    /// <returns>true on success; false when the resulting position would be negative.</returns>
     bool Seek(IVfsOpenFile openFile, long offset, SeekWhence whence, out long newPosition);
 
+    /// <summary>
+    /// Flush the file's data and metadata to the backing store so completed
+    /// writes are durable (POSIX <c>fsync</c>).
+    /// </summary>
+    /// <param name="openFile">Open file to synchronize.</param>
+    /// <returns>true on success.</returns>
     bool Fsync(IVfsOpenFile openFile);
 
+    /// <summary>
+    /// Release driver-side state when the open file is closed.
+    /// Implementations typically flush pending writes first.
+    /// </summary>
+    /// <param name="openFile">Open file being closed.</param>
     void Release(IVfsOpenFile openFile);
 }

--- a/src/Cosmos.Kernel.HAL/Vfs/IInodeOperations.cs
+++ b/src/Cosmos.Kernel.HAL/Vfs/IInodeOperations.cs
@@ -7,6 +7,13 @@ namespace Cosmos.Kernel.HAL.Vfs;
 /// </summary>
 public interface IInodeOperations
 {
+    /// <summary>
+    /// Resolve a child entry by name within a directory.
+    /// </summary>
+    /// <param name="dir">Directory to search.</param>
+    /// <param name="name">Child name, a single path component.</param>
+    /// <param name="child">Resolved child inode, or null when not found.</param>
+    /// <returns>true when the name exists in <paramref name="dir"/>.</returns>
     bool Lookup(IVfsInode dir, ReadOnlySpan<char> name, out IVfsInode? child);
 
     /// <summary>
@@ -17,27 +24,87 @@ public interface IInodeOperations
     /// </summary>
     bool ReadDir(IVfsInode dir, out IReadOnlyList<IVfsInode> entries);
 
+    /// <summary>
+    /// Create an empty regular file in a directory.
+    /// </summary>
+    /// <param name="dir">Parent directory.</param>
+    /// <param name="name">Name of the new file, a single path component.</param>
+    /// <param name="mode">Permission bits for the new inode.</param>
+    /// <param name="inode">Created inode on success; null on failure.</param>
+    /// <returns>true on success; false when the name already exists or allocation fails.</returns>
     bool Create(IVfsInode dir, ReadOnlySpan<char> name, ModeEnum mode, out IVfsInode? inode);
 
+    /// <summary>
+    /// Create an empty subdirectory in a directory.
+    /// </summary>
+    /// <param name="dir">Parent directory.</param>
+    /// <param name="name">Name of the new directory, a single path component.</param>
+    /// <param name="mode">Permission bits for the new inode.</param>
+    /// <param name="inode">Created inode on success; null on failure.</param>
+    /// <returns>true on success; false when the name already exists or allocation fails.</returns>
     bool Mkdir(IVfsInode dir, ReadOnlySpan<char> name, ModeEnum mode, out IVfsInode? inode);
 
+    /// <summary>
+    /// Create a symbolic link pointing at <paramref name="target"/>.
+    /// </summary>
+    /// <param name="dir">Parent directory.</param>
+    /// <param name="name">Name of the new link, a single path component.</param>
+    /// <param name="target">Path the link points to; stored verbatim, not resolved.</param>
+    /// <param name="inode">Created inode on success; null on failure.</param>
+    /// <returns>true on success; false when the filesystem does not support symbolic links.</returns>
     bool Symlink(
         IVfsInode dir,
         ReadOnlySpan<char> name,
         ReadOnlySpan<char> target,
         out IVfsInode? inode);
 
+    /// <summary>
+    /// Remove the directory entry for a non-directory child and free its storage.
+    /// </summary>
+    /// <param name="dir">Parent directory.</param>
+    /// <param name="name">Name of the entry to remove.</param>
+    /// <returns>true on success; false when the name does not exist or names a directory.</returns>
     bool Unlink(IVfsInode dir, ReadOnlySpan<char> name);
 
+    /// <summary>
+    /// Remove an empty child directory.
+    /// </summary>
+    /// <param name="dir">Parent directory.</param>
+    /// <param name="name">Name of the directory to remove.</param>
+    /// <returns>true on success; false when the name does not exist, is not a directory, or is not empty.</returns>
     bool Rmdir(IVfsInode dir, ReadOnlySpan<char> name);
 
+    /// <summary>
+    /// Move an entry to a new parent and/or name. Both directories belong
+    /// to the same filesystem instance.
+    /// </summary>
+    /// <param name="oldParent">Directory currently holding the entry.</param>
+    /// <param name="oldName">Current name of the entry.</param>
+    /// <param name="newParent">Destination directory; may equal <paramref name="oldParent"/>.</param>
+    /// <param name="newName">New name for the entry.</param>
+    /// <returns>true when the entry was moved.</returns>
     bool Rename(
         IVfsInode oldParent,
         ReadOnlySpan<char> oldName,
         IVfsInode newParent,
         ReadOnlySpan<char> newName);
 
+    /// <summary>
+    /// Read the inode's attributes (POSIX <c>stat</c>).
+    /// </summary>
+    /// <param name="inode">Inode to query.</param>
+    /// <param name="stat">Populated attributes on success.</param>
+    /// <returns>true on success.</returns>
     bool GetAttr(IVfsInode inode, out VfsStat stat);
 
+    /// <summary>
+    /// Update the inode attributes selected by <paramref name="flags"/>.
+    /// Selecting <see cref="SetAttrFlags.Size"/> truncates or zero-extends
+    /// the file; fields without a corresponding flag are ignored.
+    /// </summary>
+    /// <param name="inode">Inode to modify.</param>
+    /// <param name="flags">Which fields of <paramref name="attributes"/> to apply.</param>
+    /// <param name="attributes">Source values for the selected fields.</param>
+    /// <returns>true on success; false when a selected change is not supported.</returns>
     bool SetAttr(IVfsInode inode, SetAttrFlags flags, in VfsStat attributes);
 }

--- a/src/Cosmos.Kernel.HAL/Vfs/ISuperblockOperations.cs
+++ b/src/Cosmos.Kernel.HAL/Vfs/ISuperblockOperations.cs
@@ -7,8 +7,20 @@ namespace Cosmos.Kernel.HAL.Vfs;
 /// </summary>
 public interface ISuperblockOperations
 {
+    /// <summary>
+    /// Flush all dirty filesystem state to the backing store so completed
+    /// writes are durable (POSIX <c>sync</c>).
+    /// </summary>
+    /// <param name="superblock">Mount to synchronize.</param>
+    /// <returns>true on success.</returns>
     bool Sync(IVfsSuperblock superblock);
 
+    /// <summary>
+    /// Read filesystem-level statistics (POSIX <c>statfs</c>).
+    /// </summary>
+    /// <param name="superblock">Mount to query.</param>
+    /// <param name="statFs">Populated statistics on success.</param>
+    /// <returns>true on success.</returns>
     bool StatFs(IVfsSuperblock superblock, out VfsStatFs statFs);
 
     /// <summary>

--- a/src/Cosmos.Kernel.HAL/Vfs/IVfsFilesystemType.cs
+++ b/src/Cosmos.Kernel.HAL/Vfs/IVfsFilesystemType.cs
@@ -9,9 +9,14 @@ namespace Cosmos.Kernel.HAL.Vfs;
 /// </summary>
 public interface IVfsFilesystemType
 {
+    /// <summary>
+    /// Mount the filesystem found on <paramref name="source"/> and produce
+    /// its superblock.
+    /// </summary>
     /// <param name="source">Optional backing store identifier (device path, image id, etc.).</param>
     /// <param name="flags">Mount flags (<see cref="MountFlags"/>).</param>
     /// <param name="superblock">Populated superblock on success.</param>
+    /// <returns>true when a filesystem was recognized and mounted.</returns>
     bool TryMount(ReadOnlySpan<char> source, MountFlags flags, [NotNullWhen(true)] out IVfsSuperblock? superblock);
 
     /// <summary>

--- a/src/Cosmos.Kernel.HAL/Vfs/IVfsInode.cs
+++ b/src/Cosmos.Kernel.HAL/Vfs/IVfsInode.cs
@@ -7,6 +7,7 @@ namespace Cosmos.Kernel.HAL.Vfs;
 /// </summary>
 public interface IVfsInode
 {
+    /// <summary>Directory and metadata operations for this inode.</summary>
     IInodeOperations InodeOperations { get; }
 
     /// <summary>Non-null for regular files and other seekable/readable nodes; null for pure directory entries if the driver splits roles.</summary>

--- a/src/Cosmos.Kernel.HAL/Vfs/IVfsOpenFile.cs
+++ b/src/Cosmos.Kernel.HAL/Vfs/IVfsOpenFile.cs
@@ -7,9 +7,16 @@ namespace Cosmos.Kernel.HAL.Vfs;
 /// </summary>
 public interface IVfsOpenFile
 {
+    /// <summary>Inode this open file refers to.</summary>
     IVfsInode Inode { get; }
 
+    /// <summary>Byte I/O operations that service reads and writes on this open file.</summary>
     IFileOperations Operations { get; }
 
+    /// <summary>
+    /// Current byte offset for the next read or write. The VFS layer
+    /// advances it by the return value of <see cref="IFileOperations.Read"/>
+    /// and <see cref="IFileOperations.Write"/>; implementations of those do not.
+    /// </summary>
     long Position { get; set; }
 }

--- a/src/Cosmos.Kernel.HAL/Vfs/IVfsSuperblock.cs
+++ b/src/Cosmos.Kernel.HAL/Vfs/IVfsSuperblock.cs
@@ -7,8 +7,10 @@ namespace Cosmos.Kernel.HAL.Vfs;
 /// </summary>
 public interface IVfsSuperblock
 {
+    /// <summary>Root directory inode of this mount.</summary>
     IVfsInode Root { get; }
 
+    /// <summary>Superblock-level callbacks (sync, statfs, unmount).</summary>
     ISuperblockOperations SuperOperations { get; }
 
     /// <summary>Fundamental block size in bytes, or 0 if not applicable.</summary>

--- a/src/Cosmos.Kernel.HAL/Vfs/MountFlags.cs
+++ b/src/Cosmos.Kernel.HAL/Vfs/MountFlags.cs
@@ -8,6 +8,7 @@ namespace Cosmos.Kernel.HAL.Vfs;
 [Flags]
 public enum MountFlags : uint
 {
+    /// <summary>No mount options.</summary>
     None = 0,
     /// <summary>Read-only mount.</summary>
     ReadOnly = 1,

--- a/src/Cosmos.Kernel.HAL/Vfs/SeekWhence.cs
+++ b/src/Cosmos.Kernel.HAL/Vfs/SeekWhence.cs
@@ -7,7 +7,10 @@ namespace Cosmos.Kernel.HAL.Vfs;
 /// </summary>
 public enum SeekWhence
 {
+    /// <summary>Offset is relative to the start of the file (<c>SEEK_SET</c>).</summary>
     Set = 0,
+    /// <summary>Offset is relative to the current position (<c>SEEK_CUR</c>).</summary>
     Cur = 1,
+    /// <summary>Offset is relative to the end of the file (<c>SEEK_END</c>).</summary>
     End = 2,
 }

--- a/src/Cosmos.Kernel.HAL/Vfs/SetAttrFlags.cs
+++ b/src/Cosmos.Kernel.HAL/Vfs/SetAttrFlags.cs
@@ -8,12 +8,20 @@ namespace Cosmos.Kernel.HAL.Vfs;
 [Flags]
 public enum SetAttrFlags : uint
 {
+    /// <summary>No fields selected.</summary>
     None = 0,
+    /// <summary>Apply <see cref="VfsStat.Mode"/> (permission bits; the file type is not changed).</summary>
     Mode = 1 << 0,
+    /// <summary>Apply <see cref="VfsStat.Uid"/>.</summary>
     Uid = 1 << 1,
+    /// <summary>Apply <see cref="VfsStat.Gid"/>.</summary>
     Gid = 1 << 2,
+    /// <summary>Apply <see cref="VfsStat.Size"/>: truncate or zero-extend the file.</summary>
     Size = 1 << 3,
+    /// <summary>Apply <see cref="VfsStat.Atime"/>.</summary>
     Atime = 1 << 4,
+    /// <summary>Apply <see cref="VfsStat.Mtime"/>.</summary>
     Mtime = 1 << 5,
+    /// <summary>Apply <see cref="VfsStat.Ctime"/>.</summary>
     Ctime = 1 << 6,
 }

--- a/src/Cosmos.Kernel.HAL/Vfs/VfsStat.cs
+++ b/src/Cosmos.Kernel.HAL/Vfs/VfsStat.cs
@@ -7,16 +7,28 @@ namespace Cosmos.Kernel.HAL.Vfs;
 /// </summary>
 public struct VfsStat
 {
+    /// <summary>Inode number, unique within the filesystem instance (<c>st_ino</c>).</summary>
     public ulong Ino;
+    /// <summary>File type and permission bits (<c>st_mode</c>).</summary>
     public ModeEnum Mode;
+    /// <summary>Number of hard links to the inode (<c>st_nlink</c>).</summary>
     public uint NLink;
+    /// <summary>Owner user id (<c>st_uid</c>).</summary>
     public uint Uid;
+    /// <summary>Owner group id (<c>st_gid</c>).</summary>
     public uint Gid;
+    /// <summary>Device id for character and block device nodes; 0 otherwise (<c>st_rdev</c>).</summary>
     public ulong Rdev;
+    /// <summary>File size in bytes (<c>st_size</c>).</summary>
     public ulong Size;
+    /// <summary>Preferred I/O block size in bytes (<c>st_blksize</c>).</summary>
     public long BlkSize;
+    /// <summary>Number of storage blocks allocated to the inode (<c>st_blocks</c>).</summary>
     public ulong Blocks;
+    /// <summary>Last access time (<c>st_atim</c>).</summary>
     public VfsTimespec Atime;
+    /// <summary>Last data modification time (<c>st_mtim</c>).</summary>
     public VfsTimespec Mtime;
+    /// <summary>Last status change time (<c>st_ctim</c>).</summary>
     public VfsTimespec Ctime;
 }

--- a/src/Cosmos.Kernel.HAL/Vfs/VfsStatFs.cs
+++ b/src/Cosmos.Kernel.HAL/Vfs/VfsStatFs.cs
@@ -7,13 +7,22 @@ namespace Cosmos.Kernel.HAL.Vfs;
 /// </summary>
 public struct VfsStatFs
 {
+    /// <summary>Filesystem type magic number (<c>f_type</c>).</summary>
     public ulong Type;
+    /// <summary>Block size in bytes; the unit for <see cref="Blocks"/>, <see cref="Bfree"/> and <see cref="Bavail"/> (<c>f_bsize</c>).</summary>
     public ulong BlockSize;
+    /// <summary>Total data blocks in the filesystem (<c>f_blocks</c>).</summary>
     public ulong Blocks;
+    /// <summary>Free blocks (<c>f_bfree</c>).</summary>
     public ulong Bfree;
+    /// <summary>Free blocks available to unprivileged callers (<c>f_bavail</c>).</summary>
     public ulong Bavail;
+    /// <summary>Total inodes, or 0 when the filesystem does not track an inode count (<c>f_files</c>).</summary>
     public ulong Files;
+    /// <summary>Free inodes, or 0 when the filesystem does not track an inode count (<c>f_ffree</c>).</summary>
     public ulong Ffree;
+    /// <summary>Maximum file name length in bytes (<c>f_namelen</c>).</summary>
     public ulong NameMax;
+    /// <summary>Fragment size in bytes (<c>f_frsize</c>).</summary>
     public ulong Frsize;
 }

--- a/src/Cosmos.Kernel.HAL/Vfs/VfsTimespec.cs
+++ b/src/Cosmos.Kernel.HAL/Vfs/VfsTimespec.cs
@@ -7,9 +7,16 @@ namespace Cosmos.Kernel.HAL.Vfs;
 /// </summary>
 public struct VfsTimespec
 {
+    /// <summary>Whole seconds since the Unix epoch (<c>tv_sec</c>).</summary>
     public long TvSec;
+    /// <summary>Nanoseconds within the second, in [0, 999999999] (<c>tv_nsec</c>).</summary>
     public long TvNsec;
 
+    /// <summary>
+    /// Creates a timespec from seconds and nanoseconds.
+    /// </summary>
+    /// <param name="tvSec">Whole seconds since the Unix epoch.</param>
+    /// <param name="tvNsec">Nanoseconds within the second.</param>
     public VfsTimespec(long tvSec, long tvNsec)
     {
         TvSec = tvSec;

--- a/src/Cosmos.Kernel.Plugs/Cosmos.Kernel.Plugs.csproj
+++ b/src/Cosmos.Kernel.Plugs/Cosmos.Kernel.Plugs.csproj
@@ -11,6 +11,8 @@
     <RepositoryUrl>https://github.com/valentinbreiz/nativeaot-patcher</RepositoryUrl>
     <PackageProjectUrl>https://github.com/valentinbreiz/nativeaot-patcher</PackageProjectUrl>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+    <!-- The socket plugs drive the TCP machinery through the experimental packet seam (COSMOS0002). -->
+    <NoWarn>$(NoWarn);COSMOS0002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cosmos.Kernel.Plugs/System/Net/Sockets/SocketPlug.cs
+++ b/src/Cosmos.Kernel.Plugs/System/Net/Sockets/SocketPlug.cs
@@ -343,7 +343,7 @@ public static class SocketPlug
         // Set status BEFORE sending packet to avoid race condition
         // (SendEmptyPacket calls NetworkStack.Update which can process incoming packets)
         sm.Status = Status.SYN_SENT;
-        sm.SendEmptyPacket(Flags.SYN);
+        sm.SendEmptyPacket(TcpFlags.SYN);
 
         if (sm.WaitStatus(Status.ESTABLISHED, 5000) == false)
         {
@@ -447,7 +447,7 @@ public static class SocketPlug
 
             for (int i = 0; i < chunks.Length; i++)
             {
-                var packet = new TcpPacket(sm.LocalEndPoint.Address, sm.RemoteEndPoint.Address, sm.LocalEndPoint.Port, sm.RemoteEndPoint.Port, sm.TCB.SndNxt, sm.TCB.RcvNxt, 20, i == chunks.Length - 1 ? (byte)(Flags.PSH | Flags.ACK) : (byte)Flags.ACK, sm.TCB.SndWnd, 0, chunks[i]);
+                var packet = new TcpPacket(sm.LocalEndPoint.Address, sm.RemoteEndPoint.Address, sm.LocalEndPoint.Port, sm.RemoteEndPoint.Port, sm.TCB.SndNxt, sm.TCB.RcvNxt, 20, i == chunks.Length - 1 ? (byte)(TcpFlags.PSH | TcpFlags.ACK) : (byte)TcpFlags.ACK, sm.TCB.SndWnd, 0, chunks[i]);
                 OutgoingBuffer.AddPacket(packet);
 
                 // Increment SndNxt BEFORE NetworkStack.Update() so incoming packets see the correct value
@@ -467,7 +467,7 @@ public static class SocketPlug
             byte[] data = new byte[size];
             Buffer.BlockCopy(buffer, offset, data, 0, size);
 
-            var packet = new TcpPacket(sm.LocalEndPoint.Address, sm.RemoteEndPoint.Address, sm.LocalEndPoint.Port, sm.RemoteEndPoint.Port, sm.TCB.SndNxt, sm.TCB.RcvNxt, 20, (byte)(Flags.PSH | Flags.ACK), sm.TCB.SndWnd, 0, data);
+            var packet = new TcpPacket(sm.LocalEndPoint.Address, sm.RemoteEndPoint.Address, sm.LocalEndPoint.Port, sm.RemoteEndPoint.Port, sm.TCB.SndNxt, sm.TCB.RcvNxt, 20, (byte)(TcpFlags.PSH | TcpFlags.ACK), sm.TCB.SndWnd, 0, data);
             Serial.WriteString("[SocketPlug] SendTcp: adding to outgoing buffer\n");
             OutgoingBuffer.AddPacket(packet);
 
@@ -829,7 +829,7 @@ public static class SocketPlug
             // passive close all the way to CLOSED, and an assignment after the
             // send would overwrite CLOSED with FIN_WAIT1 and hang the close.
             sm.Status = Status.FIN_WAIT1;
-            sm.SendEmptyPacket(Flags.FIN | Flags.ACK);
+            sm.SendEmptyPacket(TcpFlags.FIN | TcpFlags.ACK);
 
             // Wait for the peer to ACK our FIN. Once it is ACKed the close has
             // succeeded from the caller's point of view — the peer may hold

--- a/src/Cosmos.Kernel.System/Cosmos.Kernel.System.csproj
+++ b/src/Cosmos.Kernel.System/Cosmos.Kernel.System.csproj
@@ -7,6 +7,9 @@
     <!-- Public surface tracked in PublicAPI.Shipped/Unshipped.txt (see Directory.Build.props) -->
     <CosmosTrackPublicApi>true</CosmosTrackPublicApi>
 
+    <!-- SchedulerInfo fronts the experimental scheduler seam (COSMOS0001). -->
+    <NoWarn>$(NoWarn);COSMOS0001</NoWarn>
+
     <!-- Package Metadata -->
     <PackageId>Cosmos.Kernel.System</PackageId>
     <Title>Cosmos Kernel System</Title>

--- a/src/Cosmos.Kernel.System/Cosmos.Kernel.System.csproj
+++ b/src/Cosmos.Kernel.System/Cosmos.Kernel.System.csproj
@@ -8,7 +8,8 @@
     <CosmosTrackPublicApi>true</CosmosTrackPublicApi>
 
     <!-- SchedulerInfo fronts the experimental scheduler seam (COSMOS0001). -->
-    <NoWarn>$(NoWarn);COSMOS0001</NoWarn>
+    <!-- COSMOS0002: this assembly declares the experimental packet seam and consumes it itself. -->
+    <NoWarn>$(NoWarn);COSMOS0001;COSMOS0002</NoWarn>
 
     <!-- Package Metadata -->
     <PackageId>Cosmos.Kernel.System</PackageId>

--- a/src/Cosmos.Kernel.System/Diagnostics/KernelThreadInfo.cs
+++ b/src/Cosmos.Kernel.System/Diagnostics/KernelThreadInfo.cs
@@ -1,0 +1,70 @@
+namespace Cosmos.Kernel.System.Diagnostics;
+
+/// <summary>
+/// Point-in-time snapshot of one kernel thread, produced by
+/// <see cref="SchedulerInfo"/>. The snapshot is taken without locking the
+/// scheduler, so fields of a thread that is being rescheduled concurrently
+/// may be one tick stale.
+/// </summary>
+public readonly struct KernelThreadInfo
+{
+    internal KernelThreadInfo(
+        uint id,
+        uint cpuId,
+        KernelThreadState state,
+        bool isIdle,
+        bool isManaged,
+        ulong totalRuntimeNs,
+        ulong stackSizeBytes,
+        long priority,
+        bool hasPriority)
+    {
+        Id = id;
+        CpuId = cpuId;
+        State = state;
+        IsIdle = isIdle;
+        IsManaged = isManaged;
+        TotalRuntimeNs = totalRuntimeNs;
+        StackSizeBytes = stackSizeBytes;
+        Priority = priority;
+        HasPriority = hasPriority;
+    }
+
+    /// <summary>Unique thread identifier. The idle thread has ID 0.</summary>
+    public uint Id { get; }
+
+    /// <summary>CPU the thread is assigned to.</summary>
+    public uint CpuId { get; }
+
+    /// <summary>Lifecycle state at the time of the snapshot.</summary>
+    public KernelThreadState State { get; }
+
+    /// <summary>Whether this is a per-CPU idle thread.</summary>
+    public bool IsIdle { get; }
+
+    /// <summary>
+    /// Whether the thread was started from a managed
+    /// <see cref="global::System.Threading.Thread"/>.
+    /// </summary>
+    public bool IsManaged { get; }
+
+    /// <summary>Accumulated CPU time in nanoseconds.</summary>
+    public ulong TotalRuntimeNs { get; }
+
+    /// <summary>Size of the thread's stack in bytes.</summary>
+    public ulong StackSizeBytes { get; }
+
+    /// <summary>
+    /// Scheduling priority as reported by the active scheduler. Only
+    /// meaningful when <see cref="HasPriority"/> is set; the
+    /// interpretation is scheduler-specific (the default stride scheduler
+    /// reports tickets, where higher means more CPU time).
+    /// </summary>
+    public long Priority { get; }
+
+    /// <summary>
+    /// Whether the active scheduler is tracking this thread and reported a
+    /// priority for it.
+    /// </summary>
+    public bool HasPriority { get; }
+}

--- a/src/Cosmos.Kernel.System/Diagnostics/KernelThreadState.cs
+++ b/src/Cosmos.Kernel.System/Diagnostics/KernelThreadState.cs
@@ -1,0 +1,26 @@
+namespace Cosmos.Kernel.System.Diagnostics;
+
+/// <summary>
+/// Lifecycle state of a kernel thread as reported by
+/// <see cref="SchedulerInfo"/>.
+/// </summary>
+public enum KernelThreadState : byte
+{
+    /// <summary>Created but never scheduled.</summary>
+    Created,
+
+    /// <summary>In a run queue, waiting for CPU time.</summary>
+    Ready,
+
+    /// <summary>Currently executing on a CPU.</summary>
+    Running,
+
+    /// <summary>Waiting on I/O or a synchronization primitive.</summary>
+    Blocked,
+
+    /// <summary>In a timed wait.</summary>
+    Sleeping,
+
+    /// <summary>Terminated, awaiting cleanup.</summary>
+    Dead,
+}

--- a/src/Cosmos.Kernel.System/Diagnostics/Log.cs
+++ b/src/Cosmos.Kernel.System/Diagnostics/Log.cs
@@ -1,0 +1,92 @@
+using Cosmos.Kernel.Core.IO;
+
+namespace Cosmos.Kernel.System.Diagnostics;
+
+/// <summary>
+/// Kernel debug log, written to the platform serial port (COM1 on x64,
+/// PL011 on ARM64). This is the supported way for kernels to emit debug
+/// output that a host can capture; on QEMU the stream appears on the
+/// <c>-serial</c> device. Writes are synchronous, allocation-free for
+/// strings and numbers, and usable from the earliest phase of
+/// <c>BeforeRun</c> onward.
+/// </summary>
+public static class Log
+{
+    /// <summary>
+    /// Writes a string to the log without appending a line terminator.
+    /// </summary>
+    /// <param name="text">Text to write.</param>
+    public static void WriteString(string text) => Serial.WriteString(text);
+
+    /// <summary>
+    /// Writes an unsigned 64-bit number in decimal, or hexadecimal without
+    /// a <c>0x</c> prefix when <paramref name="hex"/> is set.
+    /// </summary>
+    /// <param name="number">Value to write.</param>
+    /// <param name="hex">Write base-16 digits instead of base-10.</param>
+    public static void WriteNumber(ulong number, bool hex = false) => Serial.WriteNumber(number, hex);
+
+    /// <summary>
+    /// Writes an unsigned 32-bit number in decimal, or hexadecimal without
+    /// a <c>0x</c> prefix when <paramref name="hex"/> is set.
+    /// </summary>
+    /// <param name="number">Value to write.</param>
+    /// <param name="hex">Write base-16 digits instead of base-10.</param>
+    public static void WriteNumber(uint number, bool hex = false) => Serial.WriteNumber(number, hex);
+
+    /// <summary>
+    /// Writes a signed 32-bit number in decimal, or hexadecimal without a
+    /// <c>0x</c> prefix when <paramref name="hex"/> is set. Negative values
+    /// are prefixed with <c>-</c>.
+    /// </summary>
+    /// <param name="number">Value to write.</param>
+    /// <param name="hex">Write base-16 digits instead of base-10.</param>
+    public static void WriteNumber(int number, bool hex = false) => Serial.WriteNumber(number, hex);
+
+    /// <summary>
+    /// Writes a signed 64-bit number in decimal, or hexadecimal without a
+    /// <c>0x</c> prefix when <paramref name="hex"/> is set. Negative values
+    /// are prefixed with <c>-</c>.
+    /// </summary>
+    /// <param name="number">Value to write.</param>
+    /// <param name="hex">Write base-16 digits instead of base-10.</param>
+    public static void WriteNumber(long number, bool hex = false) => Serial.WriteNumber(number, hex);
+
+    /// <summary>
+    /// Writes an unsigned 64-bit number as hexadecimal digits without a
+    /// <c>0x</c> prefix.
+    /// </summary>
+    /// <param name="number">Value to write.</param>
+    public static void WriteHex(ulong number) => Serial.WriteHex(number);
+
+    /// <summary>
+    /// Writes an unsigned 32-bit number as hexadecimal digits without a
+    /// <c>0x</c> prefix.
+    /// </summary>
+    /// <param name="number">Value to write.</param>
+    public static void WriteHex(uint number) => Serial.WriteHex(number);
+
+    /// <summary>
+    /// Writes an unsigned 64-bit number as hexadecimal digits with a
+    /// <c>0x</c> prefix.
+    /// </summary>
+    /// <param name="number">Value to write.</param>
+    public static void WriteHexWithPrefix(ulong number) => Serial.WriteHexWithPrefix(number);
+
+    /// <summary>
+    /// Writes an unsigned 32-bit number as hexadecimal digits with a
+    /// <c>0x</c> prefix.
+    /// </summary>
+    /// <param name="number">Value to write.</param>
+    public static void WriteHexWithPrefix(uint number) => Serial.WriteHexWithPrefix(number);
+
+    /// <summary>
+    /// Writes each value in order: strings and characters as text, integers
+    /// in decimal, bytes and byte arrays in hexadecimal, booleans as
+    /// <c>true</c>/<c>false</c>, <see langword="null"/> as <c>null</c>, and
+    /// anything else via <see cref="object.ToString"/>. Boxing the arguments
+    /// allocates; prefer the typed overloads on allocation-sensitive paths.
+    /// </summary>
+    /// <param name="args">Values to write.</param>
+    public static void Write(params object?[] args) => Serial.Write(args);
+}

--- a/src/Cosmos.Kernel.System/Diagnostics/Log.cs
+++ b/src/Cosmos.Kernel.System/Diagnostics/Log.cs
@@ -1,3 +1,4 @@
+using Cosmos.Kernel.Core.CPU;
 using Cosmos.Kernel.Core.IO;
 
 namespace Cosmos.Kernel.System.Diagnostics;
@@ -89,4 +90,23 @@ public static class Log
     /// </summary>
     /// <param name="args">Values to write.</param>
     public static void Write(params object?[] args) => Serial.Write(args);
+
+    /// <summary>
+    /// Writes raw bytes to the log stream as one uninterrupted sequence.
+    /// Interrupts are masked for the duration of the write, so traces
+    /// logged from IRQ handlers cannot interleave into the middle of the
+    /// data. Use this for binary wire formats that share the serial port
+    /// with text output, such as the kernel test protocol.
+    /// </summary>
+    /// <param name="bytes">Bytes to write.</param>
+    public static void WriteBytes(ReadOnlySpan<byte> bytes)
+    {
+        using (InternalCpu.DisableInterruptsScope())
+        {
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                Serial.ComWrite(bytes[i]);
+            }
+        }
+    }
 }

--- a/src/Cosmos.Kernel.System/Diagnostics/MemoryInfo.cs
+++ b/src/Cosmos.Kernel.System/Diagnostics/MemoryInfo.cs
@@ -1,0 +1,57 @@
+using Cosmos.Kernel.Core.Memory;
+using Cosmos.Kernel.Core.Memory.GarbageCollector;
+using KernelHeap = Cosmos.Kernel.Core.Memory.Heap.Heap;
+
+namespace Cosmos.Kernel.System.Diagnostics;
+
+/// <summary>
+/// Read-only view of the kernel's physical-memory and garbage-collector
+/// statistics, plus a forced collection. All reads are plain field reads
+/// with no allocation, so they are safe to poll from a monitor loop at
+/// display refresh rate. Managed-heap figures beyond these counters come
+/// from the BCL (<see cref="global::System.GC.GetGCMemoryInfo()"/>).
+/// </summary>
+public static class MemoryInfo
+{
+    /// <summary>
+    /// Size of a physical page in bytes.
+    /// </summary>
+    public static ulong PageSizeBytes => PageAllocator.PageSize;
+
+    /// <summary>
+    /// Total number of physical pages managed by the page allocator.
+    /// </summary>
+    public static ulong TotalPages => PageAllocator.TotalPageCount;
+
+    /// <summary>
+    /// Number of physical pages currently free.
+    /// </summary>
+    public static ulong FreePages => PageAllocator.FreePageCount;
+
+    /// <summary>
+    /// Total usable RAM in bytes, as reported by the bootloader memory map.
+    /// </summary>
+    public static ulong RamSizeBytes => PageAllocator.RamSize;
+
+    /// <summary>
+    /// Percentage of time spent in the garbage collector during the most
+    /// recent collection window, from 0 to 100.
+    /// </summary>
+    public static int GcTimePercent => GarbageCollector.GetLastGCPercentTimeInGC();
+
+    /// <summary>
+    /// Returns the kernel garbage collector's lifetime counters.
+    /// </summary>
+    /// <param name="totalCollections">Number of collections since boot.</param>
+    /// <param name="totalObjectsFreed">Number of objects freed since boot.</param>
+    public static void GetGcStats(out int totalCollections, out int totalObjectsFreed) =>
+        GarbageCollector.GetStats(out totalCollections, out totalObjectsFreed);
+
+    /// <summary>
+    /// Forces an immediate garbage collection and returns the number of
+    /// objects freed. Unlike <see cref="global::System.GC.Collect()"/>,
+    /// the count of freed objects is reported back to the caller.
+    /// </summary>
+    /// <returns>Number of objects freed by the collection.</returns>
+    public static int Collect() => KernelHeap.Collect();
+}

--- a/src/Cosmos.Kernel.System/Diagnostics/SchedulerInfo.cs
+++ b/src/Cosmos.Kernel.System/Diagnostics/SchedulerInfo.cs
@@ -1,0 +1,230 @@
+using Cosmos.Kernel.Core;
+using Cosmos.Kernel.Core.Scheduler;
+using SchedThread = Cosmos.Kernel.Core.Scheduler.Thread;
+
+namespace Cosmos.Kernel.System.Diagnostics;
+
+/// <summary>
+/// Read-only view of the kernel scheduler: feature and lifecycle state,
+/// per-CPU thread tables, and the global thread registry, plus a request
+/// to terminate a thread by ID. All reads are allocation-free and safe to
+/// poll from a monitor loop; snapshots of threads that are being
+/// rescheduled concurrently may be one tick stale.
+/// </summary>
+public static class SchedulerInfo
+{
+    /// <summary>
+    /// Nanoseconds per millisecond, for converting the nanosecond figures
+    /// reported here into milliseconds.
+    /// </summary>
+    public const ulong NanosecondsPerMillisecond = 1_000_000;
+
+    /// <summary>
+    /// Whether scheduler support is compiled into this kernel
+    /// (the <c>CosmosEnableScheduler</c> feature switch).
+    /// </summary>
+    public static bool IsSupported => CosmosFeatures.SchedulerEnabled;
+
+    /// <summary>
+    /// Whether a scheduler has been installed and per-CPU state exists.
+    /// </summary>
+    public static bool IsInitialized => SchedulerManager.Current != null;
+
+    /// <summary>
+    /// Whether the scheduler is processing timer ticks and preempting
+    /// threads.
+    /// </summary>
+    public static bool IsRunning => SchedulerManager.Enabled;
+
+    /// <summary>
+    /// Name of the installed scheduler, or <see langword="null"/> before
+    /// initialization.
+    /// </summary>
+    public static string? SchedulerName => SchedulerManager.Current?.Name;
+
+    /// <summary>
+    /// Number of CPUs the scheduler manages.
+    /// </summary>
+    public static uint CpuCount => SchedulerManager.CpuCount;
+
+    /// <summary>
+    /// Length of the time slice handed to each thread, in nanoseconds.
+    /// </summary>
+    public static ulong QuantumNs => SchedulerManager.DefaultQuantumNs;
+
+    /// <summary>
+    /// Total busy CPU time in nanoseconds, summed over all CPUs and all
+    /// non-idle threads since boot. Monotonic across thread exits; sample
+    /// it over a wall-clock window to derive CPU utilization.
+    /// </summary>
+    public static ulong BusyCpuTimeNs => SchedulerManager.GetBusyCpuTimeNs();
+
+    /// <summary>
+    /// Number of live threads in the registry.
+    /// </summary>
+    public static int ThreadCount => SchedulerManager.ThreadCount;
+
+    /// <summary>
+    /// Number of slots in the thread registry. Slots can be empty; iterate
+    /// from 0 to this value and probe each with <see cref="TryGetThread"/>.
+    /// </summary>
+    public static int ThreadSlotCount => SchedulerManager.Threads?.Length ?? 0;
+
+    /// <summary>
+    /// Snapshots the thread in the given registry slot.
+    /// </summary>
+    /// <param name="slot">Registry slot index, from 0 to <see cref="ThreadSlotCount"/> exclusive.</param>
+    /// <param name="info">Snapshot of the thread occupying the slot.</param>
+    /// <returns><see langword="false"/> when the slot is out of range or empty.</returns>
+    public static bool TryGetThread(int slot, out KernelThreadInfo info)
+    {
+        SchedThread?[]? threads = SchedulerManager.Threads;
+        if (threads == null || slot < 0 || slot >= threads.Length || threads[slot] is not SchedThread thread)
+        {
+            info = default;
+            return false;
+        }
+
+        info = Snapshot(thread);
+        return true;
+    }
+
+    /// <summary>
+    /// Snapshots the thread currently running on a CPU.
+    /// </summary>
+    /// <param name="cpuId">CPU to inspect.</param>
+    /// <param name="info">Snapshot of the running thread.</param>
+    /// <returns><see langword="false"/> when the CPU ID is out of range or no thread is current.</returns>
+    public static bool TryGetCurrentThread(uint cpuId, out KernelThreadInfo info)
+    {
+        SchedThread? thread = cpuId < SchedulerManager.CpuCount
+            ? SchedulerManager.GetCpuState(cpuId)?.CurrentThread
+            : null;
+        if (thread == null)
+        {
+            info = default;
+            return false;
+        }
+
+        info = Snapshot(thread);
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the number of threads waiting in a CPU's run queue.
+    /// </summary>
+    /// <param name="cpuId">CPU to inspect.</param>
+    /// <returns>Queue length, or 0 when the CPU ID is out of range or the scheduler is not initialized.</returns>
+    public static int GetRunQueueCount(uint cpuId)
+    {
+        IScheduler? scheduler = SchedulerManager.Current;
+        PerCpuState? state = cpuId < SchedulerManager.CpuCount ? SchedulerManager.GetCpuState(cpuId) : null;
+        return scheduler != null && state != null ? scheduler.GetRunQueueCount(state) : 0;
+    }
+
+    /// <summary>
+    /// Snapshots a thread in a CPU's run queue by position.
+    /// </summary>
+    /// <param name="cpuId">CPU to inspect.</param>
+    /// <param name="index">Queue position, from 0 to <see cref="GetRunQueueCount"/> exclusive.</param>
+    /// <param name="info">Snapshot of the queued thread.</param>
+    /// <returns><see langword="false"/> when the CPU ID or index is out of range.</returns>
+    public static bool TryGetRunQueueThread(uint cpuId, int index, out KernelThreadInfo info)
+    {
+        IScheduler? scheduler = SchedulerManager.Current;
+        PerCpuState? state = cpuId < SchedulerManager.CpuCount ? SchedulerManager.GetCpuState(cpuId) : null;
+        SchedThread? thread = scheduler != null && state != null ? scheduler.GetRunQueueThread(state, index) : null;
+        if (thread == null)
+        {
+            info = default;
+            return false;
+        }
+
+        info = Snapshot(thread);
+        return true;
+    }
+
+    /// <summary>
+    /// Requests termination of a thread by ID. A thread waiting in a run
+    /// queue is terminated immediately; a currently running thread is
+    /// marked dead and reaped by the scheduler on its next reschedule.
+    /// Idle threads are refused.
+    /// </summary>
+    /// <param name="threadId">ID of the thread to terminate.</param>
+    /// <returns>What happened to the thread; see <see cref="ThreadKillResult"/>.</returns>
+    public static ThreadKillResult RequestKill(uint threadId)
+    {
+        IScheduler? scheduler = SchedulerManager.Current;
+        if (scheduler == null)
+        {
+            return ThreadKillResult.NotFound;
+        }
+
+        for (uint cpuId = 0; cpuId < SchedulerManager.CpuCount; cpuId++)
+        {
+            PerCpuState? state = SchedulerManager.GetCpuState(cpuId);
+            if (state == null)
+            {
+                continue;
+            }
+
+            SchedThread? current = state.CurrentThread;
+            if (current?.Id == threadId)
+            {
+                if ((current.Flags & ThreadFlags.IdleThread) != 0)
+                {
+                    return ThreadKillResult.RefusedIdle;
+                }
+
+                current.State = ThreadState.Dead;
+                return ThreadKillResult.MarkedForExit;
+            }
+
+            int count = scheduler.GetRunQueueCount(state);
+            for (int i = 0; i < count; i++)
+            {
+                SchedThread? thread = scheduler.GetRunQueueThread(state, i);
+                if (thread?.Id != threadId)
+                {
+                    continue;
+                }
+
+                if ((thread.Flags & ThreadFlags.IdleThread) != 0)
+                {
+                    return ThreadKillResult.RefusedIdle;
+                }
+
+                SchedulerManager.ExitThread(cpuId, thread);
+                return ThreadKillResult.Killed;
+            }
+        }
+
+        return ThreadKillResult.NotFound;
+    }
+
+    private static KernelThreadInfo Snapshot(SchedThread thread)
+    {
+        bool hasPriority = thread.SchedulerData != null;
+        long priority = hasPriority ? SchedulerManager.Current?.GetPriority(thread) ?? 0 : 0;
+        return new KernelThreadInfo(
+            thread.Id,
+            thread.CpuId,
+            MapState(thread.State),
+            (thread.Flags & ThreadFlags.IdleThread) != 0,
+            (thread.Flags & ThreadFlags.Managed) != 0,
+            thread.TotalRuntime,
+            thread.StackSize,
+            priority,
+            hasPriority);
+    }
+
+    private static KernelThreadState MapState(ThreadState state) => state switch
+    {
+        ThreadState.Created => KernelThreadState.Created,
+        ThreadState.Ready => KernelThreadState.Ready,
+        ThreadState.Running => KernelThreadState.Running,
+        ThreadState.Blocked => KernelThreadState.Blocked,
+        ThreadState.Sleeping => KernelThreadState.Sleeping,
+        _ => KernelThreadState.Dead,
+    };
+}

--- a/src/Cosmos.Kernel.System/Diagnostics/SchedulerInfo.cs
+++ b/src/Cosmos.Kernel.System/Diagnostics/SchedulerInfo.cs
@@ -1,6 +1,7 @@
 using Cosmos.Kernel.Core;
 using Cosmos.Kernel.Core.Scheduler;
 using SchedThread = Cosmos.Kernel.Core.Scheduler.Thread;
+using SchedThreadState = Cosmos.Kernel.Core.Scheduler.ThreadState;
 
 namespace Cosmos.Kernel.System.Diagnostics;
 
@@ -176,7 +177,7 @@ public static class SchedulerInfo
                     return ThreadKillResult.RefusedIdle;
                 }
 
-                current.State = ThreadState.Dead;
+                current.State = SchedThreadState.Dead;
                 return ThreadKillResult.MarkedForExit;
             }
 
@@ -218,13 +219,13 @@ public static class SchedulerInfo
             hasPriority);
     }
 
-    private static KernelThreadState MapState(ThreadState state) => state switch
+    private static KernelThreadState MapState(SchedThreadState state) => state switch
     {
-        ThreadState.Created => KernelThreadState.Created,
-        ThreadState.Ready => KernelThreadState.Ready,
-        ThreadState.Running => KernelThreadState.Running,
-        ThreadState.Blocked => KernelThreadState.Blocked,
-        ThreadState.Sleeping => KernelThreadState.Sleeping,
+        SchedThreadState.Created => KernelThreadState.Created,
+        SchedThreadState.Ready => KernelThreadState.Ready,
+        SchedThreadState.Running => KernelThreadState.Running,
+        SchedThreadState.Blocked => KernelThreadState.Blocked,
+        SchedThreadState.Sleeping => KernelThreadState.Sleeping,
         _ => KernelThreadState.Dead,
     };
 }

--- a/src/Cosmos.Kernel.System/Diagnostics/ThreadKillResult.cs
+++ b/src/Cosmos.Kernel.System/Diagnostics/ThreadKillResult.cs
@@ -1,0 +1,22 @@
+namespace Cosmos.Kernel.System.Diagnostics;
+
+/// <summary>
+/// Outcome of <see cref="SchedulerInfo.RequestKill"/>.
+/// </summary>
+public enum ThreadKillResult : byte
+{
+    /// <summary>No live thread has the requested ID.</summary>
+    NotFound,
+
+    /// <summary>The thread was removed from its run queue and terminated.</summary>
+    Killed,
+
+    /// <summary>
+    /// The thread is currently running; it was marked dead and will be
+    /// reaped by the scheduler on its next reschedule.
+    /// </summary>
+    MarkedForExit,
+
+    /// <summary>The request named an idle thread, which cannot be killed.</summary>
+    RefusedIdle,
+}

--- a/src/Cosmos.Kernel.System/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
+++ b/src/Cosmos.Kernel.System/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
@@ -16,7 +16,7 @@ namespace Internal.Runtime.CompilerHelpers
     /// <summary>
     /// This class is responsible for initializing the library and its dependencies. It is called by the runtime before any managed code is executed.
     /// </summary>
-    public class LibraryInitializer
+    internal class LibraryInitializer
     {
         /// <summary>
         /// Initialize all enabled services provided by Cosmos.Kernel.System, such as TimerManager, KeyboardManager, and NetworkManager. This method is called by the runtime before any managed code is executed.

--- a/src/Cosmos.Kernel.System/KernelFeatures.cs
+++ b/src/Cosmos.Kernel.System/KernelFeatures.cs
@@ -1,0 +1,73 @@
+using Cosmos.Kernel.Core;
+
+namespace Cosmos.Kernel.System;
+
+/// <summary>
+/// Read-only view of the kernel feature switches, one per
+/// <c>CosmosEnable*</c> MSBuild property. Each flag reports whether the
+/// corresponding subsystem is compiled into this kernel; ILC folds the
+/// flags to constants, so guarded code is trimmed when a feature is off.
+/// </summary>
+public static class KernelFeatures
+{
+    /// <summary>
+    /// Whether interrupt support (IDT/IRQ) is enabled
+    /// (<c>CosmosEnableInterrupts</c>). Disabling it also disables Timer,
+    /// Keyboard, Mouse, Network, Scheduler, and Graphics.
+    /// </summary>
+    public static bool Interrupts => CosmosFeatures.InterruptsEnabled;
+
+    /// <summary>
+    /// Whether UART serial support is enabled (<c>CosmosEnableUART</c>).
+    /// </summary>
+    public static bool Uart => CosmosFeatures.UARTEnabled;
+
+    /// <summary>
+    /// Whether PCI support is enabled (<c>CosmosEnablePCI</c>).
+    /// </summary>
+    public static bool Pci => CosmosFeatures.PCIEnabled;
+
+    /// <summary>
+    /// Whether timer support is enabled (<c>CosmosEnableTimer</c>).
+    /// Disabling it also disables the scheduler.
+    /// </summary>
+    public static bool Timer => CosmosFeatures.TimerEnabled;
+
+    /// <summary>
+    /// Whether keyboard support is enabled (<c>CosmosEnableKeyboard</c>).
+    /// </summary>
+    public static bool Keyboard => CosmosFeatures.KeyboardEnabled;
+
+    /// <summary>
+    /// Whether mouse support is enabled (<c>CosmosEnableMouse</c>).
+    /// </summary>
+    public static bool Mouse => CosmosFeatures.MouseEnabled;
+
+    /// <summary>
+    /// Whether network support is enabled (<c>CosmosEnableNetwork</c>).
+    /// </summary>
+    public static bool Network => CosmosFeatures.NetworkEnabled;
+
+    /// <summary>
+    /// Whether scheduler and threading support is enabled
+    /// (<c>CosmosEnableScheduler</c>).
+    /// </summary>
+    public static bool Scheduler => CosmosFeatures.SchedulerEnabled;
+
+    /// <summary>
+    /// Whether graphics support is enabled (<c>CosmosEnableGraphics</c>).
+    /// </summary>
+    public static bool Graphics => CosmosFeatures.GraphicsEnabled;
+
+    /// <summary>
+    /// Whether block storage support is enabled
+    /// (<c>CosmosEnableStorage</c>). Requires PCI and Interrupts.
+    /// </summary>
+    public static bool Storage => CosmosFeatures.StorageEnabled;
+
+    /// <summary>
+    /// Whether the FAT filesystem driver is enabled
+    /// (<c>CosmosEnableFat</c>). Requires Storage.
+    /// </summary>
+    public static bool Fat => CosmosFeatures.FatEnabled;
+}

--- a/src/Cosmos.Kernel.System/Network/ARP/ArpPacket.cs
+++ b/src/Cosmos.Kernel.System/Network/ARP/ArpPacket.cs
@@ -1,17 +1,40 @@
-﻿using Cosmos.Kernel.Core.IO;
+using System.Diagnostics.CodeAnalysis;
+using Cosmos.Kernel.Core.IO;
 using Cosmos.Kernel.HAL.Devices.Network;
 
 namespace Cosmos.Kernel.System.Network.ARP;
 
 /// <summary>
-/// Represents an ARP (Address Resolution Protocol) packet.
+/// Represents an ARP (Address Resolution Protocol) frame carried over Ethernet with EtherType 0x0806.
+/// The header properties are snapshots parsed from <see cref="EthernetPacket.RawData"/> once, at
+/// construction, and are never re-read afterwards.
 /// </summary>
-internal class ArpPacket : EthernetPacket
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class ArpPacket : EthernetPacket
 {
+    /// <summary>
+    /// The hardware type field (HTYPE) parsed from the frame at construction; 1 means Ethernet.
+    /// </summary>
     protected ushort hardwareType;
+
+    /// <summary>
+    /// The protocol type field (PTYPE) parsed from the frame at construction; 0x0800 means IPv4.
+    /// </summary>
     protected ushort protocolType;
+
+    /// <summary>
+    /// The hardware address length field (HLEN) parsed from the frame at construction; 6 for Ethernet.
+    /// </summary>
     protected byte hardwareAddrLength;
+
+    /// <summary>
+    /// The protocol address length field (PLEN) parsed from the frame at construction; 4 for IPv4.
+    /// </summary>
     protected byte protocolAddrLength;
+
+    /// <summary>
+    /// The operation code field (OPER) parsed from the frame at construction; 1 is a request, 2 is a reply.
+    /// </summary>
     protected ushort opCode;
 
     /// <summary>
@@ -70,21 +93,22 @@ internal class ArpPacket : EthernetPacket
         }
     }
 
-    // /// <summary>
-    // /// Initializes a new instance of the <see cref="ArpPacket"/> class.
-    // /// </summary>
-    // internal ArpPacket()
-    //     : base()
-    // { }
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArpPacket"/> class.
+    /// Initializes a new instance of the <see cref="ArpPacket"/> class from a received frame.
+    /// The array is aliased without copying: <see cref="EthernetPacket.RawData"/> refers to
+    /// <paramref name="rawData"/> itself, and the ARP header fields are parsed from it once,
+    /// at construction.
     /// </summary>
-    /// <param name="rawData">Raw data.</param>
+    /// <param name="rawData">The raw Ethernet frame, starting at the destination MAC address.</param>
     public ArpPacket(byte[] rawData)
         : base(rawData)
     { }
 
+    /// <summary>
+    /// Parses the ARP header fields (hardware type, protocol type, address lengths, operation code)
+    /// from <see cref="EthernetPacket.RawData"/> into the protected fields. Called once during
+    /// construction; the parsed values are never refreshed afterwards.
+    /// </summary>
     protected override void InitializeFields()
     {
         base.InitializeFields();
@@ -96,16 +120,18 @@ internal class ArpPacket : EthernetPacket
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArpPacket"/> class.
+    /// Initializes a new ARP packet for sending. Allocates a frame of <paramref name="packet_size"/>
+    /// bytes, writes the Ethernet header with EtherType 0x0806 and the ARP header fields into it,
+    /// then parses the header back into the properties. Nothing is recomputed after construction.
     /// </summary>
-    /// <param name="dest">Destination MAC address.</param>
-    /// <param name="src">Source MAC address.</param>
-    /// <param name="hwType">Hardware type.</param>
-    /// <param name="protoType">Protocol type.</param>
-    /// <param name="hwLen">Hardware address length.</param>
-    /// <param name="protoLen">Protocol length.</param>
-    /// <param name="operation">Operation.</param>
-    /// <param name="packet_size">Packet size.</param>
+    /// <param name="dest">Destination MAC address of the Ethernet frame.</param>
+    /// <param name="src">Source MAC address of the Ethernet frame.</param>
+    /// <param name="hwType">Hardware type (HTYPE); 1 for Ethernet.</param>
+    /// <param name="protoType">Protocol type (PTYPE); 0x0800 for IPv4.</param>
+    /// <param name="hwLen">Hardware address length in bytes (HLEN); 6 for Ethernet.</param>
+    /// <param name="protoLen">Protocol address length in bytes (PLEN); 4 for IPv4.</param>
+    /// <param name="operation">Operation code (OPER); 1 for a request, 2 for a reply.</param>
+    /// <param name="packet_size">Total frame size in bytes.</param>
     protected ArpPacket(MACAddress dest, MACAddress src, ushort hwType, ushort protoType,
         byte hwLen, byte protoLen, ushort operation, int packet_size)
         : base(dest, src, 0x0806, packet_size)
@@ -123,20 +149,28 @@ internal class ArpPacket : EthernetPacket
     }
 
     /// <summary>
-    /// Gets the operation code.
+    /// Gets the operation code (OPER); 1 is a request, 2 is a reply. This is a snapshot parsed
+    /// from <see cref="EthernetPacket.RawData"/> at construction.
     /// </summary>
-    internal ushort Operation => opCode;
+    public ushort Operation => opCode;
 
     /// <summary>
-    /// Get the hardware type.
+    /// Gets the hardware type (HTYPE); 1 means Ethernet. This is a snapshot parsed from
+    /// <see cref="EthernetPacket.RawData"/> at construction.
     /// </summary>
-    internal ushort HardwareType => hardwareType;
+    public ushort HardwareType => hardwareType;
 
     /// <summary>
-    /// Gets the protocol type.
+    /// Gets the protocol type (PTYPE); 0x0800 means IPv4. This is a snapshot parsed from
+    /// <see cref="EthernetPacket.RawData"/> at construction.
     /// </summary>
-    internal ushort ProtocolType => protocolType;
+    public ushort ProtocolType => protocolType;
 
+    /// <summary>
+    /// Returns a string listing the source and destination MAC addresses, hardware type,
+    /// protocol type, and operation code.
+    /// </summary>
+    /// <returns>A string representation of the packet.</returns>
     public override string ToString()
     {
         return "ARP Packet Src=" + srcMAC + ", Dest=" + destMAC + ", HWType=" + hardwareType + ", Protocol=" + protocolType +

--- a/src/Cosmos.Kernel.System/Network/ARP/ArpPacketEthernet.cs
+++ b/src/Cosmos.Kernel.System/Network/ARP/ArpPacketEthernet.cs
@@ -1,12 +1,17 @@
-﻿using Cosmos.Kernel.HAL.Devices.Network;
+using System.Diagnostics.CodeAnalysis;
+using Cosmos.Kernel.HAL.Devices.Network;
 using Cosmos.Kernel.System.Network.IPv4;
 
 namespace Cosmos.Kernel.System.Network.ARP;
 
 /// <summary>
-/// Represents an ARP Ethernet packet.
+/// Represents an ARP packet for IPv4 over Ethernet: hardware type 1, protocol type 0x0800,
+/// with 6-byte hardware and 4-byte protocol addresses. The address properties are snapshots
+/// parsed from <see cref="EthernetPacket.RawData"/> once, at construction, and are never
+/// re-read afterwards.
 /// </summary>
-internal abstract class ArpPacketEthernet : ArpPacket
+[Experimental(Experimentals.PacketSeamDiagId)]
+public abstract class ArpPacketEthernet : ArpPacket
 {
     /// <summary>
     /// The sender MAC address.
@@ -28,21 +33,22 @@ internal abstract class ArpPacketEthernet : ArpPacket
     /// </summary>
     protected Address targetIP = null!;
 
-    // /// <summary>
-    // /// Initializes a new instance of the <see cref="ArpRequestEthernet"/> class.
-    // /// </summary>
-    // internal ArpPacketEthernet()
-    //     : base()
-    // { }
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArpRequestEthernet"/> class.
+    /// Initializes a new instance of the <see cref="ArpPacketEthernet"/> class from a received
+    /// frame. The array is aliased without copying: <see cref="EthernetPacket.RawData"/> refers
+    /// to <paramref name="rawData"/> itself, and the address fields are parsed from it once,
+    /// at construction.
     /// </summary>
-    /// <param name="rawData">Raw data.</param>
-    internal ArpPacketEthernet(byte[] rawData)
+    /// <param name="rawData">The raw Ethernet frame, starting at the destination MAC address.</param>
+    public ArpPacketEthernet(byte[] rawData)
         : base(rawData)
     { }
 
+    /// <summary>
+    /// Parses the sender and target hardware and protocol addresses (SHA, SPA, THA, TPA) from
+    /// <see cref="EthernetPacket.RawData"/> into the protected fields. Called once during
+    /// construction; the parsed values are never refreshed afterwards.
+    /// </summary>
     protected override void InitializeFields()
     {
         base.InitializeFields();
@@ -53,16 +59,21 @@ internal abstract class ArpPacketEthernet : ArpPacket
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArpRequestEthernet"/> class.
+    /// Initializes a new IPv4-over-Ethernet ARP packet for sending. Allocates a frame of
+    /// <paramref name="packetSize"/> bytes, writes the Ethernet header (destination
+    /// <paramref name="targetMAC"/>, source <paramref name="senderMAC"/>, EtherType 0x0806),
+    /// the fixed ARP header (hardware type 1, protocol type 0x0800, address lengths 6 and 4,
+    /// <paramref name="operation"/>), and the four address fields, then parses them back into
+    /// the properties.
     /// </summary>
-    /// <param name="operation">The operation.</param>
-    /// <param name="senderMAC">The source MAC address.</param>
-    /// <param name="senderIP">The source IP address.</param>
-    /// <param name="targetMAC">The destination MAC address.</param>
-    /// <param name="targetIP">The destination IP address.</param>
-    /// <param name="packetSize">The packet size.</param>
-    /// <param name="arpTargetMAC">The ARP destination MAC address.</param>
-    /// <exception cref="ArgumentException">Thrown if RawData is invalid or null.</exception>
+    /// <param name="operation">Operation code (OPER); 1 for a request, 2 for a reply.</param>
+    /// <param name="senderMAC">Sender hardware address (SHA); also the Ethernet source address.</param>
+    /// <param name="senderIP">Sender protocol address (SPA).</param>
+    /// <param name="targetMAC">Destination MAC address of the Ethernet frame.</param>
+    /// <param name="targetIP">Target protocol address (TPA).</param>
+    /// <param name="packetSize">Total frame size in bytes.</param>
+    /// <param name="arpTargetMAC">Target hardware address (THA), the value written into the ARP
+    /// body at offset 32; it can differ from the Ethernet destination, as in a broadcast request.</param>
     protected ArpPacketEthernet(ushort operation, MACAddress senderMAC, Address senderIP,
         MACAddress targetMAC, Address targetIP, int packetSize, MACAddress arpTargetMAC)
         : base(targetMAC, senderMAC, 1, 0x0800, 6, 4, operation, packetSize)
@@ -82,25 +93,34 @@ internal abstract class ArpPacketEthernet : ArpPacket
     }
 
     /// <summary>
-    /// Gets the senders MAC address.
+    /// Gets the sender hardware address (SHA). This is a snapshot parsed from
+    /// <see cref="EthernetPacket.RawData"/> at construction.
     /// </summary>
-    internal MACAddress SenderMAC => senderMAC;
+    public MACAddress SenderMAC => senderMAC;
 
     /// <summary>
-    /// Gets the targets MAC address.
+    /// Gets the target hardware address (THA), read from the ARP body, not from the Ethernet
+    /// header. This is a snapshot parsed from <see cref="EthernetPacket.RawData"/> at construction.
     /// </summary>
-    internal MACAddress TargetMAC => targetMAC;
+    public MACAddress TargetMAC => targetMAC;
 
     /// <summary>
-    /// Gets the senders IP address.
+    /// Gets the sender protocol address (SPA). This is a snapshot parsed from
+    /// <see cref="EthernetPacket.RawData"/> at construction.
     /// </summary>
-    internal Address SenderIP => senderIP;
+    public Address SenderIP => senderIP;
 
     /// <summary>
-    /// Gets the targets IP address.
+    /// Gets the target protocol address (TPA). This is a snapshot parsed from
+    /// <see cref="EthernetPacket.RawData"/> at construction.
     /// </summary>
-    internal Address TargetIP => targetIP;
+    public Address TargetIP => targetIP;
 
+    /// <summary>
+    /// Returns a string listing the sender and target MAC addresses, sender and target IP
+    /// addresses, and the operation code.
+    /// </summary>
+    /// <returns>A string representation of the packet.</returns>
     public override string ToString()
     {
         return "IPv4 Ethernet ARP Packet SenderMAC=" + senderMAC + ", TargetMAC=" + targetMAC + ", SenderIP=" + senderIP +
@@ -109,40 +129,45 @@ internal abstract class ArpPacketEthernet : ArpPacket
 }
 
 /// <summary>
-/// Represents an ARP reply Ethernet packet.
+/// Represents an ARP reply packet (operation code 2) for IPv4 over Ethernet.
 /// </summary>
 /// <remarks>
 /// See also: <seealso cref="ArpPacketEthernet"/>.
 /// </remarks>
-internal class ArpReplyEthernet : ArpPacketEthernet
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class ArpReplyEthernet : ArpPacketEthernet
 {
-    // /// <summary>
-    // /// Initializes a new instance of the <see cref="ArpReplyEthernet"/> class.
-    // /// </summary>
-    // internal ArpReplyEthernet()
-    //     : base()
-    // { }
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArpReplyEthernet"/> class.
+    /// Initializes a new instance of the <see cref="ArpReplyEthernet"/> class from a received
+    /// frame. The array is aliased without copying, and the header fields are parsed from it
+    /// once, at construction.
     /// </summary>
-    /// <param name="rawData">Raw data.</param>
-    internal ArpReplyEthernet(byte[] rawData)
+    /// <param name="rawData">The raw Ethernet frame, starting at the destination MAC address.</param>
+    public ArpReplyEthernet(byte[] rawData)
         : base(rawData)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArpReplyEthernet"/> class.
+    /// Initializes a new 42-byte ARP reply for sending. The frame is sent unicast to
+    /// <paramref name="targetMAC"/>, which is written both as the Ethernet destination and as
+    /// the ARP target hardware address (THA), so the reply carries the requester's MAC in both
+    /// places.
     /// </summary>
-    /// <param name="ourMAC">The source MAC address.</param>
-    /// <param name="ourIP">The source IP address.</param>
-    /// <param name="targetMAC">The destination MAC address.</param>
-    /// <param name="targetIP">The destination IP address.</param>
-    /// <exception cref="ArgumentException">Thrown if RawData is invalid or null.</exception>
-    internal ArpReplyEthernet(MACAddress ourMAC, Address ourIP, MACAddress targetMAC, Address targetIP)
-        : base(2, ourMAC, ourIP, targetMAC, targetIP, 42, MACAddress.None)
+    /// <param name="ourMAC">Our MAC address: the sender hardware address (SHA) and the Ethernet
+    /// source address.</param>
+    /// <param name="ourIP">Our IP address: the sender protocol address (SPA).</param>
+    /// <param name="targetMAC">The requester's MAC address: the Ethernet destination and the ARP
+    /// target hardware address (THA).</param>
+    /// <param name="targetIP">The requester's IP address: the target protocol address (TPA).</param>
+    public ArpReplyEthernet(MACAddress ourMAC, Address ourIP, MACAddress targetMAC, Address targetIP)
+        : base(2, ourMAC, ourIP, targetMAC, targetIP, 42, targetMAC)
     { }
 
+    /// <summary>
+    /// Returns a string listing the source and destination MAC addresses and the sender and
+    /// target IP addresses.
+    /// </summary>
+    /// <returns>A string representation of the packet.</returns>
     public override string ToString()
     {
         return "ARP Reply Src=" + srcMAC + ", Dest=" + destMAC + ", Sender=" + senderIP + ", Target=" + targetIP;
@@ -150,42 +175,48 @@ internal class ArpReplyEthernet : ArpPacketEthernet
 }
 
 /// <summary>
-/// Represents an ARP request Ethernet packet.
+/// Represents an ARP request packet (operation code 1) for IPv4 over Ethernet.
 /// </summary>
 /// <remarks>
 /// See also: <seealso cref="ArpPacketEthernet"/>.
 /// </remarks>
-internal class ArpRequestEthernet : ArpPacketEthernet
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class ArpRequestEthernet : ArpPacketEthernet
 {
-    // /// <summary>
-    // /// Initializes a new instance of the <see cref="ArpRequestEthernet"/> class.
-    // /// </summary>
-    // internal ArpRequestEthernet()
-    //     : base()
-    // { }
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArpRequestEthernet"/> class.
+    /// Initializes a new instance of the <see cref="ArpRequestEthernet"/> class from a received
+    /// frame. The array is aliased without copying, and the header fields are parsed from it
+    /// once, at construction.
     /// </summary>
-    /// <param name="rawData">Raw data.</param>
-    internal ArpRequestEthernet(byte[] rawData)
+    /// <param name="rawData">The raw Ethernet frame, starting at the destination MAC address.</param>
+    public ArpRequestEthernet(byte[] rawData)
         : base(rawData)
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArpRequestEthernet"/> class.
+    /// Initializes a new 42-byte ARP request for sending. Callers normally pass
+    /// <see cref="MACAddress.Broadcast"/> as <paramref name="targetMAC"/> (the Ethernet
+    /// destination) and <see cref="MACAddress.None"/> as <paramref name="arpTargetMAC"/>: the
+    /// target hardware address field of a request is zero because it is the value being asked for.
     /// </summary>
-    /// <param name="ourMAC">The source MAC address.</param>
-    /// <param name="ourIP">The source IP address.</param>
-    /// <param name="targetMAC">The destination MAC address.</param>
-    /// <param name="targetIP">The destination IP address.</param>
-    /// <param name="arpTargetMAC">The ARP destination MAC address.</param>
-    /// <exception cref="ArgumentException">Thrown if RawData is invalid or null.</exception>
-    internal ArpRequestEthernet(MACAddress ourMAC, Address ourIP, MACAddress targetMAC, Address targetIP, MACAddress arpTargetMAC)
+    /// <param name="ourMAC">Our MAC address: the sender hardware address (SHA) and the Ethernet
+    /// source address.</param>
+    /// <param name="ourIP">Our IP address: the sender protocol address (SPA).</param>
+    /// <param name="targetMAC">Destination MAC address of the Ethernet frame, normally
+    /// <see cref="MACAddress.Broadcast"/>.</param>
+    /// <param name="targetIP">The IP address being resolved: the target protocol address (TPA).</param>
+    /// <param name="arpTargetMAC">Target hardware address (THA) written into the ARP body,
+    /// normally <see cref="MACAddress.None"/>.</param>
+    public ArpRequestEthernet(MACAddress ourMAC, Address ourIP, MACAddress targetMAC, Address targetIP, MACAddress arpTargetMAC)
         : base(1, ourMAC, ourIP, targetMAC, targetIP, 42, arpTargetMAC)
     { }
 
+    /// <summary>
+    /// Returns a string listing the source and destination MAC addresses and the sender and
+    /// target IP addresses.
+    /// </summary>
+    /// <returns>A string representation of the packet.</returns>
     public override string ToString()
     {
         return "ARP Request Src=" + srcMAC + ", Dest=" + destMAC + ", Sender=" + senderIP + ", Target=" + targetIP;

--- a/src/Cosmos.Kernel.System/Network/EthernetPacket.cs
+++ b/src/Cosmos.Kernel.System/Network/EthernetPacket.cs
@@ -1,26 +1,31 @@
-﻿using Cosmos.Kernel.HAL.Devices.Network;
+using System.Diagnostics.CodeAnalysis;
+using Cosmos.Kernel.HAL.Devices.Network;
 
 namespace Cosmos.Kernel.System.Network;
 
 /// <summary>
-/// Represents an Ethernet packet.
+/// An Ethernet frame, the root of the packet hierarchy. The frame lives in
+/// <see cref="RawData"/>; every header property is a snapshot parsed from
+/// that buffer at construction time and is not refreshed by later writes to
+/// the buffer. Derived types lay their headers into the same buffer from
+/// their constructors, including checksums: there is no separate
+/// finalize-before-send step.
 /// </summary>
 // For more info, refer to http://standards.ieee.org/about/get/802/802.3.html
-internal class EthernetPacket
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class EthernetPacket
 {
+    /// <summary>Parsed source MAC address backing <see cref="SourceMAC"/>.</summary>
     protected MACAddress srcMAC = null!;
+
+    /// <summary>Parsed destination MAC address backing <see cref="DestinationMAC"/>.</summary>
     protected MACAddress destMAC = null!;
 
-    // /// <summary>
-    // /// Initializes a new instance of the <see cref="EthernetPacket"/> class.
-    // /// </summary>
-    // protected EthernetPacket()
-    // {
-    //     RawData = [];
-    // }
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="EthernetPacket"/> class, with specified raw data.
+    /// Initializes a new instance of the <see cref="EthernetPacket"/> class
+    /// over existing frame bytes. The array is stored by reference, not
+    /// copied: the caller must not reuse the buffer while the packet is
+    /// alive.
     /// </summary>
     /// <param name="rawData">The raw data of the packet.</param>
     public EthernetPacket(byte[] rawData)
@@ -30,7 +35,10 @@ internal class EthernetPacket
     }
 
     /// <summary>
-    /// Initializes all internal fields.
+    /// Parses the header fields from <see cref="RawData"/> into the typed
+    /// properties. Runs from the constructors (including the base
+    /// constructor, before derived-type state exists) and again whenever a
+    /// MAC address setter rewrites the buffer.
     /// </summary>
     protected virtual void InitializeFields()
     {
@@ -42,14 +50,20 @@ internal class EthernetPacket
     /// <summary>
     /// Initializes a new instance of the <see cref="EthernetPacket"/> class, with specified type and size.
     /// </summary>
+    /// <param name="type">EtherType of the frame.</param>
+    /// <param name="packetSize">Total frame size in bytes; the buffer is allocated here.</param>
     protected EthernetPacket(ushort type, int packetSize)
         : this(MACAddress.None, MACAddress.None, type, packetSize)
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="EthernetPacket"/> class, with specified dsetination, source, type and size.
+    /// Initializes a new instance of the <see cref="EthernetPacket"/> class, with specified destination, source, type and size.
     /// </summary>
+    /// <param name="dest">Destination MAC address.</param>
+    /// <param name="src">Source MAC address.</param>
+    /// <param name="type">EtherType of the frame.</param>
+    /// <param name="packetSize">Total frame size in bytes; the buffer is allocated here.</param>
     protected EthernetPacket(MACAddress dest, MACAddress src, ushort type, int packetSize)
     {
         RawData = new byte[packetSize];
@@ -65,17 +79,22 @@ internal class EthernetPacket
     }
 
     /// <summary>
-    /// Gets the raw data of the packet in the form of a byte array.
+    /// The complete wire image of the frame. The property is get-only but
+    /// the array contents are mutable; header properties parsed from it do
+    /// not track direct writes, and checksums computed at construction are
+    /// not recomputed.
     /// </summary>
     public byte[] RawData { get; }
 
     /// <summary>
-    /// The source MAC address.
+    /// The source MAC address. The setter (used by the transmit path when
+    /// it stamps the sending device's address) rewrites the buffer and
+    /// re-parses the whole packet.
     /// </summary>
-    internal MACAddress SourceMAC
+    public MACAddress SourceMAC
     {
         get => srcMAC;
-        set
+        internal set
         {
             for (int i = 0; i < 6; i++)
             {
@@ -86,12 +105,14 @@ internal class EthernetPacket
     }
 
     /// <summary>
-    /// The destination MAC address.
+    /// The destination MAC address. The setter (used by the transmit path
+    /// once ARP resolution completes) rewrites the buffer and re-parses the
+    /// whole packet.
     /// </summary>
-    internal MACAddress DestinationMAC
+    public MACAddress DestinationMAC
     {
         get => destMAC;
-        set
+        internal set
         {
             for (int i = 0; i < 6; i++)
             {
@@ -103,15 +124,11 @@ internal class EthernetPacket
     }
 
     /// <summary>
-    /// The type of the packet.
+    /// The EtherType of the frame (0x0800 IPv4, 0x0806 ARP).
     /// </summary>
-    internal ushort EthernetType { get; private set; }
+    public ushort EthernetType { get; private set; }
 
-    /// <summary>
-    /// Prepares the packet for sending. Not implemented.
-    /// </summary>
-    internal virtual void PrepareForSending() { }
-
+    /// <inheritdoc/>
     public override string ToString()
     {
         return "Ethernet Packet : Src=" + srcMAC + ", Dest=" + destMAC + ", Type=" + EthernetType;

--- a/src/Cosmos.Kernel.System/Network/Experimentals.cs
+++ b/src/Cosmos.Kernel.System/Network/Experimentals.cs
@@ -1,0 +1,19 @@
+namespace Cosmos.Kernel.System.Network;
+
+/// <summary>
+/// Diagnostic IDs of the experimental API seams exposed by
+/// Cosmos.Kernel.System. An experimental API is usable today but carries no
+/// compatibility promise; referencing one produces an error with the ID
+/// below until the caller suppresses it, which is the caller's
+/// acknowledgement of that contract.
+/// </summary>
+internal static class Experimentals
+{
+    /// <summary>
+    /// The packet seam: the protocol packet types (Ethernet, ARP, IPv4,
+    /// ICMP, UDP, DHCP, DNS, TCP), the <see cref="NetworkStack"/> members
+    /// that transmit and inject them, and the client members that accept
+    /// or return packet objects.
+    /// </summary>
+    internal const string PacketSeamDiagId = "COSMOS0002";
+}

--- a/src/Cosmos.Kernel.System/Network/IPv4/IPPacket.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/IPPacket.cs
@@ -1,4 +1,5 @@
-﻿using Cosmos.Kernel.Core.IO;
+﻿using System.Diagnostics.CodeAnalysis;
+using Cosmos.Kernel.Core.IO;
 using Cosmos.Kernel.HAL.Devices.Network;
 using Cosmos.Kernel.System.Network.ARP;
 using Cosmos.Kernel.System.Network.IPv4.TCP;
@@ -7,12 +8,20 @@ using Cosmos.Kernel.System.Network.IPv4.UDP;
 namespace Cosmos.Kernel.System.Network.IPv4;
 
 /// <summary>
-/// Represents an IP (Internet Protocol) packet.
+/// An IPv4 packet over Ethernet. The build constructors write the complete
+/// IPv4 header, including the header checksum, at construction time; the
+/// checksum is never recomputed, so the header bytes must not be modified
+/// afterwards. Derive from this class to implement a custom IP protocol:
+/// pass the protocol number and payload length to a build constructor and
+/// write the payload into <see cref="EthernetPacket.RawData"/> from
+/// <see cref="DataOffset"/> onward.
 /// </summary>
-internal class IPPacket : EthernetPacket
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class IPPacket : EthernetPacket
 {
+    /// <summary>Header length in 32-bit words, as parsed from the IHL field.</summary>
     protected byte ipHeaderLength;
-    private static ushort s_sNextFragmentID;
+    private static ushort s_nextFragmentID;
 
     /// <summary>
     /// Handles a single IPv4 packet.
@@ -64,12 +73,14 @@ internal class IPPacket : EthernetPacket
     }
 
     /// <summary>
-    /// Gets the next IP fragment ID.
+    /// Gets the next IP fragment ID. Reading advances the counter.
     /// </summary>
-    public static ushort NextIPFragmentID => s_sNextFragmentID++;
+    internal static ushort NextIPFragmentID => s_nextFragmentID++;
 
     /// <summary>
-    /// Create new instance of the <see cref="IPPacket"/> class.
+    /// Initializes a new instance of the <see cref="IPPacket"/> class over
+    /// existing frame bytes. The array is aliased, not copied, and neither
+    /// the length fields nor the header checksum are validated.
     /// </summary>
     /// <param name="rawData">Raw data.</param>
     public IPPacket(byte[] rawData)
@@ -100,28 +111,34 @@ internal class IPPacket : EthernetPacket
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="IPPacket"/> class.
+    /// Initializes a new instance of the <see cref="IPPacket"/> class. The
+    /// source MAC is looked up from the configured devices by the source IP
+    /// (<see cref="MACAddress.None"/> when the address is not configured)
+    /// and the destination MAC is left unset for ARP resolution at send
+    /// time.
     /// </summary>
-    /// <param name="dataLength">Data length.</param>
-    /// <param name="protocol">Protocol.</param>
+    /// <param name="dataLength">Length of the IP payload, in bytes.</param>
+    /// <param name="protocol">IP protocol number of the payload.</param>
     /// <param name="source">Source address.</param>
-    /// <param name="dest">Destionation address.</param>
-    /// <param name="Flags">Flags.</param>
-    protected IPPacket(ushort dataLength, byte protocol, Address source, Address dest, byte Flags)
-        : this(GetSourceMAC(source), MACAddress.None, dataLength, protocol, source, dest, Flags)
+    /// <param name="dest">Destination address.</param>
+    /// <param name="flags">Raw value of header byte 20: the 3 flag bits followed by the upper 5 bits of the fragment offset.</param>
+    protected IPPacket(ushort dataLength, byte protocol, Address source, Address dest, byte flags)
+        : this(GetSourceMAC(source), MACAddress.None, dataLength, protocol, source, dest, flags)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="IPPacket"/> class.
+    /// Initializes a new instance of the <see cref="IPPacket"/> class with
+    /// a known destination MAC (used for broadcast destinations, which skip
+    /// ARP resolution).
     /// </summary>
-    /// <param name="dataLength">Data length.</param>
-    /// <param name="protocol">Protocol.</param>
+    /// <param name="dataLength">Length of the IP payload, in bytes.</param>
+    /// <param name="protocol">IP protocol number of the payload.</param>
     /// <param name="source">Source address.</param>
-    /// <param name="dest">Destionation address.</param>
-    /// <param name="Flags">Flags.</param>
-    /// /// <param name="destMAC">Destination Mac address</param>
-    protected IPPacket(ushort dataLength, byte protocol, Address source, Address dest, byte Flags, MACAddress destMAC)
-        : this(GetSourceMAC(source), destMAC, dataLength, protocol, source, dest, Flags)
+    /// <param name="dest">Destination address.</param>
+    /// <param name="flags">Raw value of header byte 20: the 3 flag bits followed by the upper 5 bits of the fragment offset.</param>
+    /// <param name="destMAC">Destination MAC address.</param>
+    protected IPPacket(ushort dataLength, byte protocol, Address source, Address dest, byte flags, MACAddress destMAC)
+        : this(GetSourceMAC(source), destMAC, dataLength, protocol, source, dest, flags)
     { }
 
     /// <summary>
@@ -138,18 +155,19 @@ internal class IPPacket : EthernetPacket
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="IPPacket"/> class.
+    /// Initializes a new instance of the <see cref="IPPacket"/> class,
+    /// writing the complete IPv4 header: TTL 0x80, a fragment ID drawn from
+    /// a global counter, and the header checksum computed here.
     /// </summary>
     /// <param name="srcMAC">Source MAC address.</param>
     /// <param name="destMAC">Destination MAC address.</param>
-    /// <param name="dataLength">Data length.</param>
-    /// <param name="protocol">Protocol.</param>
+    /// <param name="dataLength">Length of the IP payload, in bytes.</param>
+    /// <param name="protocol">IP protocol number of the payload.</param>
     /// <param name="source">Source address.</param>
     /// <param name="dest">Destination address.</param>
-    /// <param name="Flags">Flags.</param>
-    /// <exception cref="ArgumentException">Thrown if RawData is invalid or null.</exception>
+    /// <param name="flags">Raw value of header byte 20: the 3 flag bits followed by the upper 5 bits of the fragment offset.</param>
     public IPPacket(MACAddress srcMAC, MACAddress destMAC, ushort dataLength, byte protocol,
-        Address source, Address dest, byte Flags)
+        Address source, Address dest, byte flags)
         : base(destMAC, srcMAC, 0x0800, dataLength + 14 + 20)
     {
         RawData[14] = 0x45;
@@ -162,7 +180,7 @@ internal class IPPacket : EthernetPacket
         FragmentID = NextIPFragmentID;
         RawData[18] = (byte)((FragmentID >> 8) & 0xFF);
         RawData[19] = (byte)((FragmentID >> 0) & 0xFF);
-        RawData[20] = Flags;
+        RawData[20] = flags;
         RawData[21] = 0x00;
         RawData[22] = 0x80;
         RawData[23] = protocol;
@@ -181,14 +199,17 @@ internal class IPPacket : EthernetPacket
     }
 
     /// <summary>
-    /// Calculates the CRC of the packet.
+    /// Computes the Internet ones'-complement checksum over a range of
+    /// <see cref="EthernetPacket.RawData"/>. Available to derived packet
+    /// types for their own header checksums.
     /// </summary>
     /// <param name="offset">The offset, in bytes.</param>
     /// <param name="length">The length, in bytes.</param>
     protected ushort CalcOcCRC(ushort offset, ushort length) => CalcOcCRC(RawData, offset, length);
 
     /// <summary>
-    /// Calculates the CRC of the packet.
+    /// Computes the Internet ones'-complement checksum over a range of the
+    /// given buffer.
     /// </summary>
     /// <param name="buffer">The buffer to use.</param>
     /// <param name="offset">The offset, in bytes.</param>
@@ -198,6 +219,13 @@ internal class IPPacket : EthernetPacket
         return (ushort)~SumShortValues(buffer, offset, length);
     }
 
+    /// <summary>
+    /// Sums a range of the buffer as big-endian 16-bit words with
+    /// end-around carry, the accumulation step of the Internet checksum.
+    /// </summary>
+    /// <param name="buffer">The buffer to use.</param>
+    /// <param name="offset">The offset, in bytes.</param>
+    /// <param name="length">The length, in bytes.</param>
     protected static ushort SumShortValues(byte[] buffer, int offset, int length)
     {
         uint chksum = 0;
@@ -218,7 +246,8 @@ internal class IPPacket : EthernetPacket
     }
 
     /// <summary>
-    /// Calculates the CRC of the packet.
+    /// Computes the IPv4 header checksum over the first
+    /// <paramref name="headerLength"/> bytes of the IP header.
     /// </summary>
     /// <param name="headerLength">The length of the header, in bytes.</param>
     protected ushort CalcIPCRC(ushort headerLength)
@@ -229,52 +258,53 @@ internal class IPPacket : EthernetPacket
     /// <summary>
     /// Gets the IP version of the packet.
     /// </summary>
-    internal byte IPVersion { get; private set; }
+    public byte IPVersion { get; private set; }
 
     /// <summary>
-    /// Gets the length of the header, in bytes.
+    /// Gets the length of the IP header, in bytes.
     /// </summary>
-    internal ushort HeaderLength => (ushort)(ipHeaderLength * 4);
+    public ushort HeaderLength => (ushort)(ipHeaderLength * 4);
 
     /// <summary>
     /// Gets the type of service.
     /// </summary>
-    internal byte TypeOfService { get; private set; }
+    public byte TypeOfService { get; private set; }
 
     /// <summary>
-    /// Gets the IP length of the packet.
+    /// Gets the total length of the IP packet (header plus payload), in bytes.
     /// </summary>
-    internal ushort IPLength { get; private set; }
+    public ushort IPLength { get; private set; }
 
     /// <summary>
     /// Gets the fragment ID.
     /// </summary>
-    internal ushort FragmentID { get; private set; }
+    public ushort FragmentID { get; private set; }
 
     /// <summary>
-    /// Gets the flags of the packet.
+    /// Gets the 3 flag bits of the packet.
     /// </summary>
-    internal byte IPFlags { get; private set; }
+    public byte IPFlags { get; private set; }
 
     /// <summary>
     /// Gets the fragment offset.
     /// </summary>
-    internal ushort FragmentOffset { get; private set; }
+    public ushort FragmentOffset { get; private set; }
 
     /// <summary>
     /// Gets the TTL (Time-To-Live) of the packet.
     /// </summary>
-    internal byte TTL { get; private set; }
+    public byte TTL { get; private set; }
 
     /// <summary>
-    /// Gets the protocol.
+    /// Gets the IP protocol number of the payload (1 ICMP, 6 TCP, 17 UDP).
     /// </summary>
-    internal byte Protocol { get; private set; }
+    public byte Protocol { get; private set; }
 
     /// <summary>
-    /// Gets the IPCRC.
+    /// Gets the IP header checksum as parsed from the header. On locally
+    /// built packets it holds the value computed at construction.
     /// </summary>
-    internal ushort IPCRC { get; private set; }
+    public ushort IPCRC { get; private set; }
 
     /// <summary>
     /// Gets the source IP address.
@@ -287,15 +317,17 @@ internal class IPPacket : EthernetPacket
     public Address DestinationIP { get; private set; } = null!;
 
     /// <summary>
-    /// Gets the offset of the data.
+    /// Gets the offset of the IP payload from the start of the frame
+    /// (Ethernet header plus IP header), in bytes.
     /// </summary>
-    internal ushort DataOffset { get; private set; }
+    public ushort DataOffset { get; private set; }
 
     /// <summary>
-    /// Gets the length of the data.
+    /// Gets the length of the IP payload, in bytes.
     /// </summary>
-    internal ushort DataLength => (ushort)(IPLength - HeaderLength);
+    public ushort DataLength => (ushort)(IPLength - HeaderLength);
 
+    /// <inheritdoc/>
     public override string ToString()
     {
         return "IP Packet Src=" + SourceIP + ", Dest=" + DestinationIP + ", Protocol=" + Protocol + ", TTL=" + TTL + ", DataLen=" + DataLength;

--- a/src/Cosmos.Kernel.System/Network/IPv4/IcmpClient.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/IcmpClient.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Cosmos.Kernel.System.Network.Config;
 using Cosmos.Kernel.System.Timer;
 
@@ -79,6 +80,40 @@ public class IcmpClient : IDisposable
         var request = new IcmpEchoRequest(source, _destination, id, sequence);
         OutgoingBuffer.AddPacket(request);
         NetworkStack.Update();
+    }
+
+    /// <summary>
+    /// Transmits a prebuilt ICMP packet through the stack's outgoing queue,
+    /// including ARP resolution of the destination.
+    /// </summary>
+    /// <param name="packet">The packet to transmit; its headers and checksum must already be final.</param>
+    /// <returns><see langword="false"/> when no configured interface matches the packet's source address; otherwise, <see langword="true"/>.</returns>
+    [Experimental(Experimentals.PacketSeamDiagId)]
+    public bool Send(IcmpPacket packet) => Cosmos.Kernel.System.Network.NetworkStack.Send(packet);
+
+    /// <summary>
+    /// Receives one ICMP packet from this client's receive queue. Unlike
+    /// <see cref="Receive"/>, this hands back the parsed packet object so the
+    /// caller can read the ICMP identifier, sequence number, and payload.
+    /// </summary>
+    /// <param name="timeoutMs">The timeout in milliseconds; a non-positive value checks the queue once without waiting.</param>
+    /// <returns>The dequeued <see cref="IcmpPacket"/>, or <see langword="null"/> if none arrived before the timeout.</returns>
+    [Experimental(Experimentals.PacketSeamDiagId)]
+    public IcmpPacket? ReceivePacket(int timeoutMs = 5000)
+    {
+        int waited = 0;
+        while (_rxBuffer.Count < 1 && waited < timeoutMs)
+        {
+            TimerManager.Wait(10);
+            waited += 10;
+        }
+
+        if (_rxBuffer.Count < 1)
+        {
+            return null;
+        }
+
+        return _rxBuffer.Dequeue();
     }
 
     /// <summary>

--- a/src/Cosmos.Kernel.System/Network/IPv4/IcmpPacket.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/IcmpPacket.cs
@@ -1,17 +1,27 @@
+using System.Diagnostics.CodeAnalysis;
 using Cosmos.Kernel.Core.IO;
 
 namespace Cosmos.Kernel.System.Network.IPv4;
 
 /// <summary>
-/// Represents an ICMP packet.
+/// An ICMP packet carried in an <see cref="IPPacket"/> (IP protocol 1).
+/// Header properties are snapshots parsed from <see cref="EthernetPacket.RawData"/>
+/// at construction time; the checksum is computed in the constructors and never
+/// recomputed afterward.
 /// </summary>
 /// <remarks>
 /// See also: <seealso cref="IPPacket"/>.
 /// </remarks>
-internal class IcmpPacket : IPPacket
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class IcmpPacket : IPPacket
 {
+    /// <summary>Parsed ICMP type backing <see cref="ICMPType"/>.</summary>
     protected byte icmpType;
+
+    /// <summary>Parsed ICMP code backing <see cref="ICMPCode"/>.</summary>
     protected byte icmpCode;
+
+    /// <summary>Parsed or computed ICMP checksum backing <see cref="ICMPCRC"/>.</summary>
     protected ushort icmpCRC;
 
     private static int s_echoRequestsReplied;
@@ -20,12 +30,12 @@ internal class IcmpPacket : IPPacket
     /// <summary>
     /// Number of echo requests answered with an echo reply.
     /// </summary>
-    public static int EchoRequestsReplied => s_echoRequestsReplied;
+    internal static int EchoRequestsReplied => s_echoRequestsReplied;
 
     /// <summary>
     /// ICMP payload of the most recently answered echo request.
     /// </summary>
-    public static byte[]? LastEchoRequestData => s_lastEchoRequestData;
+    internal static byte[]? LastEchoRequestData => s_lastEchoRequestData;
 
     /// <summary>
     /// Handles an ICMP packet.
@@ -43,7 +53,9 @@ internal class IcmpPacket : IPPacket
                 Serial.WriteString("\n");
 
                 var receiver = IcmpClient.GetClient(icmpPacket.SourceIP.Id);
-                receiver?.ReceiveData(icmpPacket);
+                // Deliver the typed reply so consumers see the identifier
+                // and sequence number, not just the base ICMP fields.
+                receiver?.ReceiveData(new IcmpEchoReply(packetData));
                 break;
             case 8: // Echo request
                 var request = new IcmpEchoRequest(packetData);
@@ -63,14 +75,20 @@ internal class IcmpPacket : IPPacket
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="IcmpPacket"/> class.
+    /// Initializes a new instance of the <see cref="IcmpPacket"/> class over
+    /// existing frame bytes. The array is stored by reference, not copied:
+    /// the caller must not reuse the buffer while the packet is alive.
     /// </summary>
-    /// <param name="rawData">Raw data.</param>
-    internal IcmpPacket(byte[] rawData)
+    /// <param name="rawData">The raw data of the packet.</param>
+    public IcmpPacket(byte[] rawData)
         : base(rawData)
     {
     }
 
+    /// <summary>
+    /// Parses the ICMP type, code, and checksum snapshots from
+    /// <see cref="EthernetPacket.RawData"/>, in addition to the base fields.
+    /// </summary>
     protected override void InitializeFields()
     {
         base.InitializeFields();
@@ -80,18 +98,21 @@ internal class IcmpPacket : IPPacket
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="IcmpPacket"/> class.
+    /// Initializes a new instance of the <see cref="IcmpPacket"/> class,
+    /// building a frame with the given ICMP header values. The checksum is
+    /// computed here, over the header and payload bytes as they are at this
+    /// point, and is never recomputed: writes to the payload after
+    /// construction invalidate it.
     /// </summary>
-    /// <param name="source">Source address.</param>
-    /// <param name="dest">Destination address.</param>
-    /// <param name="type">Type.</param>
-    /// <param name="code">Code.</param>
-    /// <param name="id">ID.</param>
-    /// <param name="seq">SEQ.</param>
-    /// <param name="icmpDataSize">Data size.</param>
-    /// <exception cref="ArgumentException">Thrown if RawData is invalid or null.</exception>
-    internal IcmpPacket(Address source, Address dest, byte type, byte code, ushort id, ushort seq, ushort icmpDataSize)
-        : base(icmpDataSize, 1, source, dest, 0x00)
+    /// <param name="source">Source IP address.</param>
+    /// <param name="dest">Destination IP address.</param>
+    /// <param name="type">ICMP type.</param>
+    /// <param name="code">ICMP code.</param>
+    /// <param name="id">ICMP identifier, written to the second header word.</param>
+    /// <param name="seq">ICMP sequence number, written to the second header word.</param>
+    /// <param name="icmpLength">The length in bytes of the ICMP header plus payload: the whole IP payload length.</param>
+    public IcmpPacket(Address source, Address dest, byte type, byte code, ushort id, ushort seq, ushort icmpLength)
+        : base(icmpLength, 1, source, dest, 0x00)
     {
         RawData[DataOffset] = type;
         RawData[DataOffset + 1] = code;
@@ -102,7 +123,7 @@ internal class IcmpPacket : IPPacket
         RawData[DataOffset + 6] = (byte)((seq >> 8) & 0xFF);
         RawData[DataOffset + 7] = (byte)((seq >> 0) & 0xFF);
 
-        icmpCRC = CalcICMPCRC(icmpDataSize);
+        icmpCRC = CalcICMPCRC(icmpLength);
 
         RawData[DataOffset + 2] = (byte)((icmpCRC >> 8) & 0xFF);
         RawData[DataOffset + 3] = (byte)((icmpCRC >> 0) & 0xFF);
@@ -110,38 +131,46 @@ internal class IcmpPacket : IPPacket
     }
 
     /// <summary>
-    /// Calculates the ICMP CRC.
+    /// Computes the ones-complement checksum over the ICMP section of
+    /// <see cref="EthernetPacket.RawData"/>, starting at the ICMP header. The
+    /// result is not written to the buffer: constructors store it themselves,
+    /// and nothing recomputes it after construction.
     /// </summary>
-    /// <param name="length">The length of the packet.</param>
+    /// <param name="length">The number of bytes to sum: the ICMP header plus payload.</param>
+    /// <returns>The checksum value.</returns>
     protected ushort CalcICMPCRC(ushort length)
     {
         return CalcOcCRC(DataOffset, length);
     }
 
     /// <summary>
-    /// The ICMP packet type.
+    /// The ICMP packet type, a snapshot parsed from <see cref="EthernetPacket.RawData"/> at construction time.
     /// </summary>
-    internal byte ICMPType => icmpType;
+    public byte ICMPType => icmpType;
 
     /// <summary>
-    /// The ICMP packet code.
+    /// The ICMP packet code, a snapshot parsed from <see cref="EthernetPacket.RawData"/> at construction time.
     /// </summary>
-    internal byte ICMPCode => icmpCode;
+    public byte ICMPCode => icmpCode;
 
     /// <summary>
-    /// The ICMP packet CRC.
+    /// The ICMP checksum, a snapshot taken at construction time. It is
+    /// computed in the constructors and never recomputed afterward.
     /// </summary>
-    internal ushort ICMPCRC => icmpCRC;
+    public ushort ICMPCRC => icmpCRC;
 
     /// <summary>
-    /// The ICMP packet data length.
+    /// The length in bytes of the ICMP payload: the IP payload length minus
+    /// the 8-byte ICMP header.
     /// </summary>
-    internal ushort ICMPDataLength => (ushort)(DataLength - 8);
+    public ushort ICMPDataLength => (ushort)(DataLength - 8);
 
     /// <summary>
-    /// Returns the ICMP packet data.
+    /// Returns a fresh copy of the ICMP payload (the bytes after the 8-byte
+    /// ICMP header). Mutating the returned array does not affect the packet.
     /// </summary>
-    internal byte[] GetICMPData()
+    /// <returns>A new array holding the payload bytes.</returns>
+    public byte[] GetICMPData()
     {
         byte[] data = new byte[ICMPDataLength];
 
@@ -153,6 +182,10 @@ internal class IcmpPacket : IPPacket
         return data;
     }
 
+    /// <summary>
+    /// Returns a string describing the packet's source, destination, type, and code.
+    /// </summary>
+    /// <returns>The description string.</returns>
     public override string ToString()
     {
         return "ICMP Packet Src=" + SourceIP + ", Dest=" + DestinationIP + ", Type=" + icmpType + ", Code=" + icmpCode;
@@ -160,34 +193,45 @@ internal class IcmpPacket : IPPacket
 }
 
 /// <summary>
-/// Represents an ICMP echo request packet.
+/// An ICMP echo request packet. The identifier and sequence properties are
+/// snapshots parsed from <see cref="EthernetPacket.RawData"/> at construction
+/// time.
 /// </summary>
 /// <remarks>
 /// See also: <seealso cref="IcmpPacket"/>.
 /// </remarks>
-internal class IcmpEchoRequest : IcmpPacket
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class IcmpEchoRequest : IcmpPacket
 {
+    /// <summary>Parsed ICMP identifier backing <see cref="ICMPID"/>.</summary>
     protected ushort icmpID;
+
+    /// <summary>Parsed ICMP sequence number backing <see cref="ICMPSequence"/>.</summary>
     protected ushort icmpSequence;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="IcmpEchoRequest"/> class.
+    /// Initializes a new instance of the <see cref="IcmpEchoRequest"/> class
+    /// over existing frame bytes. The array is stored by reference, not
+    /// copied: the caller must not reuse the buffer while the packet is
+    /// alive.
     /// </summary>
-    /// <param name="rawData">Raw data.</param>
-    internal IcmpEchoRequest(byte[] rawData)
+    /// <param name="rawData">The raw data of the packet.</param>
+    public IcmpEchoRequest(byte[] rawData)
         : base(rawData)
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="IcmpEchoRequest"/> class.
+    /// Initializes a new instance of the <see cref="IcmpEchoRequest"/> class,
+    /// building a request with a 32-byte payload whose leading bytes are
+    /// filled with an incrementing pattern. The checksum is computed here and
+    /// never recomputed.
     /// </summary>
-    /// <param name="source">Source address.</param>
-    /// <param name="dest">Destination address.</param>
-    /// <param name="id">ID.</param>
-    /// <param name="sequence">Sequence.</param>
-    /// <exception cref="ArgumentException">Thrown if RawData is invalid or null.</exception>
-    internal IcmpEchoRequest(Address source, Address dest, ushort id, ushort sequence)
+    /// <param name="source">Source IP address.</param>
+    /// <param name="dest">Destination IP address.</param>
+    /// <param name="id">ICMP echo identifier.</param>
+    /// <param name="sequence">ICMP echo sequence number.</param>
+    public IcmpEchoRequest(Address source, Address dest, ushort id, ushort sequence)
         : base(source, dest, 8, 0, id, sequence, 40)
     {
         for (int b = 8; b < ICMPDataLength; b++)
@@ -202,6 +246,10 @@ internal class IcmpEchoRequest : IcmpPacket
         RawData[DataOffset + 3] = (byte)((icmpCRC >> 0) & 0xFF);
     }
 
+    /// <summary>
+    /// Parses the identifier and sequence number snapshots from
+    /// <see cref="EthernetPacket.RawData"/>, in addition to the base fields.
+    /// </summary>
     protected override void InitializeFields()
     {
         base.InitializeFields();
@@ -210,15 +258,19 @@ internal class IcmpEchoRequest : IcmpPacket
     }
 
     /// <summary>
-    /// The ICMP packet ID.
+    /// The ICMP echo identifier, a snapshot parsed from <see cref="EthernetPacket.RawData"/> at construction time.
     /// </summary>
-    internal ushort ICMPID => icmpID;
+    public ushort ICMPID => icmpID;
 
     /// <summary>
-    /// The ICMP packet sequence.
+    /// The ICMP echo sequence number, a snapshot parsed from <see cref="EthernetPacket.RawData"/> at construction time.
     /// </summary>
-    internal ushort ICMPSequence => icmpSequence;
+    public ushort ICMPSequence => icmpSequence;
 
+    /// <summary>
+    /// Returns a string describing the request's source, destination, identifier, and sequence number.
+    /// </summary>
+    /// <returns>The description string.</returns>
     public override string ToString()
     {
         return "ICMP Echo Request Src=" + SourceIP + ", Dest=" + DestinationIP + ", ID=" + icmpID + ", Sequence=" + icmpSequence;
@@ -226,31 +278,43 @@ internal class IcmpEchoRequest : IcmpPacket
 }
 
 /// <summary>
-/// Represents an ICMP echo reply packet.
+/// An ICMP echo reply packet. The identifier and sequence properties are
+/// snapshots parsed from <see cref="EthernetPacket.RawData"/> at construction
+/// time.
 /// </summary>
 /// <remarks>
 /// See also: <seealso cref="IcmpPacket"/>.
 /// </remarks>
-internal class IcmpEchoReply : IcmpPacket
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class IcmpEchoReply : IcmpPacket
 {
+    /// <summary>Parsed ICMP identifier backing <see cref="ICMPID"/>.</summary>
     protected ushort icmpID;
+
+    /// <summary>Parsed ICMP sequence number backing <see cref="ICMPSequence"/>.</summary>
     protected ushort icmpSequence;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="IcmpEchoReply"/> class.
+    /// Initializes a new instance of the <see cref="IcmpEchoReply"/> class
+    /// over existing frame bytes. The array is stored by reference, not
+    /// copied: the caller must not reuse the buffer while the packet is
+    /// alive.
     /// </summary>
-    /// <param name="rawData">Raw data.</param>
-    internal IcmpEchoReply(byte[] rawData)
+    /// <param name="rawData">The raw data of the packet.</param>
+    public IcmpEchoReply(byte[] rawData)
         : base(rawData)
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="IcmpEchoReply"/> class.
+    /// Initializes a new instance of the <see cref="IcmpEchoReply"/> class,
+    /// building a reply to <paramref name="request"/>: source and destination
+    /// are swapped, and the identifier, sequence number, and payload are
+    /// copied from the request. The checksum is computed here and never
+    /// recomputed.
     /// </summary>
-    /// <param name="request">ICMP echo request.</param>
-    /// <exception cref="ArgumentException">Thrown if RawData is invalid or null.</exception>
-    internal IcmpEchoReply(IcmpEchoRequest request)
+    /// <param name="request">The ICMP echo request to answer.</param>
+    public IcmpEchoReply(IcmpEchoRequest request)
         : base(request.DestinationIP, request.SourceIP, 0, 0, request.ICMPID, request.ICMPSequence, (ushort)(request.ICMPDataLength + 8))
     {
         for (int b = 0; b < ICMPDataLength; b++)
@@ -265,6 +329,10 @@ internal class IcmpEchoReply : IcmpPacket
         RawData[DataOffset + 3] = (byte)((icmpCRC >> 0) & 0xFF);
     }
 
+    /// <summary>
+    /// Parses the identifier and sequence number snapshots from
+    /// <see cref="EthernetPacket.RawData"/>, in addition to the base fields.
+    /// </summary>
     protected override void InitializeFields()
     {
         base.InitializeFields();
@@ -273,15 +341,19 @@ internal class IcmpEchoReply : IcmpPacket
     }
 
     /// <summary>
-    /// The ICMP packet ID.
+    /// The ICMP echo identifier, a snapshot parsed from <see cref="EthernetPacket.RawData"/> at construction time.
     /// </summary>
-    internal ushort ICMPID => icmpID;
+    public ushort ICMPID => icmpID;
 
     /// <summary>
-    /// The ICMP packet sequence.
+    /// The ICMP echo sequence number, a snapshot parsed from <see cref="EthernetPacket.RawData"/> at construction time.
     /// </summary>
-    internal ushort ICMPSequence => icmpSequence;
+    public ushort ICMPSequence => icmpSequence;
 
+    /// <summary>
+    /// Returns a string describing the reply's source, destination, identifier, and sequence number.
+    /// </summary>
+    /// <returns>The description string.</returns>
     public override string ToString()
     {
         return "ICMP Echo Reply Src=" + SourceIP + ", Dest=" + DestinationIP + ", ID=" + icmpID + ", Sequence=" + icmpSequence;

--- a/src/Cosmos.Kernel.System/Network/IPv4/OutgoingBuffer.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/OutgoingBuffer.cs
@@ -64,20 +64,25 @@ internal static class OutgoingBuffer
     }
 
     /// <summary>
-    /// Adds a packet to the buffer. for use by drivers
+    /// Adds a packet to the buffer, resolving the sending device from the
+    /// packet's source address.
     /// </summary>
     /// <param name="packet">The IP packet.</param>
-    public static void AddPacket(IPPacket packet)
+    /// <returns>False when no configured interface matches the packet's source address.</returns>
+    public static bool AddPacket(IPPacket packet)
     {
         var device = IPConfig.FindInterface(packet.SourceIP);
-        if (device != null)
+        if (device == null)
         {
-            AddPacket(packet, device);
+            return false;
         }
+
+        AddPacket(packet, device);
+        return true;
     }
 
     /// <summary>
-    /// Adds a packet to the buffer. for use by drivers
+    /// Adds a packet to the buffer.
     /// </summary>
     /// <param name="packet">The IP packet.</param>
     /// <param name="device">The Network Interface Controller.</param>

--- a/src/Cosmos.Kernel.System/Network/IPv4/TCP/Tcp.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/TCP/Tcp.cs
@@ -437,7 +437,7 @@ internal class Tcp : IDisposable
             {
                 if (!packet._rst)
                 {
-                    SendEmptyPacket(Flags.ACK);
+                    SendEmptyPacket(TcpFlags.ACK);
                 }
 
                 Serial.WriteString("[TCP] Sequence number or segment data invalid, packet passed.\n");
@@ -490,7 +490,7 @@ internal class Tcp : IDisposable
             TCB.RcvUp = 0;
             TCB.IRS = packet.SequenceNumber;
 
-            SendEmptyPacket(Flags.SYN | Flags.ACK);
+            SendEmptyPacket(TcpFlags.SYN | TcpFlags.ACK);
 
             Status = Status.SYN_RECEIVED;
         }
@@ -513,7 +513,7 @@ internal class Tcp : IDisposable
             }
             else
             {
-                SendEmptyPacket(Flags.RST, packet.AckNumber);
+                SendEmptyPacket(TcpFlags.RST, packet.AckNumber);
             }
         }
     }
@@ -535,11 +535,11 @@ internal class Tcp : IDisposable
                 TCB.SndWl1 = packet.SequenceNumber;
                 TCB.SndWl2 = packet.AckNumber;
 
-                SendEmptyPacket(Flags.ACK);
+                SendEmptyPacket(TcpFlags.ACK);
 
                 Status = Status.ESTABLISHED;
             }
-            else if (packet.TCPFlags == (byte)Flags.SYN)
+            else if (packet.TCPFlags == (byte)TcpFlags.SYN)
             {
                 Status = Status.CLOSED;
                 Serial.WriteString("[TCP] Simultaneous open not supported.\n");
@@ -555,7 +555,7 @@ internal class Tcp : IDisposable
             //Check for bad ACK packet
             if ((int)packet.AckNumber - TCB.ISS < 0 || packet.AckNumber - TCB.SndNxt > 0)
             {
-                SendEmptyPacket(Flags.RST, packet.AckNumber);
+                SendEmptyPacket(TcpFlags.RST, packet.AckNumber);
                 Serial.WriteString("[TCP] Bad ACK received at SYN_SENT.\n");
             }
             else
@@ -609,7 +609,7 @@ internal class Tcp : IDisposable
             if (packet.AckNumber > TCB.SndNxt)
             {
                 Serial.WriteString("[TCP] ACK for unsent data, sending ACK\n");
-                SendEmptyPacket(Flags.ACK);
+                SendEmptyPacket(TcpFlags.ACK);
                 return;
             }
 
@@ -633,19 +633,19 @@ internal class Tcp : IDisposable
                     Serial.WriteString("[TCP] PSH+FIN received, closing\n");
                     TCB.RcvNxt++;
 
-                    SendEmptyPacket(Flags.ACK);
+                    SendEmptyPacket(TcpFlags.ACK);
 
                     Status = Status.CLOSE_WAIT;
 
                     SimpleWait(300);
 
-                    SendEmptyPacket(Flags.FIN);
+                    SendEmptyPacket(TcpFlags.FIN);
 
                     Status = Status.LAST_ACK;
                 }
                 else
                 {
-                    SendEmptyPacket(Flags.ACK);
+                    SendEmptyPacket(TcpFlags.ACK);
                 }
                 return;
             }
@@ -654,7 +654,7 @@ internal class Tcp : IDisposable
                 Serial.WriteString("[TCP] FIN received, closing connection\n");
                 TCB.RcvNxt++;
 
-                SendEmptyPacket(Flags.ACK);
+                SendEmptyPacket(TcpFlags.ACK);
 
                 WaitAndClose();
 
@@ -678,13 +678,13 @@ internal class Tcp : IDisposable
         {
             TCB.RcvNxt++;
 
-            SendEmptyPacket(Flags.ACK);
+            SendEmptyPacket(TcpFlags.ACK);
 
             Status = Status.CLOSE_WAIT;
 
             SimpleWait(300);
 
-            SendEmptyPacket(Flags.FIN);
+            SendEmptyPacket(TcpFlags.FIN);
 
             Status = Status.LAST_ACK;
         }
@@ -701,7 +701,7 @@ internal class Tcp : IDisposable
             {
                 TCB.RcvNxt++;
 
-                SendEmptyPacket(Flags.ACK);
+                SendEmptyPacket(TcpFlags.ACK);
 
                 WaitAndClose();
             }
@@ -714,7 +714,7 @@ internal class Tcp : IDisposable
         {
             TCB.RcvNxt++;
 
-            SendEmptyPacket(Flags.ACK);
+            SendEmptyPacket(TcpFlags.ACK);
 
             Status = Status.CLOSING;
         }
@@ -729,7 +729,7 @@ internal class Tcp : IDisposable
         {
             TCB.RcvNxt++;
 
-            SendEmptyPacket(Flags.ACK);
+            SendEmptyPacket(TcpFlags.ACK);
 
             WaitAndClose();
         }
@@ -835,7 +835,7 @@ internal class Tcp : IDisposable
     /// <summary>
     /// Sends an empty packet.
     /// </summary>
-    public void SendEmptyPacket(Flags flag)
+    public void SendEmptyPacket(TcpFlags flag)
     {
         SendPacket(new TcpPacket(LocalEndPoint.Address, RemoteEndPoint.Address, LocalEndPoint.Port, RemoteEndPoint.Port,
             TCB.SndNxt, TCB.RcvNxt, 20, (byte)flag, TCB.SndWnd, 0));
@@ -844,7 +844,7 @@ internal class Tcp : IDisposable
     /// <summary>
     /// Sends an empty packet.
     /// </summary>
-    internal void SendEmptyPacket(Flags flag, uint sequenceNumber)
+    internal void SendEmptyPacket(TcpFlags flag, uint sequenceNumber)
     {
         SendPacket(new TcpPacket(LocalEndPoint.Address, RemoteEndPoint.Address, LocalEndPoint.Port, RemoteEndPoint.Port,
             sequenceNumber, TCB.RcvNxt, 20, (byte)flag, TCB.SndWnd, 0));

--- a/src/Cosmos.Kernel.System/Network/IPv4/TCP/TcpPacket.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/TCP/TcpPacket.cs
@@ -5,61 +5,79 @@
 *                   Port of Cosmos Code.
 */
 
+using System.Diagnostics.CodeAnalysis;
 using Cosmos.Kernel.Core.IO;
 
 namespace Cosmos.Kernel.System.Network.IPv4.TCP;
 
 /// <summary>
-/// TCP Flags
+/// TCP header control flags, as defined by RFC 793.
 /// </summary>
 [Flags]
-internal enum Flags : byte
+[Experimental(Experimentals.PacketSeamDiagId)]
+public enum TcpFlags : byte
 {
     /// <summary>
-    /// No more data from sender.
+    /// FIN: no more data from sender.
     /// </summary>
     FIN = 1 << 0,
 
     /// <summary>
-    /// Synchronize sequence numbers.
+    /// SYN: synchronize sequence numbers.
     /// </summary>
     SYN = 1 << 1,
 
     /// <summary>
-    /// Reset the connection.
+    /// RST: reset the connection.
     /// </summary>
     RST = 1 << 2,
 
     /// <summary>
-    /// Push Function.
+    /// PSH: push function, deliver buffered data to the application.
     /// </summary>
     PSH = 1 << 3,
 
     /// <summary>
-    /// Acknowledgment field significant.
+    /// ACK: the acknowledgment number field is significant.
     /// </summary>
     ACK = 1 << 4,
 
     /// <summary>
-    /// Urgent Pointer field significant.
+    /// URG: the urgent pointer field is significant.
     /// </summary>
     URG = 1 << 5
 }
 
 /// <summary>
-/// TCP Option
+/// A TCP header option parsed from a received segment.
+/// Options are parse products only: the stack reads them from incoming segments but never serializes them into packets it builds.
 /// </summary>
-internal class TcpOption
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class TcpOption
 {
-    public byte Kind { get; set; }
-    public byte Length { get; set; }
-    public byte[]? Data { get; set; }
+    /// <summary>
+    /// Gets the option kind byte (for example 2 for Maximum Segment Size).
+    /// </summary>
+    public byte Kind { get; internal set; }
+
+    /// <summary>
+    /// Gets the total option length in bytes, including the kind and length bytes. Reads zero for options that carry no length byte.
+    /// </summary>
+    public byte Length { get; internal set; }
+
+    /// <summary>
+    /// Gets the option payload (the bytes after the kind and length bytes), or null when the option has no payload.
+    /// </summary>
+    public byte[]? Data { get; internal set; }
 }
 
 /// <summary>
-/// TCP Packet Class
+/// Represents a TCP segment carried in an <see cref="IPPacket"/>.
+/// Header properties are snapshots parsed from <see cref="EthernetPacket.RawData"/> at construction and are never recomputed; the checksum
+/// of a locally built segment is likewise computed once, in the constructor, so mutating the raw bytes afterwards leaves it stale.
 /// </summary>
-internal class TcpPacket : IPPacket
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class TcpPacket : IPPacket
 {
     /// <summary>
     /// TCP handler.
@@ -81,52 +99,69 @@ internal class TcpPacket : IPPacket
         }
     }
 
-    // /// <summary>
-    // /// Create new instance of the <see cref="TcpPacket"/> class.
-    // /// </summary>
-    // internal TcpPacket()
-    //     : base()
-    // { }
-
     /// <summary>
-    /// Create new instance of the <see cref="TcpPacket"/> class.
+    /// Creates a TCP packet from a received frame.
+    /// The array is aliased, not copied: the instance keeps a reference to <paramref name="rawData"/> and parses every header property from it once, during construction.
     /// </summary>
-    /// <param name="rawData">Raw data.</param>
+    /// <param name="rawData">Raw frame bytes containing the Ethernet, IPv4 and TCP headers followed by the payload.</param>
     public TcpPacket(byte[] rawData)
         : base(rawData)
     { }
 
     /// <summary>
-    /// Create new instance of the <see cref="TcpPacket"/> class.
+    /// Builds a TCP segment carrying <paramref name="data"/> as payload.
+    /// The header bytes and the TCP checksum are written into <see cref="EthernetPacket.RawData"/> here, in the constructor, and never recomputed.
     /// </summary>
+    /// <param name="source">Source IPv4 address.</param>
+    /// <param name="dest">Destination IPv4 address.</param>
+    /// <param name="srcPort">Source TCP port.</param>
+    /// <param name="destPort">Destination TCP port.</param>
+    /// <param name="sequenceNumber">Sequence number of the first payload byte.</param>
+    /// <param name="ackNumber">Acknowledgment number, the next sequence number expected from the peer.</param>
+    /// <param name="headerLength">TCP header length in bytes; the stack always passes 20, a header without options.</param>
+    /// <param name="flags">Flag bits for the header, a byte cast of combined <see cref="TcpFlags"/> values.</param>
+    /// <param name="windowSize">Receive window size to advertise.</param>
+    /// <param name="urgentPointer">Urgent pointer field value.</param>
+    /// <param name="data">Payload bytes, copied into the segment after the 20 byte header.</param>
     public TcpPacket(Address source, Address dest, ushort srcPort, ushort destPort,
-        ulong sequencenumber, ulong acknowledgmentnb, ushort Headerlenght, byte Flags,
-        ushort WSValue, ushort UrgentPointer, byte[] data)
+        uint sequenceNumber, uint ackNumber, ushort headerLength, byte flags,
+        ushort windowSize, ushort urgentPointer, byte[] data)
         : base((ushort)(20 + data.Length), 6, source, dest, 0x40)
     {
         AddRawData(data);
-        MakePacket(source, dest, srcPort, destPort, sequencenumber,
-        acknowledgmentnb, Headerlenght, Flags, WSValue, UrgentPointer);
+        MakePacket(source, dest, srcPort, destPort, sequenceNumber,
+        ackNumber, headerLength, flags, windowSize, urgentPointer);
     }
 
     /// <summary>
-    /// Create new instance of the <see cref="TcpPacket"/> class.
+    /// Builds an empty TCP segment (header only, no payload), used for control packets such as SYN, ACK and FIN.
+    /// The header bytes and the TCP checksum are written into <see cref="EthernetPacket.RawData"/> here, in the constructor, and never recomputed.
     /// </summary>
+    /// <param name="source">Source IPv4 address.</param>
+    /// <param name="dest">Destination IPv4 address.</param>
+    /// <param name="srcPort">Source TCP port.</param>
+    /// <param name="destPort">Destination TCP port.</param>
+    /// <param name="sequenceNumber">Sequence number for the segment.</param>
+    /// <param name="ackNumber">Acknowledgment number, the next sequence number expected from the peer.</param>
+    /// <param name="headerLength">TCP header length in bytes; the stack always passes 20, a header without options.</param>
+    /// <param name="flags">Flag bits for the header, a byte cast of combined <see cref="TcpFlags"/> values.</param>
+    /// <param name="windowSize">Receive window size to advertise.</param>
+    /// <param name="urgentPointer">Urgent pointer field value.</param>
     public TcpPacket(Address source, Address dest, ushort srcPort, ushort destPort,
-        ulong sequencenumber, ulong acknowledgmentnb, ushort Headerlenght, byte Flags,
-        ushort WSValue, ushort UrgentPointer)
+        uint sequenceNumber, uint ackNumber, ushort headerLength, byte flags,
+        ushort windowSize, ushort urgentPointer)
         : base(20, 6, source, dest, 0x40)
     {
-        MakePacket(source, dest, srcPort, destPort, sequencenumber,
-        acknowledgmentnb, Headerlenght, Flags, WSValue, UrgentPointer);
+        MakePacket(source, dest, srcPort, destPort, sequenceNumber,
+        ackNumber, headerLength, flags, windowSize, urgentPointer);
     }
 
     /// <summary>
     /// Make TCP Packet.
     /// </summary>
     private void MakePacket(Address source, Address dest, ushort srcPort, ushort destPort,
-        ulong sequencenumber, ulong acknowledgmentnb, ushort Headerlenght, byte Flags,
-        ushort WSValue, ushort UrgentPointer)
+        uint sequenceNumber, uint ackNumber, ushort headerLength, byte flags,
+        ushort windowSize, ushort urgentPointer)
     {
         //ports
         RawData[DataOffset + 0] = (byte)((srcPort >> 8) & 0xFF);
@@ -135,35 +170,35 @@ internal class TcpPacket : IPPacket
         RawData[DataOffset + 2] = (byte)((destPort >> 8) & 0xFF);
         RawData[DataOffset + 3] = (byte)((destPort >> 0) & 0xFF);
 
-        //sequencenumber
-        RawData[DataOffset + 4] = (byte)((sequencenumber >> 24) & 0xFF);
-        RawData[DataOffset + 5] = (byte)((sequencenumber >> 16) & 0xFF);
-        RawData[DataOffset + 6] = (byte)((sequencenumber >> 8) & 0xFF);
-        RawData[DataOffset + 7] = (byte)((sequencenumber >> 0) & 0xFF);
+        //sequence number
+        RawData[DataOffset + 4] = (byte)((sequenceNumber >> 24) & 0xFF);
+        RawData[DataOffset + 5] = (byte)((sequenceNumber >> 16) & 0xFF);
+        RawData[DataOffset + 6] = (byte)((sequenceNumber >> 8) & 0xFF);
+        RawData[DataOffset + 7] = (byte)((sequenceNumber >> 0) & 0xFF);
 
         //Acknowledgment number
-        RawData[DataOffset + 8] = (byte)((acknowledgmentnb >> 24) & 0xFF);
-        RawData[DataOffset + 9] = (byte)((acknowledgmentnb >> 16) & 0xFF);
-        RawData[DataOffset + 10] = (byte)((acknowledgmentnb >> 8) & 0xFF);
-        RawData[DataOffset + 11] = (byte)((acknowledgmentnb >> 0) & 0xFF);
+        RawData[DataOffset + 8] = (byte)((ackNumber >> 24) & 0xFF);
+        RawData[DataOffset + 9] = (byte)((ackNumber >> 16) & 0xFF);
+        RawData[DataOffset + 10] = (byte)((ackNumber >> 8) & 0xFF);
+        RawData[DataOffset + 11] = (byte)((ackNumber >> 0) & 0xFF);
 
-        //Header lenght
-        RawData[DataOffset + 12] = (byte)(((Headerlenght >> 0) & 0xFF) * 4);
+        //Header length
+        RawData[DataOffset + 12] = (byte)(((headerLength >> 0) & 0xFF) * 4);
 
         //Flags
-        RawData[DataOffset + 13] = (byte)((Flags >> 0) & 0xFF);
+        RawData[DataOffset + 13] = (byte)((flags >> 0) & 0xFF);
 
         //Window size value
-        RawData[DataOffset + 14] = (byte)((WSValue >> 8) & 0xFF);
-        RawData[DataOffset + 15] = (byte)((WSValue >> 0) & 0xFF);
+        RawData[DataOffset + 14] = (byte)((windowSize >> 8) & 0xFF);
+        RawData[DataOffset + 15] = (byte)((windowSize >> 0) & 0xFF);
 
         //Checksum
         RawData[DataOffset + 16] = 0;
         RawData[DataOffset + 17] = 0;
 
         //Urgent Pointer
-        RawData[DataOffset + 18] = (byte)((UrgentPointer >> 8) & 0xFF);
-        RawData[DataOffset + 19] = (byte)((UrgentPointer >> 0) & 0xFF);
+        RawData[DataOffset + 18] = (byte)((urgentPointer >> 8) & 0xFF);
+        RawData[DataOffset + 19] = (byte)((urgentPointer >> 0) & 0xFF);
 
         InitializeFields();
 
@@ -177,7 +212,8 @@ internal class TcpPacket : IPPacket
     }
 
     /// <summary>
-    /// Init TcpPacket fields.
+    /// Parses the TCP header fields from <see cref="EthernetPacket.RawData"/> into the header properties, and the header options into <see cref="Options"/> when the header is longer than 20 bytes.
+    /// Runs during construction; the properties are snapshots and do not track later changes to the raw bytes.
     /// </summary>
     protected override void InitializeFields()
     {
@@ -192,12 +228,12 @@ internal class TcpPacket : IPPacket
         Checksum = (ushort)((RawData[DataOffset + 16] << 8) | RawData[DataOffset + 17]);
         UrgentPointer = (ushort)((RawData[DataOffset + 18] << 8) | RawData[DataOffset + 19]);
 
-        _syn = (RawData[47] & (byte)Flags.SYN) != 0;
-        _ack = (RawData[47] & (byte)Flags.ACK) != 0;
-        _fin = (RawData[47] & (byte)Flags.FIN) != 0;
-        _psh = (RawData[47] & (byte)Flags.PSH) != 0;
-        _rst = (RawData[47] & (byte)Flags.RST) != 0;
-        _urg = (RawData[47] & (byte)Flags.URG) != 0;
+        _syn = (RawData[47] & (byte)TcpFlags.SYN) != 0;
+        _ack = (RawData[47] & (byte)TcpFlags.ACK) != 0;
+        _fin = (RawData[47] & (byte)TcpFlags.FIN) != 0;
+        _psh = (RawData[47] & (byte)TcpFlags.PSH) != 0;
+        _rst = (RawData[47] & (byte)TcpFlags.RST) != 0;
+        _urg = (RawData[47] & (byte)TcpFlags.URG) != 0;
 
         if (TCPHeaderLength > 20) //options
         {
@@ -290,9 +326,10 @@ internal class TcpPacket : IPPacket
     }
 
     /// <summary>
-    /// TCP Options
+    /// Gets the TCP options parsed from a received segment's header, or null when the header is 20 bytes and carries none.
+    /// Options are parse products only: they are never serialized into packets this stack builds.
     /// </summary>
-    public List<TcpOption>? Options { get; set; }
+    public List<TcpOption>? Options { get; internal set; }
 
     /// <summary>
     /// Is SYN Flag set.
@@ -320,44 +357,45 @@ internal class TcpPacket : IPPacket
     internal bool _urg;
 
     /// <summary>
-    /// Get destination port.
+    /// Gets the destination port, a snapshot parsed from the header at construction.
     /// </summary>
     public ushort DestinationPort { get; private set; }
     /// <summary>
-    /// Get source port.
+    /// Gets the source port, a snapshot parsed from the header at construction.
     /// </summary>
     public ushort SourcePort { get; private set; }
     /// <summary>
-    /// Get acknowledge number.
+    /// Gets the acknowledgment number, a snapshot parsed from the header at construction.
     /// </summary>
     public uint AckNumber { get; private set; }
     /// <summary>
-    /// Get sequence number.
+    /// Gets the sequence number, a snapshot parsed from the header at construction.
     /// </summary>
     public uint SequenceNumber { get; private set; }
     /// <summary>
-    /// Get TCP header length.
+    /// Gets the TCP header length in bytes, decoded from the data offset field at construction.
     /// </summary>
     public byte TCPHeaderLength { get; private set; }
     /// <summary>
-    /// Get TCP flags.
+    /// Gets the raw flag byte from the header, a snapshot taken at construction; see <see cref="TcpFlags"/> for the bit values.
     /// </summary>
     public byte TCPFlags { get; private set; }
     /// <summary>
-    /// Get window size.
+    /// Gets the advertised window size, a snapshot parsed from the header at construction.
     /// </summary>
     public ushort WindowSize { get; private set; }
     /// <summary>
-    /// Get checksum.
+    /// Gets the checksum field as parsed from the header at construction.
+    /// On locally built packets this reads zero: the computed checksum bytes are patched into <see cref="EthernetPacket.RawData"/> after the parse pass, so the snapshot never sees them.
     /// </summary>
     public ushort Checksum { get; private set; }
     /// <summary>
-    /// Get urgent pointer.
+    /// Gets the urgent pointer, a snapshot parsed from the header at construction.
     /// </summary>
     public ushort UrgentPointer { get; private set; }
 
     /// <summary>
-    /// Get TCP data length.
+    /// Gets the payload length in bytes: the IP total length minus the IP header length minus the TCP header length, computed from the header snapshots.
     /// </summary>
     public ushort TCP_DataLength => (ushort)(IPLength - HeaderLength - TCPHeaderLength);
 
@@ -380,8 +418,9 @@ internal class TcpPacket : IPPacket
     }
 
     /// <summary>
-    /// Get string representation of TCP flags.
+    /// Returns the names of the flags set on this segment, pipe separated (for example "SYN|ACK"), or an empty string when none are set.
     /// </summary>
+    /// <returns>The flag names joined with a pipe character.</returns>
     public string GetFlags()
     {
         string flags = "";
@@ -424,8 +463,9 @@ internal class TcpPacket : IPPacket
     }
 
     /// <summary>
-    /// To string.
+    /// Returns a string describing the segment: source and destination endpoints, flags, sequence number and acknowledgment number.
     /// </summary>
+    /// <returns>A human readable summary of the segment.</returns>
     public override string ToString()
     {
         return "TCP Packet " + SourceIP + ":" + SourcePort +

--- a/src/Cosmos.Kernel.System/Network/IPv4/UDP/DHCP/DhcpClient.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/UDP/DHCP/DhcpClient.cs
@@ -60,7 +60,7 @@ public class DhcpClient : UdpClient
 
         var packet = new DhcpPacket(_rxBuffer.Dequeue().RawData);
 
-        if (packet.MessageType == 2) //Boot Reply
+        if (packet.Operation == 2) //Boot Reply
         {
             if (packet.RawData[284] == 0x02) //Offer packet received
             {
@@ -188,10 +188,10 @@ public class DhcpClient : UdpClient
                     Serial.WriteString("[DHCP ACK] Packet received, applying IP configuration...\n");
                     Serial.WriteString("   IP Address  : " + packet.Client.ToString() + "\n");
                     Serial.WriteString("   Subnet mask : " + (packet.Subnet?.ToString() ?? "null") + "\n");
-                    Serial.WriteString("   Gateway     : " + (packet.Server?.ToString() ?? "null") + "\n");
+                    Serial.WriteString("   Gateway     : " + (packet.Gateway?.ToString() ?? "null") + "\n");
                     Serial.WriteString("   DNS server  : " + (packet.DNS?.ToString() ?? "null") + "\n");
 
-                    IPConfig.Enable(networkDevice, packet.Client, packet.Subnet ?? new Address(255, 255, 255, 0), packet.Server ?? Address.Zero);
+                    IPConfig.Enable(networkDevice, packet.Client, packet.Subnet ?? new Address(255, 255, 255, 0), packet.Gateway ?? Address.Zero);
                     if (packet.DNS != null)
                     {
                         DnsConfig.Add(packet.DNS);

--- a/src/Cosmos.Kernel.System/Network/IPv4/UDP/DHCP/DhcpDiscover.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/UDP/DHCP/DhcpDiscover.cs
@@ -6,25 +6,33 @@
 *                   Port of Cosmos Code.
 */
 
+using System.Diagnostics.CodeAnalysis;
 using Cosmos.Kernel.HAL.Devices.Network;
 
 namespace Cosmos.Kernel.System.Network.IPv4.UDP.DHCP;
 
 /// <summary>
-/// Represents a DHCP discovery packet.
+/// Represents a DHCPDISCOVER packet, broadcast to locate DHCP servers.
 /// </summary>
-internal class DhcpDiscover : DhcpPacket
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class DhcpDiscover : DhcpPacket
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="DhcpDiscover"/> class.
+    /// Initializes a new instance of the <see cref="DhcpDiscover"/> class from received data.
+    /// The packet aliases <paramref name="rawData"/> without copying.
     /// </summary>
-    internal DhcpDiscover(byte[] rawData) : base(rawData)
+    /// <param name="rawData">The raw Ethernet frame bytes, aliased rather than copied.</param>
+    public DhcpDiscover(byte[] rawData) : base(rawData)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DhcpDiscover"/> class.
+    /// Initializes a new instance of the <see cref="DhcpDiscover"/> class as a broadcast discover.
+    /// Writes DHCP option 53 (message type) with value 1, DHCPDISCOVER, then option 55, a parameter
+    /// request list asking for options 1 (subnet mask), 3 (router), 15 (domain name) and
+    /// 6 (domain name server), then the end mark.
     /// </summary>
-    internal DhcpDiscover(MACAddress sourceMAC) : base(sourceMAC, 10) //discover packet size
+    /// <param name="sourceMAC">The MAC address of the sending network device.</param>
+    public DhcpDiscover(MACAddress sourceMAC) : base(sourceMAC, 10) //discover packet size
     {
         //Discover
         RawData[282] = 0x35;

--- a/src/Cosmos.Kernel.System/Network/IPv4/UDP/DHCP/DhcpPacket.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/UDP/DHCP/DhcpPacket.cs
@@ -6,35 +6,41 @@
 *                   Port of Cosmos Code.
 */
 
+using System.Diagnostics.CodeAnalysis;
 using Cosmos.Kernel.HAL.Devices.Network;
 
 namespace Cosmos.Kernel.System.Network.IPv4.UDP.DHCP;
 
 /// <summary>
-/// Represents a DHCP option.
+/// Represents a single DHCP option parsed from the options section of a <see cref="DhcpPacket"/>.
 /// </summary>
-internal class DhcpOption
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class DhcpOption
 {
     /// <summary>
-    /// The type of the <see cref="DhcpOption"/>.
+    /// Gets the DHCP option code, for example 1 for subnet mask, 3 for router, 6 for domain name server.
     /// </summary>
     public required byte Type { get; init; }
 
     /// <summary>
-    /// The length of the <see cref="DhcpOption"/>.
+    /// Gets the length in bytes of the option payload, computed from <see cref="Data"/>.
     /// </summary>
     public byte Length => (byte)Data.Length;
 
     /// <summary>
-    /// The raw data of the <see cref="DhcpOption"/>.
+    /// Gets the raw option payload, without the option code and length bytes.
     /// </summary>
     public required byte[] Data { get; init; }
 }
 
 /// <summary>
-/// Represents a DHCP packet.
+/// Represents a DHCP packet carried over UDP (BOOTP client port 68, server port 67).
+/// Header properties are snapshots parsed from <see cref="EthernetPacket.RawData"/> at construction
+/// and are not re-read afterwards; checksums and lengths are computed in the constructors and never
+/// recomputed.
 /// </summary>
-internal class DhcpPacket : UdpPacket
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class DhcpPacket : UdpPacket
 {
     // Simple transaction ID generator
     private static int s_idCounter = 1;
@@ -42,7 +48,7 @@ internal class DhcpPacket : UdpPacket
     /// <summary>
     /// Handles a single DHCP packet.
     /// </summary>
-    public static void DHCPHandler(byte[] packetData)
+    internal static void DHCPHandler(byte[] packetData)
     {
         var dhcpPacket = new DhcpPacket(packetData);
 
@@ -51,23 +57,37 @@ internal class DhcpPacket : UdpPacket
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DhcpPacket"/> class.
+    /// Initializes a new instance of the <see cref="DhcpPacket"/> class from received data.
+    /// The packet aliases <paramref name="rawData"/> without copying, and all header properties
+    /// are parsed from it once, during construction.
     /// </summary>
+    /// <param name="rawData">The raw Ethernet frame bytes, aliased rather than copied.</param>
     public DhcpPacket(byte[] rawData)
         : base(rawData)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DhcpPacket"/> class.
+    /// Initializes a new instance of the <see cref="DhcpPacket"/> class as a broadcast request,
+    /// sent from 0.0.0.0 to 255.255.255.255 (the form used by discover and request packets).
     /// </summary>
-    internal DhcpPacket(MACAddress mac_src, ushort dhcpDataSize)
+    /// <param name="mac_src">The MAC address of the sending network device.</param>
+    /// <param name="dhcpDataSize">The size in bytes of the DHCP options that follow the fixed BOOTP header.</param>
+    public DhcpPacket(MACAddress mac_src, ushort dhcpDataSize)
         : this(Address.Zero, Address.Broadcast, mac_src, dhcpDataSize)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DhcpPacket"/> class.
+    /// Initializes a new instance of the <see cref="DhcpPacket"/> class addressed from
+    /// <paramref name="client"/> to <paramref name="server"/>. Writes the fixed BOOTP header:
+    /// op 1 (request), hardware type Ethernet, a fresh transaction identifier, the client address
+    /// in ciaddr, the source MAC in chaddr and the DHCP magic cookie. Checksums and lengths are
+    /// computed here, in the constructor chain, and never recomputed.
     /// </summary>
-    internal DhcpPacket(Address client, Address server, MACAddress sourceMAC, ushort dhcpDataSize)
+    /// <param name="client">The IPv4 source address, also written to the ciaddr field.</param>
+    /// <param name="server">The IPv4 destination address.</param>
+    /// <param name="sourceMAC">The MAC address of the sending network device.</param>
+    /// <param name="dhcpDataSize">The size in bytes of the DHCP options that follow the fixed BOOTP header.</param>
+    public DhcpPacket(Address client, Address server, MACAddress sourceMAC, ushort dhcpDataSize)
         : base(client, server, 68, 67, (ushort)(dhcpDataSize + 240), MACAddress.Broadcast)
     {
         RawData[42] = 0x01; // Request
@@ -124,12 +144,14 @@ internal class DhcpPacket : UdpPacket
     }
 
     /// <summary>
-    /// Init DhcpPacket fields.
+    /// Parses the BOOTP op field, the yiaddr client address and the DHCP options from
+    /// <see cref="EthernetPacket.RawData"/>. Called once during construction; the resulting
+    /// property values are snapshots that are not updated afterwards.
     /// </summary>
     protected override void InitializeFields()
     {
         base.InitializeFields();
-        MessageType = RawData[42];
+        Operation = RawData[42];
 
         if (RawData[58] != 0)
         {
@@ -164,7 +186,7 @@ internal class DhcpPacket : UdpPacket
                 }
                 else if (option.Type == 3) //Router
                 {
-                    Server = new Address(option.Data, 0);
+                    Gateway = new Address(option.Data, 0);
                 }
                 else if (option.Type == 6) //DNS
                 {
@@ -175,32 +197,39 @@ internal class DhcpPacket : UdpPacket
     }
 
     /// <summary>
-    /// Gets the DHCP message type.
+    /// Gets the BOOTP op field at offset 42 of the frame: 1 for a request, 2 for a reply.
+    /// This is not the DHCP message type (option 53), which lives in the options section.
+    /// A snapshot parsed at construction.
     /// </summary>
-    internal byte MessageType { get; private set; }
+    public byte Operation { get; private set; }
 
     /// <summary>
-    /// Gets the client IPv4 address.
+    /// Gets the client IPv4 address parsed from the BOOTP yiaddr field, or null when the first
+    /// byte of yiaddr is zero. A snapshot parsed at construction.
     /// </summary>
-    internal Address? Client { get; private set; }
+    public Address? Client { get; private set; }
 
     /// <summary>
-    /// Gets the DHCP options.
+    /// Gets the DHCP options parsed from the options section, or null when the section is empty.
+    /// A snapshot parsed at construction.
     /// </summary>
-    internal List<DhcpOption>? Options { get; private set; }
+    public List<DhcpOption>? Options { get; private set; }
 
     /// <summary>
-    /// Get Subnet IPv4 Address
+    /// Gets the subnet mask parsed from DHCP option 1, or null when the option is absent.
+    /// A snapshot parsed at construction.
     /// </summary>
-    internal Address? Subnet { get; private set; }
+    public Address? Subnet { get; private set; }
 
     /// <summary>
-    /// Get DNS IPv4 Address
+    /// Gets the first domain name server parsed from DHCP option 6, or null when the option is
+    /// absent; any additional servers in the option are discarded. A snapshot parsed at construction.
     /// </summary>
-    internal Address? DNS { get; private set; }
+    public Address? DNS { get; private set; }
 
     /// <summary>
-    /// Get DHCP Server IPv4 Address
+    /// Gets the gateway address parsed from DHCP option 3 (Router), or null when the option is
+    /// absent. A snapshot parsed at construction.
     /// </summary>
-    internal Address? Server { get; private set; }
+    public Address? Gateway { get; private set; }
 }

--- a/src/Cosmos.Kernel.System/Network/IPv4/UDP/DHCP/DhcpRelease.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/UDP/DHCP/DhcpRelease.cs
@@ -6,25 +6,36 @@
 *                   Port of Cosmos Code.
 */
 
+using System.Diagnostics.CodeAnalysis;
 using Cosmos.Kernel.HAL.Devices.Network;
 
 namespace Cosmos.Kernel.System.Network.IPv4.UDP.DHCP;
 
 /// <summary>
-/// Represents a DHCP release packet.
+/// Represents a DHCPRELEASE packet, sent to give an assigned address back to the server.
 /// </summary>
-internal class DhcpRelease : DhcpPacket
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class DhcpRelease : DhcpPacket
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="DhcpRelease"/> class.
+    /// Initializes a new instance of the <see cref="DhcpRelease"/> class from received data.
+    /// The packet aliases <paramref name="rawData"/> without copying.
     /// </summary>
-    internal DhcpRelease(byte[] rawData) : base(rawData)
+    /// <param name="rawData">The raw Ethernet frame bytes, aliased rather than copied.</param>
+    public DhcpRelease(byte[] rawData) : base(rawData)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DhcpRelease"/> class.
+    /// Initializes a new instance of the <see cref="DhcpRelease"/> class, addressed to the DHCP
+    /// server's unicast IP address rather than broadcast. Writes DHCP option 53 (message type)
+    /// with value 7, DHCPRELEASE, then option 54 (server identifier) carrying
+    /// <paramref name="server"/>, then option 61 (client identifier) carrying the Ethernet
+    /// hardware type and <paramref name="source"/>, then the end mark.
     /// </summary>
-    internal DhcpRelease(Address client, Address server, MACAddress source) : base(client, server, source, 19)
+    /// <param name="client">The client's currently assigned IPv4 address, used as the source.</param>
+    /// <param name="server">The DHCP server's IPv4 address, used as the destination and written to option 54.</param>
+    /// <param name="source">The MAC address of the sending network device, written to option 61.</param>
+    public DhcpRelease(Address client, Address server, MACAddress source) : base(client, server, source, 19)
     {
         //Release
         RawData[282] = 0x35;

--- a/src/Cosmos.Kernel.System/Network/IPv4/UDP/DHCP/DhcpRequest.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/UDP/DHCP/DhcpRequest.cs
@@ -6,25 +6,35 @@
 *                   Port of Cosmos Code.
 */
 
+using System.Diagnostics.CodeAnalysis;
 using Cosmos.Kernel.HAL.Devices.Network;
 
 namespace Cosmos.Kernel.System.Network.IPv4.UDP.DHCP;
 
 /// <summary>
-/// Represents a DHCP request packet.
+/// Represents a DHCPREQUEST packet, broadcast to request a previously offered address.
 /// </summary>
-internal class DhcpRequest : DhcpPacket
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class DhcpRequest : DhcpPacket
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="DhcpRequest"/> class.
+    /// Initializes a new instance of the <see cref="DhcpRequest"/> class from received data.
+    /// The packet aliases <paramref name="rawData"/> without copying.
     /// </summary>
-    internal DhcpRequest(byte[] rawData) : base(rawData)
+    /// <param name="rawData">The raw Ethernet frame bytes, aliased rather than copied.</param>
+    public DhcpRequest(byte[] rawData) : base(rawData)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DhcpRequest"/> class.
+    /// Initializes a new instance of the <see cref="DhcpRequest"/> class as a broadcast request.
+    /// Writes DHCP option 53 (message type) with value 3, DHCPREQUEST, then option 50 carrying
+    /// <paramref name="requestedAddress"/>, then option 55, a parameter request list asking for
+    /// options 1 (subnet mask), 3 (router), 15 (domain name) and 6 (domain name server), then
+    /// the end mark.
     /// </summary>
-    internal DhcpRequest(MACAddress sourceMAC, Address requestedAddress) : base(sourceMAC, 16)
+    /// <param name="sourceMAC">The MAC address of the sending network device.</param>
+    /// <param name="requestedAddress">The IPv4 address to request, written to option 50.</param>
+    public DhcpRequest(MACAddress sourceMAC, Address requestedAddress) : base(sourceMAC, 16)
     {
         // Request
         RawData[282] = 53;

--- a/src/Cosmos.Kernel.System/Network/IPv4/UDP/DNS/DnsPacket.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/UDP/DNS/DnsPacket.cs
@@ -5,22 +5,48 @@
 *                   Port of Cosmos Code.
 */
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.System.Network;
 
 namespace Cosmos.Kernel.System.Network.IPv4.UDP.DNS;
 
 /// <summary>
-/// ReplyCode set in Flags
+/// DNS reply codes (RCODE), carried in the lower four bits of the DNS header flags (RFC 1035).
 /// </summary>
-internal enum ReplyCode
+[Experimental(Experimentals.PacketSeamDiagId)]
+public enum ReplyCode
 {
-    OK = 0000,
-    FormatError = 0001,
-    ServerFailure = 0010,
-    NameError = 0011,
-    NotSupported = 0100,
-    Refused = 0101
+    /// <summary>
+    /// No error condition.
+    /// </summary>
+    OK = 0,
+
+    /// <summary>
+    /// The server was unable to interpret the query.
+    /// </summary>
+    FormatError = 1,
+
+    /// <summary>
+    /// The server failed to process the query.
+    /// </summary>
+    ServerFailure = 2,
+
+    /// <summary>
+    /// The domain name referenced in the query does not exist (NXDOMAIN).
+    /// </summary>
+    NameError = 3,
+
+    /// <summary>
+    /// The server does not support the requested kind of query.
+    /// </summary>
+    NotSupported = 4,
+
+    /// <summary>
+    /// The server refuses to perform the requested operation.
+    /// </summary>
+    Refused = 5
 }
 
 /// <summary>
@@ -33,34 +59,87 @@ internal static class DnsRecordType
 }
 
 /// <summary>
-/// Represents a DNS query.
+/// A DNS question parsed from the question section of a response. Instances are parse products
+/// created by <see cref="DnsPacketAnswer"/>, not builder inputs.
 /// </summary>
-internal class DnsQuery
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class DnsQuery
 {
-    public string? Name { get; set; }
-    public ushort Type { get; set; }
-    public ushort Class { get; set; }
+    /// <summary>
+    /// The queried domain name, read label by label from the question section without following
+    /// compression pointers.
+    /// </summary>
+    public string? Name { get; internal set; }
+
+    /// <summary>
+    /// The 16-bit question type (QTYPE), for example 1 for an A record.
+    /// </summary>
+    public ushort Type { get; internal set; }
+
+    /// <summary>
+    /// The 16-bit question class (QCLASS), 1 for the Internet class.
+    /// </summary>
+    public ushort Class { get; internal set; }
 }
 
 /// <summary>
-/// Represents a DNS answer (response).
+/// A DNS resource record parsed from the answer section of a response. Instances are parse products
+/// created by <see cref="DnsPacketAnswer"/>, not builder inputs.
 /// </summary>
-internal class DnsAnswer
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class DnsAnswer
 {
-    public ushort Name { get; set; }
-    public string? ResolvedName { get; set; }
-    public ushort Type { get; set; }
-    public ushort Class { get; set; }
-    public int TimeToLive { get; set; }
-    public ushort DataLength { get; set; }
-    public byte[]? Address { get; set; }
-    public string? CanonicalName { get; set; }
+    /// <summary>
+    /// The raw 16-bit NAME field exactly as read from the record, usually a compression pointer
+    /// (top two bits set) rather than a name.
+    /// </summary>
+    public ushort Name { get; internal set; }
+
+    /// <summary>
+    /// The domain name obtained by following the compression pointer in <see cref="Name"/>, or null
+    /// when the NAME field is not a compression pointer (inline names are not resolved).
+    /// </summary>
+    public string? ResolvedName { get; internal set; }
+
+    /// <summary>
+    /// The 16-bit record type (TYPE), for example 1 for A and 5 for CNAME.
+    /// </summary>
+    public ushort Type { get; internal set; }
+
+    /// <summary>
+    /// The 16-bit record class (CLASS), 1 for the Internet class.
+    /// </summary>
+    public ushort Class { get; internal set; }
+
+    /// <summary>
+    /// The record's time to live in seconds, read as a signed 32-bit value.
+    /// </summary>
+    public int TimeToLive { get; internal set; }
+
+    /// <summary>
+    /// The length in bytes of the record data (RDLENGTH).
+    /// </summary>
+    public ushort DataLength { get; internal set; }
+
+    /// <summary>
+    /// The raw RDATA bytes of the record: the four address bytes for an A record, but the encoded
+    /// (possibly compressed) name bytes for a CNAME record.
+    /// </summary>
+    public byte[]? Address { get; internal set; }
+
+    /// <summary>
+    /// The decompressed CNAME target, set only for CNAME records; null for every other record type.
+    /// </summary>
+    public string? CanonicalName { get; internal set; }
 }
 
 /// <summary>
-/// Represents a DNS packet.
+/// Represents a DNS message carried over UDP (RFC 1035). The DNS header fields (transaction ID,
+/// flags and section counts) are snapshots parsed from the raw buffer at construction and are never
+/// recomputed.
 /// </summary>
-internal class DnsPacket : UdpPacket
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class DnsPacket : UdpPacket
 {
     // Simple transaction ID generator
     private static byte s_transactionCounter = 1;
@@ -75,23 +154,26 @@ internal class DnsPacket : UdpPacket
         receiver?.ReceiveData(dnsPacket);
     }
 
-    // /// <summary>
-    // /// Initializes a new instance of the <see cref="DnsPacket"/> class.
-    // /// </summary>
-    // internal DnsPacket()
-    //     : base()
-    // { }
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="DnsPacket"/> class.
+    /// Parses a DNS packet from a received frame. The buffer is aliased without copying, so later
+    /// changes to <paramref name="rawData"/> are visible through the packet.
     /// </summary>
+    /// <param name="rawData">The complete Ethernet frame containing the DNS message.</param>
     public DnsPacket(byte[] rawData)
         : base(rawData)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DnsPacket"/> class.
+    /// Composes the UDP and DNS headers of a query between ports 53: a transaction ID taken from a
+    /// static 8-bit counter (only the low byte is ever populated), flags 0x0100 (recursion desired),
+    /// <paramref name="urlnb"/> questions and zero answer, authority and additional records. The
+    /// question section itself is written by subclasses. Lengths and checksums are computed by the
+    /// base constructors at construction and never recomputed.
     /// </summary>
+    /// <param name="source">The source IPv4 address.</param>
+    /// <param name="dest">The destination IPv4 address (the DNS server).</param>
+    /// <param name="urlnb">The number of questions announced in the header.</param>
+    /// <param name="len">The length in bytes of the DNS payload following the 12-byte DNS header.</param>
     public DnsPacket(Address source, Address dest, ushort urlnb, ushort len)
         : base(source, dest, 53, 53, (ushort)(len + 12))
     {
@@ -117,6 +199,10 @@ internal class DnsPacket : UdpPacket
         InitializeFields();
     }
 
+    /// <summary>
+    /// Parses the UDP fields, then captures the DNS header snapshot: transaction ID, flags and the
+    /// question, answer, authority and additional record counts.
+    /// </summary>
     protected override void InitializeFields()
     {
         base.InitializeFields();
@@ -132,7 +218,7 @@ internal class DnsPacket : UdpPacket
     /// Gets the domain name at the given offset. Does not follow compression
     /// pointers - use <see cref="ParseNameAt"/> for those.
     /// </summary>
-    public string ParseName(byte[] rawData, ref int index)
+    internal string ParseName(byte[] rawData, ref int index)
     {
         var url = new StringBuilder();
 
@@ -157,8 +243,14 @@ internal class DnsPacket : UdpPacket
     }
 
     /// <summary>
-    /// Decompresses a domain name at <paramref name="startIndex"/> per RFC 1035 pointers.
+    /// Reads a domain name starting at <paramref name="startIndex"/>, following RFC 1035 compression
+    /// pointers relative to <paramref name="messageBase"/>. Pointer chains are capped at 16 jumps to
+    /// avoid loops.
     /// </summary>
+    /// <param name="rawData">The buffer containing the DNS message.</param>
+    /// <param name="startIndex">The index of the first name byte.</param>
+    /// <param name="messageBase">The index of the first byte of the DNS header, used to resolve pointer offsets.</param>
+    /// <returns>The dotted domain name without a trailing dot, or an empty string when no labels are present.</returns>
     protected static string ParseNameAt(byte[] rawData, int startIndex, int messageBase)
     {
         StringBuilder sb = new();
@@ -205,8 +297,12 @@ internal class DnsPacket : UdpPacket
     }
 
     /// <summary>
-    /// Resolves an RR's NAME field, assuming it's a compression pointer.
+    /// Resolves a resource record's NAME field when it is a compression pointer.
     /// </summary>
+    /// <param name="nameField">The raw 16-bit NAME field of the record.</param>
+    /// <param name="rawData">The buffer containing the DNS message.</param>
+    /// <param name="messageBase">The index of the first byte of the DNS header.</param>
+    /// <returns>The decompressed name, or null when the field is not a compression pointer (inline names are not handled).</returns>
     protected static string? ResolveRRName(ushort nameField, byte[] rawData, int messageBase)
     {
         if ((nameField & 0xC000) != 0xC000)
@@ -220,45 +316,50 @@ internal class DnsPacket : UdpPacket
     }
 
     /// <summary>
-    /// The amount of answer Resource Records.
+    /// The number of answer resource records announced in the header, parsed at construction.
     /// </summary>
-    internal ushort AnswerRRs { get; private set; }
+    public ushort AnswerRRs { get; private set; }
 
     /// <summary>
-    /// The amount of authority Resource Records.
+    /// The number of authority resource records announced in the header, parsed at construction.
     /// </summary>
-    internal ushort AuthorityRRs { get; private set; }
+    public ushort AuthorityRRs { get; private set; }
 
     /// <summary>
-    /// The amount of additional Resource Records.
+    /// The number of additional resource records announced in the header, parsed at construction.
     /// </summary>
-    internal ushort AdditionalRRs { get; private set; }
+    public ushort AdditionalRRs { get; private set; }
 
     /// <summary>
-    /// The DNS transaction ID.
+    /// The 16-bit DNS transaction ID, parsed at construction. Packets built by this stack only ever
+    /// populate the low byte, from a static 8-bit counter.
     /// </summary>
-    internal ushort TransactionID { get; private set; }
+    public ushort TransactionID { get; private set; }
 
     /// <summary>
-    /// The flags of the packet.
+    /// The 16-bit DNS header flags, parsed at construction. The lower four bits of a response hold
+    /// its <see cref="ReplyCode"/>.
     /// </summary>
-    internal ushort DNSFlags { get; private set; }
+    public ushort DNSFlags { get; private set; }
 
     /// <summary>
-    /// The number of DNS queries.
+    /// The number of questions announced in the header, parsed at construction.
     /// </summary>
-    internal ushort Questions { get; private set; }
+    public ushort Questions { get; private set; }
 
     /// <summary>
-    /// The DNS queries.
+    /// The parsed question section. Populated only by the parsing subtypes
+    /// (<see cref="DnsPacketAnswer"/>); null otherwise.
     /// </summary>
-    internal List<DnsQuery>? Queries { get; set; }
+    public List<DnsQuery>? Queries { get; internal set; }
 
     /// <summary>
-    /// The DNS answers (responses).
+    /// The parsed answer section. Populated only by the parsing subtypes
+    /// (<see cref="DnsPacketAnswer"/>); null otherwise.
     /// </summary>
-    internal List<DnsAnswer>? Answers { get; set; }
+    public List<DnsAnswer>? Answers { get; internal set; }
 
+    /// <inheritdoc/>
     public override string ToString()
     {
         return "DNS Packet Src=" + SourceIP + ":" + SourcePort + ", Dest=" + DestinationIP + ":" + DestinationPort;
@@ -266,27 +367,27 @@ internal class DnsPacket : UdpPacket
 }
 
 /// <summary>
-/// Represents a DNS translation request packet.
+/// A DNS query packet that composes a single A/IN question for a given domain name.
 /// </summary>
-internal class DnsPacketAsk : DnsPacket
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class DnsPacketAsk : DnsPacket
 {
-    // /// <summary>
-    // /// Initializes a new instance of the <see cref="DnsPacketAsk"/> class.
-    // /// </summary>
-    // internal DnsPacketAsk()
-    //     : base()
-    // { }
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="DnsPacketAsk"/> class.
+    /// Parses a DNS query packet from a received frame. The buffer is aliased without copying.
     /// </summary>
+    /// <param name="rawData">The complete Ethernet frame containing the DNS message.</param>
     public DnsPacketAsk(byte[] rawData)
         : base(rawData)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DnsPacketAsk"/> class.
+    /// Composes a query with a single A/IN question for <paramref name="url"/>: the name is written
+    /// as length-prefixed labels followed by QTYPE 1 (A) and QCLASS 1 (IN). Lengths and checksums
+    /// are computed by the base constructors at construction and never recomputed.
     /// </summary>
+    /// <param name="source">The source IPv4 address.</param>
+    /// <param name="dest">The destination IPv4 address (the DNS server).</param>
+    /// <param name="url">The domain name to resolve.</param>
     public DnsPacketAsk(Address source, Address dest, string url)
         : base(source, dest, 1, (ushort)(url.Length + url.Split('.').Length + 1 + 4))
     {
@@ -318,17 +419,28 @@ internal class DnsPacketAsk : DnsPacket
 }
 
 /// <summary>
-/// Represents a DNS translation result packet.
+/// A DNS response packet. The full parse (header counts, question and answer sections, and
+/// compression-pointer resolution) runs inside the constructor.
 /// </summary>
-internal class DnsPacketAnswer : DnsPacket
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class DnsPacketAnswer : DnsPacket
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="DnsPacketAnswer"/> class.
+    /// Parses a DNS response from a received frame. The buffer is aliased without copying. The whole
+    /// message is parsed during construction: header counts, the question and answer sections, and
+    /// compression pointers; malformed input throws (typically <see cref="IndexOutOfRangeException"/>).
+    /// When the reply code is not <see cref="ReplyCode.OK"/>, section parsing is skipped and
+    /// <see cref="DnsPacket.Queries"/> and <see cref="DnsPacket.Answers"/> stay null.
     /// </summary>
+    /// <param name="rawData">The complete Ethernet frame containing the DNS message.</param>
     public DnsPacketAnswer(byte[] rawData)
         : base(rawData)
     { }
 
+    /// <summary>
+    /// Parses the DNS header, then the question and answer sections, resolving compressed names.
+    /// Skips section parsing when the reply code is not <see cref="ReplyCode.OK"/>.
+    /// </summary>
     protected override void InitializeFields()
     {
         base.InitializeFields();

--- a/src/Cosmos.Kernel.System/Network/IPv4/UDP/UdpClient.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/UDP/UdpClient.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics.CodeAnalysis;
 using Cosmos.Kernel.Core.IO;
 using Cosmos.Kernel.System.Network.Config;
+using Cosmos.Kernel.System.Timer;
 
 namespace Cosmos.Kernel.System.Network.IPv4.UDP;
 
@@ -168,6 +170,17 @@ public class UdpClient : IDisposable
     }
 
     /// <summary>
+    /// Transmits a prebuilt UDP packet through the stack's outgoing queue, including ARP
+    /// resolution of the destination MAC address when it is not already known.
+    /// </summary>
+    /// <param name="packet">The packet to transmit.</param>
+    /// <returns><see langword="true"/> when the packet was queued for transmission;
+    /// <see langword="false"/> when no configured network interface matches the packet's
+    /// source address.</returns>
+    [Experimental(Experimentals.PacketSeamDiagId)]
+    public bool Send(UdpPacket packet) => Cosmos.Kernel.System.Network.NetworkStack.Send(packet);
+
+    /// <summary>
     /// Receives data from the given end-point (non-blocking).
     /// </summary>
     /// <param name="source">The source end point.</param>
@@ -201,6 +214,35 @@ public class UdpClient : IDisposable
         source.Port = packet.SourcePort;
 
         return packet.UDPData;
+    }
+
+    /// <summary>
+    /// Waits for a datagram to arrive on this client's local port and returns the parsed
+    /// <see cref="UdpPacket"/> itself, without re-parsing. Unlike
+    /// <see cref="NonBlockingReceive"/> and <see cref="Receive"/>, which return the payload
+    /// bytes alone, the returned packet exposes the ports, the source and destination
+    /// addresses, and the payload. Polls the receive buffer in 10 millisecond slices.
+    /// </summary>
+    /// <param name="timeoutMs">Maximum time to wait in milliseconds; a non-positive value
+    /// checks the receive buffer once without waiting.</param>
+    /// <returns>The dequeued packet, or <see langword="null"/> when the timeout elapses with
+    /// no datagram queued.</returns>
+    [Experimental(Experimentals.PacketSeamDiagId)]
+    public UdpPacket? ReceivePacket(int timeoutMs = 5000)
+    {
+        int waited = 0;
+        while (_rxBuffer.Count < 1 && waited < timeoutMs)
+        {
+            TimerManager.Wait(10);
+            waited += 10;
+        }
+
+        if (_rxBuffer.Count < 1)
+        {
+            return null;
+        }
+
+        return _rxBuffer.Dequeue();
     }
 
     /// <summary>

--- a/src/Cosmos.Kernel.System/Network/IPv4/UDP/UdpPacket.cs
+++ b/src/Cosmos.Kernel.System/Network/IPv4/UDP/UdpPacket.cs
@@ -1,4 +1,5 @@
-﻿using Cosmos.Kernel.Core.IO;
+﻿using System.Diagnostics.CodeAnalysis;
+using Cosmos.Kernel.Core.IO;
 using Cosmos.Kernel.HAL.Devices.Network;
 using Cosmos.Kernel.System.Network.IPv4.UDP.DHCP;
 using Cosmos.Kernel.System.Network.IPv4.UDP.DNS;
@@ -11,16 +12,18 @@ namespace Cosmos.Kernel.System.Network.IPv4.UDP;
 internal delegate void UdpDataReceivedHandler(UdpPacket packet);
 
 /// <summary>
-/// Represents a UDP packet.
+/// Represents a UDP datagram carried in an <see cref="IPPacket"/>. Header properties are
+/// snapshots parsed from <see cref="EthernetPacket.RawData"/> when the packet is constructed;
+/// they are not re-read afterwards. The UDP checksum field is written as zero and never
+/// computed, which is legal for UDP over IPv4.
 /// </summary>
-internal class UdpPacket : IPPacket
+[Experimental(Experimentals.PacketSeamDiagId)]
+public class UdpPacket : IPPacket
 {
-    private ushort _udpCRC;
-
     /// <summary>
     /// Callback for receiving UDP data.
     /// </summary>
-    public static UdpDataReceivedHandler? OnUDPDataReceived { get; set; }
+    internal static UdpDataReceivedHandler? OnUDPDataReceived { get; set; }
 
     /// <summary>
     /// Handles UDP packets.
@@ -64,14 +67,28 @@ internal class UdpPacket : IPPacket
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="UdpPacket"/> class.
+    /// Parses a UDP packet from a raw Ethernet frame. The instance aliases
+    /// <paramref name="rawData"/> without copying, so later changes to the array are visible
+    /// through this packet. Header properties are parsed once during construction.
     /// </summary>
-    /// <param name="rawData">The raw data.</param>
+    /// <param name="rawData">The raw frame bytes, starting at the Ethernet header.</param>
     public UdpPacket(byte[] rawData)
         : base(rawData)
     {
     }
 
+    /// <summary>
+    /// Creates a UDP packet with an uninitialized payload area of
+    /// <paramref name="datalength"/> bytes. The Ethernet, IP, and UDP headers, including all
+    /// length fields and the IP header checksum, are written during construction and never
+    /// recomputed, so the payload must be filled in before the packet is sent. The UDP
+    /// checksum is written as zero and never computed, which is legal for UDP over IPv4.
+    /// </summary>
+    /// <param name="source">The source IPv4 address.</param>
+    /// <param name="dest">The destination IPv4 address.</param>
+    /// <param name="srcport">The source port.</param>
+    /// <param name="destport">The destination port.</param>
+    /// <param name="datalength">The payload length in bytes.</param>
     public UdpPacket(Address source, Address dest, ushort srcport, ushort destport, ushort datalength)
         : base((ushort)(datalength + 8), 17, source, dest, 0x00)
     {
@@ -79,6 +96,19 @@ internal class UdpPacket : IPPacket
         InitializeFields();
     }
 
+    /// <summary>
+    /// Creates a UDP packet with an uninitialized payload area of
+    /// <paramref name="datalength"/> bytes and a preset destination MAC address, bypassing ARP
+    /// resolution. Headers, length fields, and the IP header checksum are written during
+    /// construction and never recomputed. The UDP checksum is written as zero and never
+    /// computed, which is legal for UDP over IPv4.
+    /// </summary>
+    /// <param name="source">The source IPv4 address.</param>
+    /// <param name="dest">The destination IPv4 address.</param>
+    /// <param name="srcport">The source port.</param>
+    /// <param name="destport">The destination port.</param>
+    /// <param name="datalength">The payload length in bytes.</param>
+    /// <param name="destmac">The destination MAC address to write into the Ethernet header.</param>
     public UdpPacket(Address source, Address dest, ushort srcport, ushort destport, ushort datalength, MACAddress destmac)
         : base((ushort)(datalength + 8), 17, source, dest, 0x00, destmac)
     {
@@ -87,15 +117,16 @@ internal class UdpPacket : IPPacket
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="UdpPacket"/> class.
+    /// Creates a UDP packet and copies <paramref name="data"/> into its payload area. Headers,
+    /// length fields, and the IP header checksum are written during construction and never
+    /// recomputed. The UDP checksum is written as zero and never computed, which is legal for
+    /// UDP over IPv4.
     /// </summary>
-    /// <param name="source">The source address.</param>
-    /// <param name="dest">The destination address.</param>
+    /// <param name="source">The source IPv4 address.</param>
+    /// <param name="dest">The destination IPv4 address.</param>
     /// <param name="srcPort">The source port.</param>
     /// <param name="destPort">The destination port.</param>
-    /// <param name="data">The data array.</param>
-    /// <exception cref="OverflowException">Thrown if data array length is greater than Int32.MaxValue.</exception>
-    /// <exception cref="ArgumentException">Thrown if RawData is invalid or null.</exception>
+    /// <param name="data">The payload bytes to copy into the packet.</param>
     public UdpPacket(Address source, Address dest, ushort srcPort, ushort destPort, byte[] data)
         : base((ushort)(data.Length + 8), 17, source, dest, 0x00)
     {
@@ -110,8 +141,17 @@ internal class UdpPacket : IPPacket
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="UdpPacket"/> class with destination MAC.
+    /// Creates a UDP packet with a copied payload and a preset destination MAC address,
+    /// bypassing ARP resolution. Headers, length fields, and the IP header checksum are
+    /// written during construction and never recomputed. The UDP checksum is written as zero
+    /// and never computed, which is legal for UDP over IPv4.
     /// </summary>
+    /// <param name="source">The source IPv4 address.</param>
+    /// <param name="dest">The destination IPv4 address.</param>
+    /// <param name="srcPort">The source port.</param>
+    /// <param name="destPort">The destination port.</param>
+    /// <param name="data">The payload bytes to copy into the packet.</param>
+    /// <param name="destmac">The destination MAC address to write into the Ethernet header.</param>
     public UdpPacket(Address source, Address dest, ushort srcPort, ushort destPort, byte[] data, MACAddress destmac)
         : base((ushort)(data.Length + 8), 17, source, dest, 0x00, destmac)
     {
@@ -140,39 +180,44 @@ internal class UdpPacket : IPPacket
         RawData[this.DataOffset + 7] = (byte)((0 >> 0) & 0xFF);
     }
 
+    /// <summary>
+    /// Parses the UDP header fields (source port, destination port, UDP length) from
+    /// <see cref="EthernetPacket.RawData"/> into the header properties. Runs once during
+    /// construction; the properties are snapshots and are not refreshed afterwards.
+    /// </summary>
     protected override void InitializeFields()
     {
         base.InitializeFields();
         SourcePort = (ushort)((RawData[DataOffset] << 8) | RawData[DataOffset + 1]);
         DestinationPort = (ushort)((RawData[DataOffset + 2] << 8) | RawData[DataOffset + 3]);
         UDPLength = (ushort)((RawData[DataOffset + 4] << 8) | RawData[DataOffset + 5]);
-        _udpCRC = (ushort)((RawData[DataOffset + 6] << 8) | RawData[DataOffset + 7]);
     }
 
     /// <summary>
-    /// Gets the destination port.
+    /// Gets the destination port, a snapshot parsed from the UDP header at construction.
     /// </summary>
     public ushort DestinationPort { get; private set; }
 
     /// <summary>
-    /// Gets the source port.
+    /// Gets the source port, a snapshot parsed from the UDP header at construction.
     /// </summary>
     public ushort SourcePort { get; private set; }
 
     /// <summary>
-    /// Gets the UDP length of the packet.
+    /// Gets the value of the UDP length field: the 8-byte UDP header plus the payload. It is
+    /// a snapshot parsed from the header at construction and is never recomputed.
     /// </summary>
     public ushort UDPLength { get; private set; }
 
     /// <summary>
-    /// Get UDP data length of the packet.
+    /// Gets the payload length in bytes: <see cref="UDPLength"/> minus the 8-byte UDP header.
     /// </summary>
     public ushort UDPDataLength => (ushort)(UDPLength - 8);
 
     /// <summary>
-    /// Gets the UDP data of the packet.
+    /// Gets the UDP payload. Each access allocates and returns a fresh copy of the payload
+    /// bytes; the packet's underlying buffer is not exposed.
     /// </summary>
-    /// <exception cref="OverflowException">Thrown on fatal error.</exception>
     public byte[] UDPData
     {
         get
@@ -188,6 +233,10 @@ internal class UdpPacket : IPPacket
         }
     }
 
+    /// <summary>
+    /// Returns a string with the source and destination endpoints and the payload length.
+    /// </summary>
+    /// <returns>A human-readable summary of the packet.</returns>
     public override string ToString()
     {
         return "UDP Packet Src=" + SourceIP + ":" + SourcePort + "," +

--- a/src/Cosmos.Kernel.System/Network/NetworkStack.cs
+++ b/src/Cosmos.Kernel.System/Network/NetworkStack.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Cosmos.Kernel.Core.IO;
 using Cosmos.Kernel.HAL.Interfaces.Devices;
 using Cosmos.Kernel.System.Network.ARP;
@@ -125,10 +126,34 @@ public static class NetworkStack
     }
 
     /// <summary>
-    /// Handle a network packet.
+    /// Transmits a packet through the stack's outgoing queue: the sending
+    /// device is resolved from the packet's source address, the destination
+    /// MAC is resolved by ARP for non-broadcast destinations, and the queue
+    /// is pumped before returning.
+    /// </summary>
+    /// <param name="packet">A built packet, typically created through one of the packet type constructors.</param>
+    /// <returns>False when no configured interface matches the packet's source address; the packet is not queued in that case.</returns>
+    [Experimental(Experimentals.PacketSeamDiagId)]
+    public static bool Send(IPPacket packet)
+    {
+        if (!OutgoingBuffer.AddPacket(packet))
+        {
+            return false;
+        }
+
+        Update();
+        return true;
+    }
+
+    /// <summary>
+    /// Injects a received Ethernet frame into the stack: the frame is
+    /// dispatched to the ARP or IPv4 handler by EtherType, exactly as a
+    /// frame arriving from a network device would be. This is the receive
+    /// entry point registered on every configured device.
     /// </summary>
     /// <param name="packetData">Packet data array.</param>
     /// <param name="length">Packet length.</param>
+    [Experimental(Experimentals.PacketSeamDiagId)]
     public static void HandlePacket(byte[] packetData, int length)
     {
         Serial.WriteString("[NetworkStack] HandlePacket called, len=");

--- a/src/Cosmos.Kernel.System/PublicAPI.Unshipped.txt
+++ b/src/Cosmos.Kernel.System/PublicAPI.Unshipped.txt
@@ -571,6 +571,7 @@ override Cosmos.Kernel.System.Network.IPv4.Address.GetHashCode() -> int
 override Cosmos.Kernel.System.Network.IPv4.Address.ToString() -> string!
 override Cosmos.Kernel.System.Network.IPv4.EndPoint.ToString() -> string!
 static Cosmos.Kernel.System.Diagnostics.Log.Write(params object?[]! args) -> void
+static Cosmos.Kernel.System.Diagnostics.Log.WriteBytes(System.ReadOnlySpan<byte> bytes) -> void
 static Cosmos.Kernel.System.Diagnostics.Log.WriteHex(uint number) -> void
 static Cosmos.Kernel.System.Diagnostics.Log.WriteHex(ulong number) -> void
 static Cosmos.Kernel.System.Diagnostics.Log.WriteHexWithPrefix(uint number) -> void

--- a/src/Cosmos.Kernel.System/PublicAPI.Unshipped.txt
+++ b/src/Cosmos.Kernel.System/PublicAPI.Unshipped.txt
@@ -1,4 +1,31 @@
 #nullable enable
+const Cosmos.Kernel.System.Diagnostics.SchedulerInfo.NanosecondsPerMillisecond = 1000000 -> ulong
+Cosmos.Kernel.System.Diagnostics.KernelThreadInfo
+Cosmos.Kernel.System.Diagnostics.KernelThreadInfo.CpuId.get -> uint
+Cosmos.Kernel.System.Diagnostics.KernelThreadInfo.HasPriority.get -> bool
+Cosmos.Kernel.System.Diagnostics.KernelThreadInfo.Id.get -> uint
+Cosmos.Kernel.System.Diagnostics.KernelThreadInfo.IsIdle.get -> bool
+Cosmos.Kernel.System.Diagnostics.KernelThreadInfo.IsManaged.get -> bool
+Cosmos.Kernel.System.Diagnostics.KernelThreadInfo.KernelThreadInfo() -> void
+Cosmos.Kernel.System.Diagnostics.KernelThreadInfo.Priority.get -> long
+Cosmos.Kernel.System.Diagnostics.KernelThreadInfo.StackSizeBytes.get -> ulong
+Cosmos.Kernel.System.Diagnostics.KernelThreadInfo.State.get -> Cosmos.Kernel.System.Diagnostics.KernelThreadState
+Cosmos.Kernel.System.Diagnostics.KernelThreadInfo.TotalRuntimeNs.get -> ulong
+Cosmos.Kernel.System.Diagnostics.KernelThreadState
+Cosmos.Kernel.System.Diagnostics.KernelThreadState.Blocked = 3 -> Cosmos.Kernel.System.Diagnostics.KernelThreadState
+Cosmos.Kernel.System.Diagnostics.KernelThreadState.Created = 0 -> Cosmos.Kernel.System.Diagnostics.KernelThreadState
+Cosmos.Kernel.System.Diagnostics.KernelThreadState.Dead = 5 -> Cosmos.Kernel.System.Diagnostics.KernelThreadState
+Cosmos.Kernel.System.Diagnostics.KernelThreadState.Ready = 1 -> Cosmos.Kernel.System.Diagnostics.KernelThreadState
+Cosmos.Kernel.System.Diagnostics.KernelThreadState.Running = 2 -> Cosmos.Kernel.System.Diagnostics.KernelThreadState
+Cosmos.Kernel.System.Diagnostics.KernelThreadState.Sleeping = 4 -> Cosmos.Kernel.System.Diagnostics.KernelThreadState
+Cosmos.Kernel.System.Diagnostics.Log
+Cosmos.Kernel.System.Diagnostics.MemoryInfo
+Cosmos.Kernel.System.Diagnostics.SchedulerInfo
+Cosmos.Kernel.System.Diagnostics.ThreadKillResult
+Cosmos.Kernel.System.Diagnostics.ThreadKillResult.Killed = 1 -> Cosmos.Kernel.System.Diagnostics.ThreadKillResult
+Cosmos.Kernel.System.Diagnostics.ThreadKillResult.MarkedForExit = 2 -> Cosmos.Kernel.System.Diagnostics.ThreadKillResult
+Cosmos.Kernel.System.Diagnostics.ThreadKillResult.NotFound = 0 -> Cosmos.Kernel.System.Diagnostics.ThreadKillResult
+Cosmos.Kernel.System.Diagnostics.ThreadKillResult.RefusedIdle = 3 -> Cosmos.Kernel.System.Diagnostics.ThreadKillResult
 Cosmos.Kernel.System.Filesystems.Fat.FatBootSector
 Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.BytesPerCluster.get -> uint
 Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.BytesPerSector.get -> uint
@@ -200,6 +227,7 @@ Cosmos.Kernel.System.Kernel.Started.set -> void
 Cosmos.Kernel.System.Kernel.Stop() -> void
 Cosmos.Kernel.System.Kernel.Stopped.get -> bool
 Cosmos.Kernel.System.Kernel.Stopped.set -> void
+Cosmos.Kernel.System.KernelFeatures
 Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
 Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.A = 47 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
 Cosmos.Kernel.System.Keyboard.ConsoleKeyEx.AltGr = 82 -> Cosmos.Kernel.System.Keyboard.ConsoleKeyEx
@@ -540,6 +568,37 @@ override Cosmos.Kernel.System.Storage.Partition.Flush() -> void
 override Cosmos.Kernel.System.Storage.Partition.Name.get -> string!
 override Cosmos.Kernel.System.Storage.Partition.ReadBlock(ulong blockNo, ulong blockCount, System.Span<byte> data) -> void
 override Cosmos.Kernel.System.Storage.Partition.WriteBlock(ulong blockNo, ulong blockCount, System.ReadOnlySpan<byte> data) -> void
+static Cosmos.Kernel.System.Diagnostics.Log.Write(params object?[]! args) -> void
+static Cosmos.Kernel.System.Diagnostics.Log.WriteHex(uint number) -> void
+static Cosmos.Kernel.System.Diagnostics.Log.WriteHex(ulong number) -> void
+static Cosmos.Kernel.System.Diagnostics.Log.WriteHexWithPrefix(uint number) -> void
+static Cosmos.Kernel.System.Diagnostics.Log.WriteHexWithPrefix(ulong number) -> void
+static Cosmos.Kernel.System.Diagnostics.Log.WriteNumber(int number, bool hex = false) -> void
+static Cosmos.Kernel.System.Diagnostics.Log.WriteNumber(long number, bool hex = false) -> void
+static Cosmos.Kernel.System.Diagnostics.Log.WriteNumber(uint number, bool hex = false) -> void
+static Cosmos.Kernel.System.Diagnostics.Log.WriteNumber(ulong number, bool hex = false) -> void
+static Cosmos.Kernel.System.Diagnostics.Log.WriteString(string! text) -> void
+static Cosmos.Kernel.System.Diagnostics.MemoryInfo.Collect() -> int
+static Cosmos.Kernel.System.Diagnostics.MemoryInfo.FreePages.get -> ulong
+static Cosmos.Kernel.System.Diagnostics.MemoryInfo.GcTimePercent.get -> int
+static Cosmos.Kernel.System.Diagnostics.MemoryInfo.GetGcStats(out int totalCollections, out int totalObjectsFreed) -> void
+static Cosmos.Kernel.System.Diagnostics.MemoryInfo.PageSizeBytes.get -> ulong
+static Cosmos.Kernel.System.Diagnostics.MemoryInfo.RamSizeBytes.get -> ulong
+static Cosmos.Kernel.System.Diagnostics.MemoryInfo.TotalPages.get -> ulong
+static Cosmos.Kernel.System.Diagnostics.SchedulerInfo.BusyCpuTimeNs.get -> ulong
+static Cosmos.Kernel.System.Diagnostics.SchedulerInfo.CpuCount.get -> uint
+static Cosmos.Kernel.System.Diagnostics.SchedulerInfo.GetRunQueueCount(uint cpuId) -> int
+static Cosmos.Kernel.System.Diagnostics.SchedulerInfo.IsInitialized.get -> bool
+static Cosmos.Kernel.System.Diagnostics.SchedulerInfo.IsRunning.get -> bool
+static Cosmos.Kernel.System.Diagnostics.SchedulerInfo.IsSupported.get -> bool
+static Cosmos.Kernel.System.Diagnostics.SchedulerInfo.QuantumNs.get -> ulong
+static Cosmos.Kernel.System.Diagnostics.SchedulerInfo.RequestKill(uint threadId) -> Cosmos.Kernel.System.Diagnostics.ThreadKillResult
+static Cosmos.Kernel.System.Diagnostics.SchedulerInfo.SchedulerName.get -> string?
+static Cosmos.Kernel.System.Diagnostics.SchedulerInfo.ThreadCount.get -> int
+static Cosmos.Kernel.System.Diagnostics.SchedulerInfo.ThreadSlotCount.get -> int
+static Cosmos.Kernel.System.Diagnostics.SchedulerInfo.TryGetCurrentThread(uint cpuId, out Cosmos.Kernel.System.Diagnostics.KernelThreadInfo info) -> bool
+static Cosmos.Kernel.System.Diagnostics.SchedulerInfo.TryGetRunQueueThread(uint cpuId, int index, out Cosmos.Kernel.System.Diagnostics.KernelThreadInfo info) -> bool
+static Cosmos.Kernel.System.Diagnostics.SchedulerInfo.TryGetThread(int slot, out Cosmos.Kernel.System.Diagnostics.KernelThreadInfo info) -> bool
 static Cosmos.Kernel.System.Filesystems.Fat.FatBootSector.TryParse(System.ReadOnlySpan<byte> bpb, out Cosmos.Kernel.System.Filesystems.Fat.FatBootSector? bootSector) -> bool
 static Cosmos.Kernel.System.Global.CurrentKernel.get -> Cosmos.Kernel.System.Kernel?
 static Cosmos.Kernel.System.Global.Init() -> void
@@ -570,6 +629,17 @@ static Cosmos.Kernel.System.Graphics.Mode.operator <=(Cosmos.Kernel.System.Graph
 static Cosmos.Kernel.System.Graphics.Mode.operator ==(Cosmos.Kernel.System.Graphics.Mode a, Cosmos.Kernel.System.Graphics.Mode b) -> bool
 static Cosmos.Kernel.System.Graphics.Mode.operator >(Cosmos.Kernel.System.Graphics.Mode a, Cosmos.Kernel.System.Graphics.Mode b) -> bool
 static Cosmos.Kernel.System.Graphics.Mode.operator >=(Cosmos.Kernel.System.Graphics.Mode a, Cosmos.Kernel.System.Graphics.Mode b) -> bool
+static Cosmos.Kernel.System.KernelFeatures.Fat.get -> bool
+static Cosmos.Kernel.System.KernelFeatures.Graphics.get -> bool
+static Cosmos.Kernel.System.KernelFeatures.Interrupts.get -> bool
+static Cosmos.Kernel.System.KernelFeatures.Keyboard.get -> bool
+static Cosmos.Kernel.System.KernelFeatures.Mouse.get -> bool
+static Cosmos.Kernel.System.KernelFeatures.Network.get -> bool
+static Cosmos.Kernel.System.KernelFeatures.Pci.get -> bool
+static Cosmos.Kernel.System.KernelFeatures.Scheduler.get -> bool
+static Cosmos.Kernel.System.KernelFeatures.Storage.get -> bool
+static Cosmos.Kernel.System.KernelFeatures.Timer.get -> bool
+static Cosmos.Kernel.System.KernelFeatures.Uart.get -> bool
 static Cosmos.Kernel.System.Keyboard.KeyboardManager.AltPressed.get -> bool
 static Cosmos.Kernel.System.Keyboard.KeyboardManager.CapsLock.get -> bool
 static Cosmos.Kernel.System.Keyboard.KeyboardManager.ControlPressed.get -> bool

--- a/src/Cosmos.Kernel.System/PublicAPI.Unshipped.txt
+++ b/src/Cosmos.Kernel.System/PublicAPI.Unshipped.txt
@@ -498,6 +498,12 @@ Cosmos.Kernel.System.Storage.MbrPartitionEntry.SectorCount.get -> ulong
 Cosmos.Kernel.System.Storage.MbrPartitionEntry.StartSector.get -> ulong
 Cosmos.Kernel.System.Storage.MbrPartitionEntry.SystemId.get -> byte
 Cosmos.Kernel.System.Storage.Partition
+Cosmos.Kernel.System.Storage.Partition.BlockCount.get -> ulong
+Cosmos.Kernel.System.Storage.Partition.BlockSize.get -> ulong
+Cosmos.Kernel.System.Storage.Partition.Flush() -> void
+Cosmos.Kernel.System.Storage.Partition.Name.get -> string!
+Cosmos.Kernel.System.Storage.Partition.ReadBlock(ulong blockNo, ulong blockCount, System.Span<byte> data) -> void
+Cosmos.Kernel.System.Storage.Partition.WriteBlock(ulong blockNo, ulong blockCount, System.ReadOnlySpan<byte> data) -> void
 Cosmos.Kernel.System.Storage.Partition.Host.get -> Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice!
 Cosmos.Kernel.System.Storage.Partition.Partition(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! host, ulong startSector, ulong sectorCount, string! name) -> void
 Cosmos.Kernel.System.Storage.Partition.Partition(Cosmos.Kernel.HAL.Interfaces.Devices.IBlockDevice! host, ulong startSector, ulong sectorCount, uint index) -> void
@@ -564,10 +570,6 @@ override Cosmos.Kernel.System.Network.IPv4.Address.Equals(object? obj) -> bool
 override Cosmos.Kernel.System.Network.IPv4.Address.GetHashCode() -> int
 override Cosmos.Kernel.System.Network.IPv4.Address.ToString() -> string!
 override Cosmos.Kernel.System.Network.IPv4.EndPoint.ToString() -> string!
-override Cosmos.Kernel.System.Storage.Partition.Flush() -> void
-override Cosmos.Kernel.System.Storage.Partition.Name.get -> string!
-override Cosmos.Kernel.System.Storage.Partition.ReadBlock(ulong blockNo, ulong blockCount, System.Span<byte> data) -> void
-override Cosmos.Kernel.System.Storage.Partition.WriteBlock(ulong blockNo, ulong blockCount, System.ReadOnlySpan<byte> data) -> void
 static Cosmos.Kernel.System.Diagnostics.Log.Write(params object?[]! args) -> void
 static Cosmos.Kernel.System.Diagnostics.Log.WriteHex(uint number) -> void
 static Cosmos.Kernel.System.Diagnostics.Log.WriteHex(ulong number) -> void

--- a/src/Cosmos.Kernel.System/PublicAPI.Unshipped.txt
+++ b/src/Cosmos.Kernel.System/PublicAPI.Unshipped.txt
@@ -706,7 +706,6 @@ static Cosmos.Kernel.System.Network.NetworkManager.RegisterDevice(Cosmos.Kernel.
 static Cosmos.Kernel.System.Network.NetworkManager.Send(byte[]! data, int length) -> bool
 static Cosmos.Kernel.System.Network.NetworkStack.ConfigIP(Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice! device, Cosmos.Kernel.System.Network.Config.IPConfig! config) -> void
 static Cosmos.Kernel.System.Network.NetworkStack.ConfigIP(Cosmos.Kernel.HAL.Interfaces.Devices.INetworkDevice! device, Cosmos.Kernel.System.Network.IPv4.Address! ipAddress) -> void
-static Cosmos.Kernel.System.Network.NetworkStack.HandlePacket(byte[]! packetData, int length) -> void
 static Cosmos.Kernel.System.Network.NetworkStack.Initialize() -> void
 static Cosmos.Kernel.System.Network.NetworkStack.RemoveAllConfigIP() -> void
 static Cosmos.Kernel.System.Network.NetworkStack.Update() -> void
@@ -827,3 +826,226 @@ virtual Cosmos.Kernel.System.Kernel.AfterRun() -> void
 virtual Cosmos.Kernel.System.Kernel.BeforeRun() -> void
 virtual Cosmos.Kernel.System.Kernel.OnBoot() -> void
 virtual Cosmos.Kernel.System.Kernel.Start() -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacket
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacket.ArpPacket(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacket.ArpPacket(Cosmos.Kernel.HAL.Devices.Network.MACAddress! dest, Cosmos.Kernel.HAL.Devices.Network.MACAddress! src, ushort hwType, ushort protoType, byte hwLen, byte protoLen, ushort operation, int packet_size) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacket.hardwareAddrLength -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacket.hardwareType -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacket.HardwareType.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacket.opCode -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacket.Operation.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacket.protocolAddrLength -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacket.protocolType -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacket.ProtocolType.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacketEthernet
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacketEthernet.ArpPacketEthernet(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacketEthernet.ArpPacketEthernet(ushort operation, Cosmos.Kernel.HAL.Devices.Network.MACAddress! senderMAC, Cosmos.Kernel.System.Network.IPv4.Address! senderIP, Cosmos.Kernel.HAL.Devices.Network.MACAddress! targetMAC, Cosmos.Kernel.System.Network.IPv4.Address! targetIP, int packetSize, Cosmos.Kernel.HAL.Devices.Network.MACAddress! arpTargetMAC) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacketEthernet.senderIP -> Cosmos.Kernel.System.Network.IPv4.Address!
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacketEthernet.SenderIP.get -> Cosmos.Kernel.System.Network.IPv4.Address!
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacketEthernet.senderMAC -> Cosmos.Kernel.HAL.Devices.Network.MACAddress!
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacketEthernet.SenderMAC.get -> Cosmos.Kernel.HAL.Devices.Network.MACAddress!
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacketEthernet.targetIP -> Cosmos.Kernel.System.Network.IPv4.Address!
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacketEthernet.TargetIP.get -> Cosmos.Kernel.System.Network.IPv4.Address!
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacketEthernet.targetMAC -> Cosmos.Kernel.HAL.Devices.Network.MACAddress!
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpPacketEthernet.TargetMAC.get -> Cosmos.Kernel.HAL.Devices.Network.MACAddress!
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpReplyEthernet
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpReplyEthernet.ArpReplyEthernet(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpReplyEthernet.ArpReplyEthernet(Cosmos.Kernel.HAL.Devices.Network.MACAddress! ourMAC, Cosmos.Kernel.System.Network.IPv4.Address! ourIP, Cosmos.Kernel.HAL.Devices.Network.MACAddress! targetMAC, Cosmos.Kernel.System.Network.IPv4.Address! targetIP) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpRequestEthernet
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpRequestEthernet.ArpRequestEthernet(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.ARP.ArpRequestEthernet.ArpRequestEthernet(Cosmos.Kernel.HAL.Devices.Network.MACAddress! ourMAC, Cosmos.Kernel.System.Network.IPv4.Address! ourIP, Cosmos.Kernel.HAL.Devices.Network.MACAddress! targetMAC, Cosmos.Kernel.System.Network.IPv4.Address! targetIP, Cosmos.Kernel.HAL.Devices.Network.MACAddress! arpTargetMAC) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.EthernetPacket
+[COSMOS0002]Cosmos.Kernel.System.Network.EthernetPacket.DestinationMAC.get -> Cosmos.Kernel.HAL.Devices.Network.MACAddress!
+[COSMOS0002]Cosmos.Kernel.System.Network.EthernetPacket.destMAC -> Cosmos.Kernel.HAL.Devices.Network.MACAddress!
+[COSMOS0002]Cosmos.Kernel.System.Network.EthernetPacket.EthernetPacket(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.EthernetPacket.EthernetPacket(Cosmos.Kernel.HAL.Devices.Network.MACAddress! dest, Cosmos.Kernel.HAL.Devices.Network.MACAddress! src, ushort type, int packetSize) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.EthernetPacket.EthernetPacket(ushort type, int packetSize) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.EthernetPacket.EthernetType.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.EthernetPacket.RawData.get -> byte[]!
+[COSMOS0002]Cosmos.Kernel.System.Network.EthernetPacket.SourceMAC.get -> Cosmos.Kernel.HAL.Devices.Network.MACAddress!
+[COSMOS0002]Cosmos.Kernel.System.Network.EthernetPacket.srcMAC -> Cosmos.Kernel.HAL.Devices.Network.MACAddress!
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpClient.ReceivePacket(int timeoutMs = 5000) -> Cosmos.Kernel.System.Network.IPv4.IcmpPacket?
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpClient.Send(Cosmos.Kernel.System.Network.IPv4.IcmpPacket! packet) -> bool
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpEchoReply
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpEchoReply.IcmpEchoReply(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpEchoReply.IcmpEchoReply(Cosmos.Kernel.System.Network.IPv4.IcmpEchoRequest! request) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpEchoReply.icmpID -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpEchoReply.ICMPID.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpEchoReply.icmpSequence -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpEchoReply.ICMPSequence.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpEchoRequest
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpEchoRequest.IcmpEchoRequest(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpEchoRequest.IcmpEchoRequest(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, ushort id, ushort sequence) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpEchoRequest.icmpID -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpEchoRequest.ICMPID.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpEchoRequest.icmpSequence -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpEchoRequest.ICMPSequence.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpPacket
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpPacket.CalcICMPCRC(ushort length) -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpPacket.GetICMPData() -> byte[]!
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpPacket.icmpCode -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpPacket.ICMPCode.get -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpPacket.icmpCRC -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpPacket.ICMPCRC.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpPacket.ICMPDataLength.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpPacket.IcmpPacket(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpPacket.IcmpPacket(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, byte type, byte code, ushort id, ushort seq, ushort icmpLength) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpPacket.icmpType -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IcmpPacket.ICMPType.get -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.CalcIPCRC(ushort headerLength) -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.CalcOcCRC(ushort offset, ushort length) -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.DataLength.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.DataOffset.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.DestinationIP.get -> Cosmos.Kernel.System.Network.IPv4.Address!
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.FragmentID.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.FragmentOffset.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.HeaderLength.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.IPCRC.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.IPFlags.get -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.ipHeaderLength -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.IPLength.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.IPPacket(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.IPPacket(Cosmos.Kernel.HAL.Devices.Network.MACAddress! srcMAC, Cosmos.Kernel.HAL.Devices.Network.MACAddress! destMAC, ushort dataLength, byte protocol, Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, byte flags) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.IPPacket(ushort dataLength, byte protocol, Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, byte flags) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.IPPacket(ushort dataLength, byte protocol, Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, byte flags, Cosmos.Kernel.HAL.Devices.Network.MACAddress! destMAC) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.IPVersion.get -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.Protocol.get -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.SourceIP.get -> Cosmos.Kernel.System.Network.IPv4.Address!
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.TTL.get -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.IPPacket.TypeOfService.get -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpFlags
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpFlags.ACK = 16 -> Cosmos.Kernel.System.Network.IPv4.TCP.TcpFlags
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpFlags.FIN = 1 -> Cosmos.Kernel.System.Network.IPv4.TCP.TcpFlags
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpFlags.PSH = 8 -> Cosmos.Kernel.System.Network.IPv4.TCP.TcpFlags
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpFlags.RST = 4 -> Cosmos.Kernel.System.Network.IPv4.TCP.TcpFlags
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpFlags.SYN = 2 -> Cosmos.Kernel.System.Network.IPv4.TCP.TcpFlags
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpFlags.URG = 32 -> Cosmos.Kernel.System.Network.IPv4.TCP.TcpFlags
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpOption
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpOption.Data.get -> byte[]?
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpOption.Kind.get -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpOption.Length.get -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpOption.TcpOption() -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket.AckNumber.get -> uint
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket.Checksum.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket.DestinationPort.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket.GetFlags() -> string!
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket.Options.get -> System.Collections.Generic.List<Cosmos.Kernel.System.Network.IPv4.TCP.TcpOption!>?
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket.SequenceNumber.get -> uint
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket.SourcePort.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket.TCPFlags.get -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket.TCPHeaderLength.get -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket.TcpPacket(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket.TcpPacket(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, ushort srcPort, ushort destPort, uint sequenceNumber, uint ackNumber, ushort headerLength, byte flags, ushort windowSize, ushort urgentPointer) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket.TcpPacket(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, ushort srcPort, ushort destPort, uint sequenceNumber, uint ackNumber, ushort headerLength, byte flags, ushort windowSize, ushort urgentPointer, byte[]! data) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket.TCP_DataLength.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket.UrgentPointer.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket.WindowSize.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpDiscover
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpDiscover.DhcpDiscover(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpDiscover.DhcpDiscover(Cosmos.Kernel.HAL.Devices.Network.MACAddress! sourceMAC) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpOption
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpOption.Data.get -> byte[]!
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpOption.Data.init -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpOption.DhcpOption() -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpOption.Length.get -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpOption.Type.get -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpOption.Type.init -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpPacket
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpPacket.Client.get -> Cosmos.Kernel.System.Network.IPv4.Address?
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpPacket.DhcpPacket(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpPacket.DhcpPacket(Cosmos.Kernel.HAL.Devices.Network.MACAddress! mac_src, ushort dhcpDataSize) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpPacket.DhcpPacket(Cosmos.Kernel.System.Network.IPv4.Address! client, Cosmos.Kernel.System.Network.IPv4.Address! server, Cosmos.Kernel.HAL.Devices.Network.MACAddress! sourceMAC, ushort dhcpDataSize) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpPacket.DNS.get -> Cosmos.Kernel.System.Network.IPv4.Address?
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpPacket.Gateway.get -> Cosmos.Kernel.System.Network.IPv4.Address?
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpPacket.Operation.get -> byte
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpPacket.Options.get -> System.Collections.Generic.List<Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpOption!>?
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpPacket.Subnet.get -> Cosmos.Kernel.System.Network.IPv4.Address?
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpRelease
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpRelease.DhcpRelease(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpRelease.DhcpRelease(Cosmos.Kernel.System.Network.IPv4.Address! client, Cosmos.Kernel.System.Network.IPv4.Address! server, Cosmos.Kernel.HAL.Devices.Network.MACAddress! source) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpRequest
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpRequest.DhcpRequest(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpRequest.DhcpRequest(Cosmos.Kernel.HAL.Devices.Network.MACAddress! sourceMAC, Cosmos.Kernel.System.Network.IPv4.Address! requestedAddress) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsAnswer
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsAnswer.Address.get -> byte[]?
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsAnswer.CanonicalName.get -> string?
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsAnswer.Class.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsAnswer.DataLength.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsAnswer.DnsAnswer() -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsAnswer.Name.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsAnswer.ResolvedName.get -> string?
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsAnswer.TimeToLive.get -> int
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsAnswer.Type.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacket
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacket.AdditionalRRs.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacket.AnswerRRs.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacket.Answers.get -> System.Collections.Generic.List<Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsAnswer!>?
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacket.AuthorityRRs.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacket.DNSFlags.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacket.DnsPacket(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacket.DnsPacket(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, ushort urlnb, ushort len) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacket.Queries.get -> System.Collections.Generic.List<Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsQuery!>?
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacket.Questions.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacket.TransactionID.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacketAnswer
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacketAnswer.DnsPacketAnswer(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacketAsk
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacketAsk.DnsPacketAsk(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacketAsk.DnsPacketAsk(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, string! url) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsQuery
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsQuery.Class.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsQuery.DnsQuery() -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsQuery.Name.get -> string?
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsQuery.Type.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode.FormatError = 1 -> Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode.NameError = 3 -> Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode.NotSupported = 4 -> Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode.OK = 0 -> Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode.Refused = 5 -> Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode.ServerFailure = 2 -> Cosmos.Kernel.System.Network.IPv4.UDP.DNS.ReplyCode
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.UdpClient.ReceivePacket(int timeoutMs = 5000) -> Cosmos.Kernel.System.Network.IPv4.UDP.UdpPacket?
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.UdpClient.Send(Cosmos.Kernel.System.Network.IPv4.UDP.UdpPacket! packet) -> bool
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.UdpPacket
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.UdpPacket.DestinationPort.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.UdpPacket.SourcePort.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.UdpPacket.UDPData.get -> byte[]!
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.UdpPacket.UDPDataLength.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.UdpPacket.UDPLength.get -> ushort
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.UdpPacket.UdpPacket(byte[]! rawData) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.UdpPacket.UdpPacket(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, ushort srcPort, ushort destPort, byte[]! data) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.UdpPacket.UdpPacket(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, ushort srcPort, ushort destPort, byte[]! data, Cosmos.Kernel.HAL.Devices.Network.MACAddress! destmac) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.UdpPacket.UdpPacket(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, ushort srcport, ushort destport, ushort datalength) -> void
+[COSMOS0002]Cosmos.Kernel.System.Network.IPv4.UDP.UdpPacket.UdpPacket(Cosmos.Kernel.System.Network.IPv4.Address! source, Cosmos.Kernel.System.Network.IPv4.Address! dest, ushort srcport, ushort destport, ushort datalength, Cosmos.Kernel.HAL.Devices.Network.MACAddress! destmac) -> void
+[COSMOS0002]override Cosmos.Kernel.System.Network.ARP.ArpPacket.InitializeFields() -> void
+[COSMOS0002]override Cosmos.Kernel.System.Network.ARP.ArpPacket.ToString() -> string!
+[COSMOS0002]override Cosmos.Kernel.System.Network.ARP.ArpPacketEthernet.InitializeFields() -> void
+[COSMOS0002]override Cosmos.Kernel.System.Network.ARP.ArpPacketEthernet.ToString() -> string!
+[COSMOS0002]override Cosmos.Kernel.System.Network.ARP.ArpReplyEthernet.ToString() -> string!
+[COSMOS0002]override Cosmos.Kernel.System.Network.ARP.ArpRequestEthernet.ToString() -> string!
+[COSMOS0002]override Cosmos.Kernel.System.Network.EthernetPacket.ToString() -> string!
+[COSMOS0002]override Cosmos.Kernel.System.Network.IPv4.IcmpEchoReply.InitializeFields() -> void
+[COSMOS0002]override Cosmos.Kernel.System.Network.IPv4.IcmpEchoReply.ToString() -> string!
+[COSMOS0002]override Cosmos.Kernel.System.Network.IPv4.IcmpEchoRequest.InitializeFields() -> void
+[COSMOS0002]override Cosmos.Kernel.System.Network.IPv4.IcmpEchoRequest.ToString() -> string!
+[COSMOS0002]override Cosmos.Kernel.System.Network.IPv4.IcmpPacket.InitializeFields() -> void
+[COSMOS0002]override Cosmos.Kernel.System.Network.IPv4.IcmpPacket.ToString() -> string!
+[COSMOS0002]override Cosmos.Kernel.System.Network.IPv4.IPPacket.InitializeFields() -> void
+[COSMOS0002]override Cosmos.Kernel.System.Network.IPv4.IPPacket.ToString() -> string!
+[COSMOS0002]override Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket.InitializeFields() -> void
+[COSMOS0002]override Cosmos.Kernel.System.Network.IPv4.TCP.TcpPacket.ToString() -> string!
+[COSMOS0002]override Cosmos.Kernel.System.Network.IPv4.UDP.DHCP.DhcpPacket.InitializeFields() -> void
+[COSMOS0002]override Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacket.InitializeFields() -> void
+[COSMOS0002]override Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacket.ToString() -> string!
+[COSMOS0002]override Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacketAnswer.InitializeFields() -> void
+[COSMOS0002]override Cosmos.Kernel.System.Network.IPv4.UDP.UdpPacket.InitializeFields() -> void
+[COSMOS0002]override Cosmos.Kernel.System.Network.IPv4.UDP.UdpPacket.ToString() -> string!
+[COSMOS0002]static Cosmos.Kernel.System.Network.IPv4.IPPacket.CalcOcCRC(byte[]! buffer, ushort offset, int length) -> ushort
+[COSMOS0002]static Cosmos.Kernel.System.Network.IPv4.IPPacket.SumShortValues(byte[]! buffer, int offset, int length) -> ushort
+[COSMOS0002]static Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacket.ParseNameAt(byte[]! rawData, int startIndex, int messageBase) -> string!
+[COSMOS0002]static Cosmos.Kernel.System.Network.IPv4.UDP.DNS.DnsPacket.ResolveRRName(ushort nameField, byte[]! rawData, int messageBase) -> string?
+[COSMOS0002]static Cosmos.Kernel.System.Network.NetworkStack.HandlePacket(byte[]! packetData, int length) -> void
+[COSMOS0002]static Cosmos.Kernel.System.Network.NetworkStack.Send(Cosmos.Kernel.System.Network.IPv4.IPPacket! packet) -> bool
+[COSMOS0002]virtual Cosmos.Kernel.System.Network.EthernetPacket.InitializeFields() -> void

--- a/src/Cosmos.Kernel.System/Storage/Partition.cs
+++ b/src/Cosmos.Kernel.System/Storage/Partition.cs
@@ -9,7 +9,7 @@ namespace Cosmos.Kernel.System.Storage;
 /// Block-device view of a single partition on a host disk. Read/Write are
 /// translated to the host LBA space by adding <see cref="StartSector"/>.
 /// </summary>
-public sealed class Partition : BlockDevice
+public sealed class Partition : IBlockDevice
 {
     private readonly IBlockDevice _host;
     private readonly string _name;
@@ -21,7 +21,13 @@ public sealed class Partition : BlockDevice
     public ulong StartSector { get; }
 
     /// <inheritdoc />
-    public override string Name => _name;
+    public ulong BlockCount { get; }
+
+    /// <inheritdoc />
+    public ulong BlockSize { get; }
+
+    /// <inheritdoc />
+    public string Name => _name;
 
     /// <summary>
     /// Index-based naming ctor: builds "&lt;host&gt;p&lt;index&gt;" digit by
@@ -33,7 +39,7 @@ public sealed class Partition : BlockDevice
     /// <param name="sectorCount">Length of the partition in sectors.</param>
     /// <param name="index">Zero-based partition index on the host disk.</param>
     public Partition(IBlockDevice host, ulong startSector, ulong sectorCount, uint index)
-        : this(host, startSector, sectorCount, BuildDeviceName(host.Name, "p", index))
+        : this(host, startSector, sectorCount, BlockDevice.BuildDeviceName(host.Name, "p", index))
     {
     }
 
@@ -52,21 +58,21 @@ public sealed class Partition : BlockDevice
     }
 
     /// <inheritdoc />
-    public override void ReadBlock(ulong blockNo, ulong blockCount, Span<byte> data)
+    public void ReadBlock(ulong blockNo, ulong blockCount, Span<byte> data)
     {
         CheckBounds(blockNo, blockCount);
         _host.ReadBlock(StartSector + blockNo, blockCount, data);
     }
 
     /// <inheritdoc />
-    public override void WriteBlock(ulong blockNo, ulong blockCount, ReadOnlySpan<byte> data)
+    public void WriteBlock(ulong blockNo, ulong blockCount, ReadOnlySpan<byte> data)
     {
         CheckBounds(blockNo, blockCount);
         _host.WriteBlock(StartSector + blockNo, blockCount, data);
     }
 
     /// <inheritdoc />
-    public override void Flush()
+    public void Flush()
     {
         _host.Flush();
     }

--- a/src/Cosmos.Kernel/Cosmos.Kernel.csproj
+++ b/src/Cosmos.Kernel/Cosmos.Kernel.csproj
@@ -14,6 +14,8 @@
     <RepositoryUrl>https://github.com/valentinbreiz/nativeaot-patcher</RepositoryUrl>
     <PackageProjectUrl>https://github.com/valentinbreiz/nativeaot-patcher</PackageProjectUrl>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+    <!-- The library initializer bootstraps the experimental scheduler seam (COSMOS0001). -->
+    <NoWarn>$(NoWarn);COSMOS0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cosmos.Kernel/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
+++ b/src/Cosmos.Kernel/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
@@ -13,7 +13,7 @@ namespace Internal.Runtime.CompilerHelpers
     /// <summary>
     /// This class is responsible for initializing the library and its dependencies. It is called by the runtime before any managed code is executed.
     /// </summary>
-    public class LibraryInitializer
+    internal class LibraryInitializer
     {
         /// <summary>
         /// Miscellaneous initialization of core kernel services that depend on HAL, such as interrupts, exception handlers, and scheduler. This method is called by the runtime before any managed code is executed.

--- a/tests/Cosmos.TestRunner.Framework/Cosmos.TestRunner.Framework.csproj
+++ b/tests/Cosmos.TestRunner.Framework/Cosmos.TestRunner.Framework.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Cosmos.Kernel.Core\Cosmos.Kernel.Core.csproj" />
+    <ProjectReference Include="..\..\src\Cosmos.Kernel.System\Cosmos.Kernel.System.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Cosmos.TestRunner.Framework/CoverageTracker.cs
+++ b/tests/Cosmos.TestRunner.Framework/CoverageTracker.cs
@@ -1,5 +1,4 @@
 using System.Runtime.CompilerServices;
-using Cosmos.Kernel.Core.IO;
 
 namespace Cosmos.TestRunner.Framework;
 
@@ -86,29 +85,6 @@ public static unsafe class CoverageTracker
             }
         }
 
-        SendMessage(CoverageData, payload);
-    }
-
-    /// <summary>
-    /// Send a protocol message: [MAGIC:4][Command:1][Length:2][Payload:N]
-    /// </summary>
-    private static void SendMessage(byte command, byte[] payload)
-    {
-        // Magic signature (0x19740807 little-endian)
-        Serial.ComWrite(0x07);
-        Serial.ComWrite(0x08);
-        Serial.ComWrite(0x74);
-        Serial.ComWrite(0x19);
-
-        Serial.ComWrite(command);
-
-        ushort length = (ushort)payload.Length;
-        Serial.ComWrite((byte)(length & 0xFF));
-        Serial.ComWrite((byte)((length >> 8) & 0xFF));
-
-        foreach (var b in payload)
-        {
-            Serial.ComWrite(b);
-        }
+        TestRunner.SendMessage(CoverageData, payload);
     }
 }

--- a/tests/Cosmos.TestRunner.Framework/TestRunner.cs
+++ b/tests/Cosmos.TestRunner.Framework/TestRunner.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Diagnostics;
 using Cosmos.Kernel.Boot.Limine;
-using Cosmos.Kernel.Core.CPU;
-using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.System.Diagnostics;
 
 namespace Cosmos.TestRunner.Framework
 {
@@ -23,22 +22,8 @@ namespace Cosmos.TestRunner.Framework
         /// <summary>Base of the decimal number system, used when accumulating parsed digits.</summary>
         private const int DecimalBase = 10;
 
-        /// <summary>QEMU kill marker byte 0 of the 0xDE 0xAD 0xBE 0xEF 0xCA 0xFE 0xBA 0xBE end sequence.</summary>
-        private const byte QemuKillMarkerByte0 = 0xDE;
-        /// <summary>QEMU kill marker byte 1 of the end sequence.</summary>
-        private const byte QemuKillMarkerByte1 = 0xAD;
-        /// <summary>QEMU kill marker byte 2 of the end sequence.</summary>
-        private const byte QemuKillMarkerByte2 = 0xBE;
-        /// <summary>QEMU kill marker byte 3 of the end sequence.</summary>
-        private const byte QemuKillMarkerByte3 = 0xEF;
-        /// <summary>QEMU kill marker byte 4 of the end sequence.</summary>
-        private const byte QemuKillMarkerByte4 = 0xCA;
-        /// <summary>QEMU kill marker byte 5 of the end sequence.</summary>
-        private const byte QemuKillMarkerByte5 = 0xFE;
-        /// <summary>QEMU kill marker byte 6 of the end sequence.</summary>
-        private const byte QemuKillMarkerByte6 = 0xBA;
-        /// <summary>QEMU kill marker byte 7 of the end sequence.</summary>
-        private const byte QemuKillMarkerByte7 = 0xBE;
+        /// <summary>End marker telling the QEMU host to kill the VM.</summary>
+        private static ReadOnlySpan<byte> QemuKillMarker => new byte[] { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE };
 
         private static string? _currentSuite;
         private static ushort _testCount;
@@ -104,17 +89,17 @@ namespace Cosmos.TestRunner.Framework
             uint durationMs;
             if (rawMs < 0 || rawMs > MaxSaneDurationMs)
             {
-                Serial.WriteString("[TestRunner] WARN clamped durationMs=");
-                Serial.WriteNumber(rawMs);
-                Serial.WriteString(" startTicks=");
-                Serial.WriteNumber(_testStartTicks);
-                Serial.WriteString(" endTicks=");
-                Serial.WriteNumber(endTicks);
-                Serial.WriteString(" elapsedTicks=");
-                Serial.WriteNumber(elapsedTicks);
-                Serial.WriteString(" freq=");
-                Serial.WriteNumber(freq);
-                Serial.WriteString("\n");
+                Log.WriteString("[TestRunner] WARN clamped durationMs=");
+                Log.WriteNumber(rawMs);
+                Log.WriteString(" startTicks=");
+                Log.WriteNumber(_testStartTicks);
+                Log.WriteString(" endTicks=");
+                Log.WriteNumber(endTicks);
+                Log.WriteString(" elapsedTicks=");
+                Log.WriteNumber(elapsedTicks);
+                Log.WriteString(" freq=");
+                Log.WriteNumber(freq);
+                Log.WriteString("\n");
                 durationMs = (uint)MaxSaneDurationMs;
             }
             else
@@ -382,21 +367,21 @@ namespace Cosmos.TestRunner.Framework
             SendTestSuiteEnd(totalToReport, _passedCount, _failedCount, _skippedCount);
 
             // Also send a text message for fallback/debugging
-            Serial.WriteString("\nTest Suite: ");
-            Serial.WriteString(_currentSuite ?? "Unknown");
-            Serial.WriteString("\nTotal: ");
-            Serial.WriteNumber(_testCount);
+            Log.WriteString("\nTest Suite: ");
+            Log.WriteString(_currentSuite ?? "Unknown");
+            Log.WriteString("\nTotal: ");
+            Log.WriteNumber(_testCount);
             if (_expectedTestCount > 0 && _expectedTestCount != _testCount)
             {
-                Serial.WriteString(" / ");
-                Serial.WriteNumber(_expectedTestCount);
-                Serial.WriteString(" expected");
+                Log.WriteString(" / ");
+                Log.WriteNumber(_expectedTestCount);
+                Log.WriteString(" expected");
             }
-            Serial.WriteString("  Passed: ");
-            Serial.WriteNumber(_passedCount);
-            Serial.WriteString("  Failed: ");
-            Serial.WriteNumber(_failedCount);
-            Serial.WriteString("\n");
+            Log.WriteString("  Passed: ");
+            Log.WriteNumber(_passedCount);
+            Log.WriteString("  Failed: ");
+            Log.WriteNumber(_failedCount);
+            Log.WriteString("\n");
         }
 
         /// <summary>
@@ -411,14 +396,7 @@ namespace Cosmos.TestRunner.Framework
 
             // Send unique end marker: 0xDE 0xAD 0xBE 0xEF 0xCA 0xFE 0xBA 0xBE
             // This sequence tells the QEMU host to kill the VM
-            Serial.ComWrite(QemuKillMarkerByte0);
-            Serial.ComWrite(QemuKillMarkerByte1);
-            Serial.ComWrite(QemuKillMarkerByte2);
-            Serial.ComWrite(QemuKillMarkerByte3);
-            Serial.ComWrite(QemuKillMarkerByte4);
-            Serial.ComWrite(QemuKillMarkerByte5);
-            Serial.ComWrite(QemuKillMarkerByte6);
-            Serial.ComWrite(QemuKillMarkerByte7);
+            Log.WriteBytes(QemuKillMarker);
         }
 
         #region Protocol Message Sending
@@ -450,6 +428,8 @@ namespace Cosmos.TestRunner.Framework
         /// <summary>Shift extracting byte 3 of a little-endian multi-byte value.</summary>
         private const int Byte3Shift = 24;
 
+        /// <summary>Size in bytes of the frame header: 4-byte magic, command byte, little-endian ushort length.</summary>
+        private const int HeaderSizeBytes = 7;
         /// <summary>Size in bytes of a little-endian ushort payload field (test number, expected count).</summary>
         private const int UInt16FieldSizeBytes = 2;
         /// <summary>Payload size of a TestPass message: ushort test number + uint duration in ms.</summary>
@@ -461,34 +441,23 @@ namespace Cosmos.TestRunner.Framework
         /// Send a protocol message with format: [MAGIC:4][Command:1][Length:2][Payload:N]
         /// Magic signature = 0x19740807 (SerialSignature from Consts.cs)
         /// </summary>
-        private static void SendMessage(byte command, byte[] payload)
+        internal static void SendMessage(byte command, byte[] payload)
         {
             // The protocol shares the UART with diagnostic traces written from IRQ handlers
             // and other threads ([SCHED]/[CV] wake logs). A frame must go out as one
-            // uninterrupted byte sequence: an IRQ landing mid-frame interleaves its log into
-            // the message and the host-side parser drops or garbles it.
-            using (InternalCpu.DisableInterruptsScope())
-            {
-                // Send magic signature (0x19740807 little-endian)
-                Serial.ComWrite(SerialSignatureByte0);
-                Serial.ComWrite(SerialSignatureByte1);
-                Serial.ComWrite(SerialSignatureByte2);
-                Serial.ComWrite(SerialSignatureByte3);
-
-                // Send command byte
-                Serial.ComWrite(command);
-
-                // Send length (little-endian ushort)
-                ushort length = (ushort)payload.Length;
-                Serial.ComWrite((byte)(length & ByteMask));
-                Serial.ComWrite((byte)((length >> Byte1Shift) & ByteMask));
-
-                // Send payload
-                foreach (var b in payload)
-                {
-                    Serial.ComWrite(b);
-                }
-            }
+            // uninterrupted byte sequence, so it is assembled up front and emitted through
+            // the atomic Log.WriteBytes.
+            ushort length = (ushort)payload.Length;
+            byte[] frame = new byte[HeaderSizeBytes + payload.Length];
+            frame[0] = SerialSignatureByte0;
+            frame[1] = SerialSignatureByte1;
+            frame[2] = SerialSignatureByte2;
+            frame[3] = SerialSignatureByte3;
+            frame[4] = command;
+            frame[5] = (byte)(length & ByteMask);
+            frame[6] = (byte)((length >> Byte1Shift) & ByteMask);
+            Array.Copy(payload, 0, frame, HeaderSizeBytes, payload.Length);
+            Log.WriteBytes(frame);
         }
 
         /// <summary>

--- a/tests/Kernels/Cosmos.Kernel.Tests.Fat/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Fat/Kernel.cs
@@ -1,5 +1,5 @@
 using System;
-using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.System.Diagnostics;
 using Cosmos.Kernel.HAL.Vfs;
 using Cosmos.Kernel.System.Filesystems.Fat;
 using Cosmos.Kernel.System.Vfs;
@@ -386,7 +386,7 @@ public class Kernel : Sys.Kernel
 
     protected override void BeforeRun()
     {
-        Serial.WriteString("[FatTests] BeforeRun() reached!\n");
+        Log.WriteString("[FatTests] BeforeRun() reached!\n");
 
         TR.Start("FAT Driver Tests", expectedTests: ExpectedTestCount);
 
@@ -1392,7 +1392,7 @@ public class Kernel : Sys.Kernel
 
         TR.Finish();
 
-        Serial.WriteString("\n[Tests Complete - System Halting]\n");
+        Log.WriteString("\n[Tests Complete - System Halting]\n");
     }
 
     protected override void Run()

--- a/tests/Kernels/Cosmos.Kernel.Tests.File/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.File/Kernel.cs
@@ -7,7 +7,7 @@ namespace Cosmos.Kernel.Tests.File;
 // binds to Cosmos.Kernel.System.
 using global::System;
 using global::System.IO;
-using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.System.Diagnostics;
 using Cosmos.Kernel.HAL.Vfs;
 using Cosmos.Kernel.System.Filesystems.Fat;
 using Cosmos.Kernel.System.Vfs;
@@ -46,7 +46,7 @@ public class Kernel : Sys.Kernel
 
     protected override void BeforeRun()
     {
-        Serial.WriteString("[FileTests] BeforeRun() reached!\n");
+        Log.WriteString("[FileTests] BeforeRun() reached!\n");
 
         TR.Start("System.IO File Tests", expectedTests: ExpectedTestCount);
 
@@ -468,7 +468,7 @@ public class Kernel : Sys.Kernel
 
         TR.Finish();
 
-        Serial.WriteString("\n[Tests Complete - System Halting]\n");
+        Log.WriteString("\n[Tests Complete - System Halting]\n");
     }
 
     protected override void Run()

--- a/tests/Kernels/Cosmos.Kernel.Tests.Graphic/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Graphic/Kernel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Drawing;
-using Cosmos.Kernel.Core.IO;
-using Cosmos.Kernel.Core.Memory.Heap;
+using Cosmos.Kernel.System.Diagnostics;
 using Cosmos.Kernel.System.Graphics;
 using Cosmos.Kernel.System.Graphics.Fonts;
 using Cosmos.TestRunner.Framework;
@@ -36,7 +35,7 @@ public class Kernel : Sys.Kernel
 
     protected override void BeforeRun()
     {
-        Serial.WriteString("[Graphic Tests] Starting test suite\n");
+        Log.WriteString("[Graphic Tests] Starting test suite\n");
         TR.Start("Graphic Tests", expectedTests: 23);
 
         TR.Run("PCScreenFont_ChangeFont", TestPCScreenFont);
@@ -76,7 +75,7 @@ public class Kernel : Sys.Kernel
         TR.RunIf(Canvas3DTests.Ready, "Canvas3D_CameraCaching_Fifo", Canvas3DTests.TestCameraCachingFifo, Canvas3DTests.SkipNoDevice);
         TR.Run("Canvas3D_Discovery", Canvas3DTests.TestCanvas3DDiscovery);
 
-        Serial.WriteString("[Graphic Tests] All tests completed\n");
+        Log.WriteString("[Graphic Tests] All tests completed\n");
         TR.Finish();
     }
 
@@ -215,7 +214,7 @@ public class Kernel : Sys.Kernel
         /* First test with the DefaultMode */
         Canvas canvas = KernelConsole.Default.Canvas;
 
-        Serial.Write("Testing Canvas with mode " + canvas.Mode + "\n");
+        Log.Write("Testing Canvas with mode " + canvas.Mode + "\n");
         canvas.Clear(Color.Blue);
 
         /* A red Point */
@@ -335,9 +334,9 @@ public class Kernel : Sys.Kernel
         canvas.Disable();
 
         Console.WriteLine("Back in text mode");
-        Console.WriteLine("Freed: " + Heap.Collect());
+        Console.WriteLine("Freed: " + MemoryInfo.Collect());
 
-        Serial.Write("Test of Canvas with mode " + canvas.Mode + " executed successfully");
+        Log.Write("Test of Canvas with mode " + canvas.Mode + " executed successfully");
     }
 
     private static void TestVirtualCanvas()
@@ -391,6 +390,6 @@ public class Kernel : Sys.Kernel
 
         screen.Display();
 
-        Serial.Write("Virtual canvas tests executed successfully\n");
+        Log.Write("Virtual canvas tests executed successfully\n");
     }
 }

--- a/tests/Kernels/Cosmos.Kernel.Tests.HelloWorld/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.HelloWorld/Kernel.cs
@@ -1,5 +1,5 @@
 using System;
-using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.System.Diagnostics;
 using Cosmos.TestRunner.Framework;
 using Sys = Cosmos.Kernel.System;
 using TR = Cosmos.TestRunner.Framework.TestRunner;
@@ -10,8 +10,8 @@ public class Kernel : Sys.Kernel
 {
     protected override void BeforeRun()
     {
-        Serial.WriteString("[HelloWorld] BeforeRun() reached!\n");
-        Serial.WriteString("[HelloWorld] Starting tests...\n");
+        Log.WriteString("[HelloWorld] BeforeRun() reached!\n");
+        Log.WriteString("[HelloWorld] Starting tests...\n");
 
         // Initialize test suite
         TR.Start("HelloWorld Basic Tests", expectedTests: 3);
@@ -47,7 +47,7 @@ public class Kernel : Sys.Kernel
         TR.Finish();
 
         // Output completion message
-        Serial.WriteString("\n[Tests Complete - System Halting]\n");
+        Log.WriteString("\n[Tests Complete - System Halting]\n");
     }
 
     protected override void Run()

--- a/tests/Kernels/Cosmos.Kernel.Tests.Math/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Math/Kernel.cs
@@ -4,7 +4,7 @@
 // desktop .NET 10 produces; any deviation is a Cosmos bug.
 // -----------------------------------------------------------------------------
 
-using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.System.Diagnostics;
 using Cosmos.TestRunner.Framework;
 using Sys = Cosmos.Kernel.System;
 using TR = Cosmos.TestRunner.Framework.TestRunner;
@@ -62,8 +62,8 @@ public class Kernel : Sys.Kernel
 
     protected override void BeforeRun()
     {
-        Serial.WriteString("[Math] BeforeRun() reached!\n");
-        Serial.WriteString("[Math] Starting System.Math tests...\n");
+        Log.WriteString("[Math] BeforeRun() reached!\n");
+        Log.WriteString("[Math] Starting System.Math tests...\n");
 
         TR.Start("Math Tests", expectedTests: 30);
 
@@ -119,7 +119,7 @@ public class Kernel : Sys.Kernel
 
         TR.Finish();
 
-        Serial.WriteString("\n[Tests Complete - System Halting]\n");
+        Log.WriteString("\n[Tests Complete - System Halting]\n");
     }
 
     protected override void Run()

--- a/tests/Kernels/Cosmos.Kernel.Tests.Network/Cosmos.Kernel.Tests.Network.csproj
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Network/Cosmos.Kernel.Tests.Network.csproj
@@ -5,6 +5,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <!-- The suite exercises the experimental packet seam (COSMOS0002). -->
+    <NoWarn>$(NoWarn);COSMOS0002</NoWarn>
   </PropertyGroup>
 
   <!-- Run the whole protocol suite once per NIC driver, two cells per arch:

--- a/tests/Kernels/Cosmos.Kernel.Tests.Network/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Network/Kernel.cs
@@ -15,6 +15,7 @@ using Cosmos.Kernel.System.Network.IPv4.UDP.DNS;
 using Cosmos.Kernel.System.Timer;
 using Cosmos.TestRunner.Framework;
 using CosmosEndPoint = Cosmos.Kernel.System.Network.IPv4.EndPoint;
+using CosmosUdpClient = Cosmos.Kernel.System.Network.IPv4.UDP.UdpClient;
 using DotNetTcpClient = System.Net.Sockets.TcpClient;
 using DotNetTcpListener = System.Net.Sockets.TcpListener;
 using DotNetUdpClient = System.Net.Sockets.UdpClient;
@@ -49,7 +50,7 @@ public class Kernel : Sys.Kernel
         Log.WriteString("[Network Tests] Starting test suite\n");
 
         // x64 has E1000E network driver
-        TR.Start("Network Tests", expectedTests: 15);
+        TR.Start("Network Tests", expectedTests: 18);
 
         // Network initialization tests
         TR.Run("Network_DeviceDetected", TestNetworkDeviceDetected);
@@ -64,6 +65,11 @@ public class Kernel : Sys.Kernel
         // UDP tests
         TR.Run("UDP_SendPacket", TestUDPSendPacket);
         TR.Run("UDP_ReceivePacket", TestUDPReceivePacket);
+
+        // Packet seam (COSMOS0002): crafted packets through the public packet types
+        TR.Run("PacketSeam_CraftedEchoRoundTrip", TestPacketSeamCraftedEchoRoundTrip);
+        TR.Run("PacketSeam_CraftedUdpRoundTrip", TestPacketSeamCraftedUdpRoundTrip);
+        TR.Run("PacketSeam_SendUnroutableReturnsFalse", TestPacketSeamSendUnroutable);
 
         // TCP tests
         TR.Run("TCP_ClientConnect", TestTCPClientConnect);
@@ -508,6 +514,150 @@ public class Kernel : Sys.Kernel
         }
 
         udpClient.Close();
+    }
+
+    // ==================== Packet Seam Tests ====================
+
+    private static void TestPacketSeamCraftedEchoRoundTrip()
+    {
+        var device = NetworkManager.PrimaryDevice;
+        if (device == null || !device.Ready)
+        {
+            Assert.True(false, "Network device not ready");
+            return;
+        }
+
+        if (!_networkConfigured)
+        {
+            TestDHCPConfiguration();
+        }
+
+        var target = new Address(10, 0, 2, 2);
+        const ushort echoId = 0x4242;
+        const ushort echoSequence = 9;
+
+        var icmpClient = new IcmpClient();
+        icmpClient.Connect(target);
+
+        // Build the echo request ourselves instead of going through SendEcho,
+        // so the reply can be correlated with the id/sequence we chose.
+        var request = new IcmpEchoRequest(_localIP!, target, echoId, echoSequence);
+        Log.WriteString("[Test] Sending crafted echo request id=0x4242 seq=9...\n");
+        Assert.True(NetworkStack.Send(request), "NetworkStack.Send should queue a packet with a configured source address");
+
+        IcmpPacket? replyPacket = icmpClient.ReceivePacket(5000);
+        if (replyPacket == null)
+        {
+            Log.WriteString("[Test] No reply packet within timeout\n");
+            Assert.True(false, "Crafted echo request should get a reply packet");
+            icmpClient.Close();
+            return;
+        }
+
+        if (replyPacket is IcmpEchoReply reply)
+        {
+            Log.WriteString("[Test] Echo reply id=");
+            Log.WriteNumber((ulong)reply.ICMPID);
+            Log.WriteString(" seq=");
+            Log.WriteNumber((ulong)reply.ICMPSequence);
+            Log.WriteString(" from ");
+            Log.WriteString(reply.SourceIP.ToString());
+            Log.WriteString("\n");
+
+            Assert.True(reply.ICMPID == echoId, "Echo reply should carry the identifier the request was built with");
+            Assert.True(reply.ICMPSequence == echoSequence, "Echo reply should carry the sequence number the request was built with");
+            Assert.True(reply.SourceIP.CompareTo(target) == 0, "Echo reply should come from the pinged address");
+        }
+        else
+        {
+            Assert.True(false, "Received ICMP packet should be typed as IcmpEchoReply");
+        }
+
+        icmpClient.Close();
+    }
+
+    private static void TestPacketSeamCraftedUdpRoundTrip()
+    {
+        var device = NetworkManager.PrimaryDevice;
+        if (device == null || !device.Ready)
+        {
+            Assert.True(false, "Network device not ready");
+            return;
+        }
+
+        if (!_networkConfigured)
+        {
+            TestDHCPConfiguration();
+        }
+
+        var gateway = new Address(10, 0, 2, 2);
+        const ushort seamPort = 5559;
+
+        // Bind a Cosmos UdpClient so the echo comes back as a packet object.
+        var udpClient = new CosmosUdpClient(seamPort);
+
+        byte[] payload = Encoding.ASCII.GetBytes("COSMOS_SEAM_TEST");
+        var packet = new UdpPacket(_localIP!, gateway, seamPort, TestPort, payload);
+
+        Log.WriteString("[Test] Sending crafted UDP packet to the echo server...\n");
+        Assert.True(udpClient.Send(packet), "Crafted UDP packet should be queued through the client");
+
+        UdpPacket? echo = udpClient.ReceivePacket(5000);
+        if (echo == null)
+        {
+            Log.WriteString("[Test] No echoed datagram within timeout\n");
+            Assert.True(false, "Echo of the crafted UDP packet should come back as a packet object");
+            udpClient.Close();
+            return;
+        }
+
+        Log.WriteString("[Test] Echoed datagram ");
+        Log.WriteString(echo.SourceIP.ToString());
+        Log.WriteString(":");
+        Log.WriteNumber((ulong)echo.SourcePort);
+        Log.WriteString(" -> port ");
+        Log.WriteNumber((ulong)echo.DestinationPort);
+        Log.WriteString("\n");
+
+        Assert.True(echo.DestinationPort == seamPort, "Echoed datagram should target the port the client is bound to");
+
+        byte[] echoedPayload = echo.UDPData;
+        bool payloadMatches = echoedPayload.Length == payload.Length;
+        if (payloadMatches)
+        {
+            for (int i = 0; i < payload.Length; i++)
+            {
+                if (echoedPayload[i] != payload[i])
+                {
+                    payloadMatches = false;
+                    break;
+                }
+            }
+        }
+        Assert.True(payloadMatches, "Echoed payload should match the crafted payload");
+
+        udpClient.Close();
+    }
+
+    private static void TestPacketSeamSendUnroutable()
+    {
+        var device = NetworkManager.PrimaryDevice;
+        if (device == null || !device.Ready)
+        {
+            Assert.True(false, "Network device not ready");
+            return;
+        }
+
+        if (!_networkConfigured)
+        {
+            TestDHCPConfiguration();
+        }
+
+        // A source address no interface carries: Send must report the drop
+        // instead of pretending the packet went out.
+        var unconfigured = new Address(192, 168, 250, 250);
+        var request = new IcmpEchoRequest(unconfigured, new Address(10, 0, 2, 2), 1, 1);
+        Assert.True(!NetworkStack.Send(request), "Send should return false for a source address no interface carries");
     }
 
     // ==================== TCP Tests ====================

--- a/tests/Kernels/Cosmos.Kernel.Tests.Network/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Network/Kernel.cs
@@ -3,7 +3,7 @@ using System.Collections.Immutable;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
-using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.System.Diagnostics;
 using Cosmos.Kernel.HAL.Devices.Network;
 using Cosmos.Kernel.System.Network;
 using Cosmos.Kernel.System.Network.Config;
@@ -46,7 +46,7 @@ public class Kernel : Sys.Kernel
 
     protected override void BeforeRun()
     {
-        Serial.WriteString("[Network Tests] Starting test suite\n");
+        Log.WriteString("[Network Tests] Starting test suite\n");
 
         // x64 has E1000E network driver
         TR.Start("Network Tests", expectedTests: 15);
@@ -76,7 +76,7 @@ public class Kernel : Sys.Kernel
         TR.Run("DNS_ResolveCnameChain", TestDNSResolveCnameChain);
         TR.Run("DNS_ResolveMultipleARecords", TestDNSResolveMultipleARecords);
 
-        Serial.WriteString("[Network Tests] All tests completed\n");
+        Log.WriteString("[Network Tests] All tests completed\n");
         TR.Finish();
     }
 
@@ -102,9 +102,9 @@ public class Kernel : Sys.Kernel
 
         if (device != null)
         {
-            Serial.WriteString("[Test] Device detected: ");
-            Serial.WriteString(device.Name);
-            Serial.WriteString("\n");
+            Log.WriteString("[Test] Device detected: ");
+            Log.WriteString(device.Name);
+            Log.WriteString("\n");
         }
     }
 
@@ -125,11 +125,11 @@ public class Kernel : Sys.Kernel
             attempts++;
         }
 
-        Serial.WriteString("[Test] Link status: ");
-        Serial.WriteString(device.LinkUp ? "UP" : "DOWN");
-        Serial.WriteString(", Ready: ");
-        Serial.WriteString(device.Ready ? "YES" : "NO");
-        Serial.WriteString("\n");
+        Log.WriteString("[Test] Link status: ");
+        Log.WriteString(device.LinkUp ? "UP" : "DOWN");
+        Log.WriteString(", Ready: ");
+        Log.WriteString(device.Ready ? "YES" : "NO");
+        Log.WriteString("\n");
 
         Assert.True(device.Ready, "Network device should be ready");
     }
@@ -152,30 +152,30 @@ public class Kernel : Sys.Kernel
             return;
         }
 
-        Serial.WriteString("[Test] Starting DHCP auto-configuration...\n");
+        Log.WriteString("[Test] Starting DHCP auto-configuration...\n");
 
         // Use DHCP to auto-assign IP address
         var dhcpClient = new DhcpClient();
 
-        Serial.WriteString("[Test] Sending DHCP Discover packet...\n");
+        Log.WriteString("[Test] Sending DHCP Discover packet...\n");
         int result = dhcpClient.SendDiscoverPacket();
 
         if (result == -1)
         {
-            Serial.WriteString("[Test] DHCP timeout - no response from server\n");
+            Log.WriteString("[Test] DHCP timeout - no response from server\n");
             Assert.True(false, "DHCP should receive response from QEMU DHCP server");
             return;
         }
 
-        Serial.WriteString("[Test] DHCP completed in ");
-        Serial.WriteNumber((ulong)result);
-        Serial.WriteString(" ms\n");
+        Log.WriteString("[Test] DHCP completed in ");
+        Log.WriteNumber((ulong)result);
+        Log.WriteString(" ms\n");
 
         // Verify we got an IP configuration
         var netConfig = NetworkConfigManager.Get(device);
         if (netConfig == null)
         {
-            Serial.WriteString("[Test] No network configuration after DHCP\n");
+            Log.WriteString("[Test] No network configuration after DHCP\n");
             Assert.True(false, "Network should be configured after DHCP");
             return;
         }
@@ -184,12 +184,12 @@ public class Kernel : Sys.Kernel
         _gatewayIP = netConfig.DefaultGateway;
         _networkConfigured = true;
 
-        Serial.WriteString("[Test] DHCP assigned IP: ");
-        Serial.WriteString(_localIP.ToString());
-        Serial.WriteString("\n");
-        Serial.WriteString("[Test] Gateway: ");
-        Serial.WriteString(_gatewayIP.ToString());
-        Serial.WriteString("\n");
+        Log.WriteString("[Test] DHCP assigned IP: ");
+        Log.WriteString(_localIP.ToString());
+        Log.WriteString("\n");
+        Log.WriteString("[Test] Gateway: ");
+        Log.WriteString(_gatewayIP.ToString());
+        Log.WriteString("\n");
 
         // Verify device has packet handler registered
         Assert.True(device.OnPacketReceived != null, "Device should have packet handler registered after DHCP");
@@ -218,9 +218,9 @@ public class Kernel : Sys.Kernel
         // gateway address itself, so no host-side helper is needed.
         var target = new Address(10, 0, 2, 2);
 
-        Serial.WriteString("[Test] Pinging ");
-        Serial.WriteString(target.ToString());
-        Serial.WriteString("...\n");
+        Log.WriteString("[Test] Pinging ");
+        Log.WriteString(target.ToString());
+        Log.WriteString("...\n");
 
         var icmpClient = new IcmpClient();
         icmpClient.Connect(target);
@@ -231,17 +231,17 @@ public class Kernel : Sys.Kernel
 
         if (time >= 0)
         {
-            Serial.WriteString("[Test] Echo reply from ");
-            Serial.WriteString(endpoint.Address.ToString());
-            Serial.WriteString(" in ");
-            Serial.WriteNumber((ulong)time);
-            Serial.WriteString(" ms\n");
+            Log.WriteString("[Test] Echo reply from ");
+            Log.WriteString(endpoint.Address.ToString());
+            Log.WriteString(" in ");
+            Log.WriteNumber((ulong)time);
+            Log.WriteString(" ms\n");
 
             Assert.True(endpoint.Address.CompareTo(target) == 0, "Echo reply should come from the pinged address");
         }
         else
         {
-            Serial.WriteString("[Test] No echo reply within timeout\n");
+            Log.WriteString("[Test] No echo reply within timeout\n");
             Assert.True(false, "Should receive ICMP echo reply from gateway");
         }
 
@@ -265,7 +265,7 @@ public class Kernel : Sys.Kernel
         // The test runner's IcmpTestServer pings our IP every 500 ms through
         // the raw-Ethernet hub port (slirp cannot forward host-sourced ICMP).
         // Phase 1: wait until the echo responder answered at least one request.
-        Serial.WriteString("[Test] Waiting for ICMP echo request from host...\n");
+        Log.WriteString("[Test] Waiting for ICMP echo request from host...\n");
 
         int waited = 0;
         while (IcmpPacket.EchoRequestsReplied < 1 && waited < 10000)
@@ -276,20 +276,20 @@ public class Kernel : Sys.Kernel
 
         if (IcmpPacket.EchoRequestsReplied < 1)
         {
-            Serial.WriteString("[Test] No echo request received from host within timeout\n");
+            Log.WriteString("[Test] No echo request received from host within timeout\n");
             Assert.True(false, "Host echo request should reach the kernel and be answered");
             return;
         }
 
-        Serial.WriteString("[Test] Answered ");
-        Serial.WriteNumber((ulong)IcmpPacket.EchoRequestsReplied);
-        Serial.WriteString(" echo request(s) from host\n");
+        Log.WriteString("[Test] Answered ");
+        Log.WriteNumber((ulong)IcmpPacket.EchoRequestsReplied);
+        Log.WriteString(" echo request(s) from host\n");
         Assert.True(true, "Host echo request received and answered");
 
         // Phase 2: the host validates our echo reply (checksum + payload) and
         // only then switches its request payload from COSMOS_PING to HOST_OK —
         // seeing it proves the full host->guest->host round trip.
-        Serial.WriteString("[Test] Waiting for HOST_OK acknowledgment payload...\n");
+        Log.WriteString("[Test] Waiting for HOST_OK acknowledgment payload...\n");
 
         bool hostAck = false;
         waited = 0;
@@ -312,11 +312,11 @@ public class Kernel : Sys.Kernel
 
         if (hostAck)
         {
-            Serial.WriteString("[Test] Host acknowledged a valid echo reply\n");
+            Log.WriteString("[Test] Host acknowledged a valid echo reply\n");
         }
         else
         {
-            Serial.WriteString("[Test] No HOST_OK payload within timeout\n");
+            Log.WriteString("[Test] No HOST_OK payload within timeout\n");
         }
 
         Assert.True(hostAck, "Host should confirm it received a valid echo reply");
@@ -338,7 +338,7 @@ public class Kernel : Sys.Kernel
             TestDHCPConfiguration();
         }
 
-        Serial.WriteString("[Test] Creating .NET UdpClient...\n");
+        Log.WriteString("[Test] Creating .NET UdpClient...\n");
 
         // Use .NET UdpClient (plugged by SocketPlug)
         var udpClient = new DotNetUdpClient(TestPort);
@@ -350,11 +350,11 @@ public class Kernel : Sys.Kernel
         // Gateway IP for QEMU user networking
         var gatewayEndpoint = new IPEndPoint(IPAddress.Parse("10.0.2.2"), TestPort);
 
-        Serial.WriteString("[Test] Sending UDP packet to ");
-        Serial.WriteString(gatewayEndpoint.Address.ToString());
-        Serial.WriteString(":");
-        Serial.WriteNumber(TestPort);
-        Serial.WriteString("\n");
+        Log.WriteString("[Test] Sending UDP packet to ");
+        Log.WriteString(gatewayEndpoint.Address.ToString());
+        Log.WriteString(":");
+        Log.WriteNumber(TestPort);
+        Log.WriteString("\n");
 
         int bytesSent = udpClient.Send(payload, payload.Length, gatewayEndpoint);
         if (bytesSent <= 0)
@@ -364,9 +364,9 @@ public class Kernel : Sys.Kernel
             return;
         }
 
-        Serial.WriteString("[Test] UDP packet sent (");
-        Serial.WriteNumber((ulong)bytesSent);
-        Serial.WriteString(" bytes), waiting for echo...\n");
+        Log.WriteString("[Test] UDP packet sent (");
+        Log.WriteNumber((ulong)bytesSent);
+        Log.WriteString(" bytes), waiting for echo...\n");
 
         // Wait for echo from test runner (it echoes our packet back)
         IPEndPoint remoteEP = new IPEndPoint(IPAddress.Any, 0);
@@ -393,13 +393,13 @@ public class Kernel : Sys.Kernel
 
         if (receivedData != null && receivedData.Length > 0)
         {
-            Serial.WriteString("[Test] Received echo from ");
-            Serial.WriteString(remoteEP.Address.ToString());
-            Serial.WriteString(":");
-            Serial.WriteNumber((ulong)remoteEP.Port);
-            Serial.WriteString(" with ");
-            Serial.WriteNumber((ulong)receivedData.Length);
-            Serial.WriteString(" bytes\n");
+            Log.WriteString("[Test] Received echo from ");
+            Log.WriteString(remoteEP.Address.ToString());
+            Log.WriteString(":");
+            Log.WriteNumber((ulong)remoteEP.Port);
+            Log.WriteString(" with ");
+            Log.WriteNumber((ulong)receivedData.Length);
+            Log.WriteString(" bytes\n");
 
             // Validate the echo matches what we sent
             string receivedMessage = Encoding.ASCII.GetString(receivedData);
@@ -407,20 +407,20 @@ public class Kernel : Sys.Kernel
 
             if (contentValid)
             {
-                Serial.WriteString("[Test] Echo validated: COSMOS_UDP_TEST\n");
+                Log.WriteString("[Test] Echo validated: COSMOS_UDP_TEST\n");
                 Assert.True(true, "UDP send and echo received with correct content");
             }
             else
             {
-                Serial.WriteString("[Test] Echo content mismatch! Expected: COSMOS_UDP_TEST, Got: ");
-                Serial.WriteString(receivedMessage);
-                Serial.WriteString("\n");
+                Log.WriteString("[Test] Echo content mismatch! Expected: COSMOS_UDP_TEST, Got: ");
+                Log.WriteString(receivedMessage);
+                Log.WriteString("\n");
                 Assert.True(false, "UDP echo content should match COSMOS_UDP_TEST");
             }
         }
         else
         {
-            Serial.WriteString("[Test] No echo received within timeout\n");
+            Log.WriteString("[Test] No echo received within timeout\n");
             Assert.True(false, "Should receive echo from test runner");
         }
 
@@ -441,14 +441,14 @@ public class Kernel : Sys.Kernel
             TestDHCPConfiguration();
         }
 
-        Serial.WriteString("[Test] Creating .NET UdpClient on port ");
-        Serial.WriteNumber(EchoPort);
-        Serial.WriteString("...\n");
+        Log.WriteString("[Test] Creating .NET UdpClient on port ");
+        Log.WriteNumber(EchoPort);
+        Log.WriteString("...\n");
 
         // Use .NET UdpClient (plugged by SocketPlug)
         var udpClient = new DotNetUdpClient(EchoPort);
 
-        Serial.WriteString("[Test] Waiting for UDP packet from test runner...\n");
+        Log.WriteString("[Test] Waiting for UDP packet from test runner...\n");
 
         // Wait for packet from test runner (it sends "TEST_FROM_HOST" to port 5556)
         IPEndPoint remoteEP = new IPEndPoint(IPAddress.Any, 0);
@@ -475,13 +475,13 @@ public class Kernel : Sys.Kernel
 
         if (receivedData != null && receivedData.Length > 0)
         {
-            Serial.WriteString("[Test] Received UDP packet from ");
-            Serial.WriteString(remoteEP.Address.ToString());
-            Serial.WriteString(":");
-            Serial.WriteNumber((ulong)remoteEP.Port);
-            Serial.WriteString(" with ");
-            Serial.WriteNumber((ulong)receivedData.Length);
-            Serial.WriteString(" bytes\n");
+            Log.WriteString("[Test] Received UDP packet from ");
+            Log.WriteString(remoteEP.Address.ToString());
+            Log.WriteString(":");
+            Log.WriteNumber((ulong)remoteEP.Port);
+            Log.WriteString(" with ");
+            Log.WriteNumber((ulong)receivedData.Length);
+            Log.WriteString(" bytes\n");
 
             // Validate exact content from test runner
             string receivedMessage = Encoding.ASCII.GetString(receivedData);
@@ -490,20 +490,20 @@ public class Kernel : Sys.Kernel
 
             if (contentValid)
             {
-                Serial.WriteString("[Test] Content validated: TEST_FROM_HOST\n");
+                Log.WriteString("[Test] Content validated: TEST_FROM_HOST\n");
                 Assert.True(true, "UDP packet received with correct content");
             }
             else
             {
-                Serial.WriteString("[Test] Content mismatch! Expected: TEST_FROM_HOST, Got: ");
-                Serial.WriteString(receivedMessage);
-                Serial.WriteString("\n");
+                Log.WriteString("[Test] Content mismatch! Expected: TEST_FROM_HOST, Got: ");
+                Log.WriteString(receivedMessage);
+                Log.WriteString("\n");
                 Assert.True(false, "UDP packet content should match TEST_FROM_HOST");
             }
         }
         else
         {
-            Serial.WriteString("[Test] No UDP packet received within timeout\n");
+            Log.WriteString("[Test] No UDP packet received within timeout\n");
             Assert.True(false, "Should receive UDP packet from test runner");
         }
 
@@ -526,35 +526,35 @@ public class Kernel : Sys.Kernel
             TestDHCPConfiguration();
         }
 
-        Serial.WriteString("[Test] Creating .NET TcpClient...\n");
+        Log.WriteString("[Test] Creating .NET TcpClient...\n");
 
         try
         {
             // Create TCP client and connect to test runner (gateway on port 5557)
             var tcpClient = new DotNetTcpClient();
 
-            Serial.WriteString("[Test] Connecting to ");
-            Serial.WriteString("10.0.2.2:");
-            Serial.WriteNumber(TcpClientPort);
-            Serial.WriteString("...\n");
+            Log.WriteString("[Test] Connecting to ");
+            Log.WriteString("10.0.2.2:");
+            Log.WriteNumber(TcpClientPort);
+            Log.WriteString("...\n");
 
             tcpClient.Connect(IPAddress.Parse("10.0.2.2"), TcpClientPort);
 
-            Serial.WriteString("[Test] Connected! Sending data...\n");
+            Log.WriteString("[Test] Connected! Sending data...\n");
 
             // Send test message
-            Serial.WriteString("[Test] Getting stream...\n");
+            Log.WriteString("[Test] Getting stream...\n");
             var stream = tcpClient.GetStream();
-            Serial.WriteString("[Test] Got stream, preparing message...\n");
+            Log.WriteString("[Test] Got stream, preparing message...\n");
             string message = "COSMOS_TCP_TEST";
             byte[] payload = Encoding.ASCII.GetBytes(message);
-            Serial.WriteString("[Test] Writing to stream...\n");
+            Log.WriteString("[Test] Writing to stream...\n");
             stream.Write(payload, 0, payload.Length);
-            Serial.WriteString("[Test] Write complete\n");
+            Log.WriteString("[Test] Write complete\n");
 
-            Serial.WriteString("[Test] Sent '");
-            Serial.WriteString(message);
-            Serial.WriteString("', waiting for echo...\n");
+            Log.WriteString("[Test] Sent '");
+            Log.WriteString(message);
+            Log.WriteString("', waiting for echo...\n");
 
             // Wait for echo from test runner
             byte[] buffer = new byte[256];
@@ -577,35 +577,35 @@ public class Kernel : Sys.Kernel
             if (bytesRead > 0)
             {
                 string receivedMessage = Encoding.ASCII.GetString(buffer, 0, bytesRead);
-                Serial.WriteString("[Test] Received echo: '");
-                Serial.WriteString(receivedMessage);
-                Serial.WriteString("'\n");
+                Log.WriteString("[Test] Received echo: '");
+                Log.WriteString(receivedMessage);
+                Log.WriteString("'\n");
 
                 bool contentValid = receivedMessage == message;
                 if (contentValid)
                 {
-                    Serial.WriteString("[Test] Echo validated!\n");
+                    Log.WriteString("[Test] Echo validated!\n");
                     Assert.True(true, "TCP connect and echo received with correct content");
                 }
                 else
                 {
-                    Serial.WriteString("[Test] Echo content mismatch!\n");
+                    Log.WriteString("[Test] Echo content mismatch!\n");
                     Assert.True(false, "TCP echo content should match");
                 }
             }
             else
             {
-                Serial.WriteString("[Test] No echo received within timeout\n");
+                Log.WriteString("[Test] No echo received within timeout\n");
                 Assert.True(false, "Should receive echo from test runner");
             }
 
-            Serial.WriteString("[Test] Closing TCP client...\n");
+            Log.WriteString("[Test] Closing TCP client...\n");
             tcpClient.Close();
-            Serial.WriteString("[Test] TCP client closed successfully\n");
+            Log.WriteString("[Test] TCP client closed successfully\n");
         }
         catch
         {
-            Serial.WriteString("[Test] TCP connect failed with exception\n");
+            Log.WriteString("[Test] TCP connect failed with exception\n");
             Assert.True(false, "TCP connect failed with exception");
         }
     }
@@ -624,9 +624,9 @@ public class Kernel : Sys.Kernel
             TestDHCPConfiguration();
         }
 
-        Serial.WriteString("[Test] Creating .NET TcpListener on port ");
-        Serial.WriteNumber(TcpServerPort);
-        Serial.WriteString("...\n");
+        Log.WriteString("[Test] Creating .NET TcpListener on port ");
+        Log.WriteNumber(TcpServerPort);
+        Log.WriteString("...\n");
 
         try
         {
@@ -634,7 +634,7 @@ public class Kernel : Sys.Kernel
             var listener = new DotNetTcpListener(IPAddress.Any, TcpServerPort);
             listener.Start();
 
-            Serial.WriteString("[Test] Listening, waiting for connection from test runner...\n");
+            Log.WriteString("[Test] Listening, waiting for connection from test runner...\n");
 
             // Wait for connection from test runner (it connects after a delay)
             DotNetTcpClient? client = null;
@@ -655,7 +655,7 @@ public class Kernel : Sys.Kernel
 
             if (client != null)
             {
-                Serial.WriteString("[Test] Accepted connection!\n");
+                Log.WriteString("[Test] Accepted connection!\n");
 
                 var stream = client.GetStream();
 
@@ -680,30 +680,30 @@ public class Kernel : Sys.Kernel
                 if (bytesRead > 0)
                 {
                     string receivedMessage = Encoding.ASCII.GetString(buffer, 0, bytesRead);
-                    Serial.WriteString("[Test] Received: '");
-                    Serial.WriteString(receivedMessage);
-                    Serial.WriteString("'\n");
+                    Log.WriteString("[Test] Received: '");
+                    Log.WriteString(receivedMessage);
+                    Log.WriteString("'\n");
 
                     // Echo back
                     stream.Write(buffer, 0, bytesRead);
-                    Serial.WriteString("[Test] Echoed data back\n");
+                    Log.WriteString("[Test] Echoed data back\n");
 
                     string expectedMessage = "TEST_FROM_HOST";
                     bool contentValid = receivedMessage == expectedMessage;
                     if (contentValid)
                     {
-                        Serial.WriteString("[Test] Content validated!\n");
+                        Log.WriteString("[Test] Content validated!\n");
                         Assert.True(true, "TCP server accept and received correct content");
                     }
                     else
                     {
-                        Serial.WriteString("[Test] Content mismatch! Expected: TEST_FROM_HOST\n");
+                        Log.WriteString("[Test] Content mismatch! Expected: TEST_FROM_HOST\n");
                         Assert.True(false, "TCP received content should match TEST_FROM_HOST");
                     }
                 }
                 else
                 {
-                    Serial.WriteString("[Test] No data received within timeout\n");
+                    Log.WriteString("[Test] No data received within timeout\n");
                     Assert.True(false, "Should receive data from test runner");
                 }
 
@@ -711,7 +711,7 @@ public class Kernel : Sys.Kernel
             }
             else
             {
-                Serial.WriteString("[Test] No connection received within timeout\n");
+                Log.WriteString("[Test] No connection received within timeout\n");
                 Assert.True(false, "Should receive connection from test runner");
             }
 
@@ -719,9 +719,9 @@ public class Kernel : Sys.Kernel
         }
         catch (Exception ex)
         {
-            Serial.WriteString("[Test] TCP server failed: ");
-            Serial.WriteString(ex.Message);
-            Serial.WriteString("\n");
+            Log.WriteString("[Test] TCP server failed: ");
+            Log.WriteString(ex.Message);
+            Log.WriteString("\n");
             Assert.True(false, "TCP server failed with exception");
         }
     }
@@ -740,9 +740,9 @@ public class Kernel : Sys.Kernel
             TestDHCPConfiguration();
         }
 
-        Serial.WriteString("[Test] Connecting to lingering host peer at 10.0.2.2:");
-        Serial.WriteNumber(TcpLingerPort);
-        Serial.WriteString("...\n");
+        Log.WriteString("[Test] Connecting to lingering host peer at 10.0.2.2:");
+        Log.WriteNumber(TcpLingerPort);
+        Log.WriteString("...\n");
 
         try
         {
@@ -754,9 +754,9 @@ public class Kernel : Sys.Kernel
             byte[] payload = Encoding.ASCII.GetBytes(message);
             stream.Write(payload, 0, payload.Length);
 
-            Serial.WriteString("[Test] Sent '");
-            Serial.WriteString(message);
-            Serial.WriteString("', waiting for echo...\n");
+            Log.WriteString("[Test] Sent '");
+            Log.WriteString(message);
+            Log.WriteString("', waiting for echo...\n");
 
             // Wait for the echo so we know the peer consumed our data and is
             // now idling with its half of the connection deliberately open.
@@ -779,12 +779,12 @@ public class Kernel : Sys.Kernel
 
             if (bytesRead == 0)
             {
-                Serial.WriteString("[Test] No echo received within timeout\n");
+                Log.WriteString("[Test] No echo received within timeout\n");
                 Assert.True(false, "Should receive echo from lingering host peer");
                 return;
             }
 
-            Serial.WriteString("[Test] Echo received; closing while the peer holds the connection open...\n");
+            Log.WriteString("[Test] Echo received; closing while the peer holds the connection open...\n");
 
             // Issue #369: the peer never sends its FIN, so a synchronous close
             // waiting for CLOSED throws. Standard sockets semantics: Close()
@@ -793,18 +793,18 @@ public class Kernel : Sys.Kernel
             try
             {
                 tcpClient.Close();
-                Serial.WriteString("[Test] Close() returned without throwing\n");
+                Log.WriteString("[Test] Close() returned without throwing\n");
                 Assert.True(true, "Close() succeeds while the peer holds the connection open");
             }
             catch
             {
-                Serial.WriteString("[Test] Close() threw!\n");
+                Log.WriteString("[Test] Close() threw!\n");
                 Assert.True(false, "Close() must not throw when the peer does not FIN");
             }
         }
         catch
         {
-            Serial.WriteString("[Test] TCP lingering-close test failed with exception\n");
+            Log.WriteString("[Test] TCP lingering-close test failed with exception\n");
             Assert.True(false, "TCP lingering-close test failed with exception");
         }
     }
@@ -813,7 +813,7 @@ public class Kernel : Sys.Kernel
 
     private static void TestDNSClientCreate()
     {
-        Serial.WriteString("[Test] Creating DNS client...\n");
+        Log.WriteString("[Test] Creating DNS client...\n");
 
         // Create DNS client
         var dnsClient = new DnsClient();
@@ -840,11 +840,11 @@ public class Kernel : Sys.Kernel
         }
         Assert.True(foundCloudflare, "DNS server 1.1.1.1 should be in nameservers list");
 
-        Serial.WriteString("[Test] DNS client created successfully\n");
-        Serial.WriteString("[Test] DNS server configured: ");
-        Serial.WriteString(dnsServer.ToString());
-        Serial.WriteString("\n");
-        Serial.WriteString("[Test] Verified 1.1.1.1 is in DNS nameservers list\n");
+        Log.WriteString("[Test] DNS client created successfully\n");
+        Log.WriteString("[Test] DNS server configured: ");
+        Log.WriteString(dnsServer.ToString());
+        Log.WriteString("\n");
+        Log.WriteString("[Test] Verified 1.1.1.1 is in DNS nameservers list\n");
 
         dnsClient.Close();
     }
@@ -863,7 +863,7 @@ public class Kernel : Sys.Kernel
             TestDHCPConfiguration();
         }
 
-        Serial.WriteString("[Test] Resolving valentin.bzh via DNS...\n");
+        Log.WriteString("[Test] Resolving valentin.bzh via DNS...\n");
 
         // Configure DNS server (Cloudflare's public DNS)
         var dnsServer = new Address(1, 1, 1, 1);
@@ -873,15 +873,15 @@ public class Kernel : Sys.Kernel
         var dnsClient = new DnsClient();
         dnsClient.Connect(dnsServer);
 
-        Serial.WriteString("[Test] Connected to DNS server: ");
-        Serial.WriteString(dnsServer.ToString());
-        Serial.WriteString("\n");
+        Log.WriteString("[Test] Connected to DNS server: ");
+        Log.WriteString(dnsServer.ToString());
+        Log.WriteString("\n");
 
         // Send DNS query for valentin.bzh
         string domain = "valentin.bzh";
-        Serial.WriteString("[Test] Sending DNS query for: ");
-        Serial.WriteString(domain);
-        Serial.WriteString("\n");
+        Log.WriteString("[Test] Sending DNS query for: ");
+        Log.WriteString(domain);
+        Log.WriteString("\n");
 
         dnsClient.SendAsk(domain);
 
@@ -890,10 +890,10 @@ public class Kernel : Sys.Kernel
 
         if (resolvedIP != null)
         {
-            Serial.WriteString("[Test] DNS resolution successful!\n");
-            Serial.WriteString("[Test] valentin.bzh resolved to: ");
-            Serial.WriteString(resolvedIP.ToString());
-            Serial.WriteString("\n");
+            Log.WriteString("[Test] DNS resolution successful!\n");
+            Log.WriteString("[Test] valentin.bzh resolved to: ");
+            Log.WriteString(resolvedIP.ToString());
+            Log.WriteString("\n");
 
             // Verify we got a valid IP (not 0.0.0.0)
             Assert.True(resolvedIP.Id != 0, "Resolved IP should not be 0.0.0.0");
@@ -901,7 +901,7 @@ public class Kernel : Sys.Kernel
         }
         else
         {
-            Serial.WriteString("[Test] DNS resolution timed out or failed\n");
+            Log.WriteString("[Test] DNS resolution timed out or failed\n");
             // Don't fail the test on timeout - network may not be available in test environment
             Assert.True(true, "DNS query sent (timeout may occur in isolated test environment)");
         }
@@ -927,9 +927,9 @@ public class Kernel : Sys.Kernel
         // answer carry the canonical name, not the queried one. A non-empty
         // result proves ReceiveAll followed the CNAME chain.
         string domain = "www.github.com";
-        Serial.WriteString("[Test] Resolving CNAME chain for ");
-        Serial.WriteString(domain);
-        Serial.WriteString("...\n");
+        Log.WriteString("[Test] Resolving CNAME chain for ");
+        Log.WriteString(domain);
+        Log.WriteString("...\n");
 
         var dnsServer = new Address(1, 1, 1, 1);
         var dnsClient = new DnsClient();
@@ -941,18 +941,18 @@ public class Kernel : Sys.Kernel
 
         if (addresses != null)
         {
-            Serial.WriteString("[Test] CNAME chain resolved to ");
-            Serial.WriteNumber((ulong)addresses.Count);
-            Serial.WriteString(" address(es), first: ");
-            Serial.WriteString(addresses[0].ToString());
-            Serial.WriteString("\n");
+            Log.WriteString("[Test] CNAME chain resolved to ");
+            Log.WriteNumber((ulong)addresses.Count);
+            Log.WriteString(" address(es), first: ");
+            Log.WriteString(addresses[0].ToString());
+            Log.WriteString("\n");
 
             Assert.True(addresses.Count > 0, "CNAME chain should yield at least one A record");
             Assert.True(addresses[0].Id != 0, "Resolved IP should not be 0.0.0.0");
         }
         else
         {
-            Serial.WriteString("[Test] DNS resolution timed out or failed\n");
+            Log.WriteString("[Test] DNS resolution timed out or failed\n");
             // Don't fail the test on timeout - network may not be available in test environment
             Assert.True(true, "DNS query sent (timeout may occur in isolated test environment)");
         }
@@ -977,9 +977,9 @@ public class Kernel : Sys.Kernel
         // one.one.one.one stably resolves to exactly two A records:
         // 1.1.1.1 and 1.0.0.1.
         string domain = "one.one.one.one";
-        Serial.WriteString("[Test] Resolving multiple A records for ");
-        Serial.WriteString(domain);
-        Serial.WriteString("...\n");
+        Log.WriteString("[Test] Resolving multiple A records for ");
+        Log.WriteString(domain);
+        Log.WriteString("...\n");
 
         var dnsServer = new Address(1, 1, 1, 1);
         var dnsClient = new DnsClient();
@@ -991,16 +991,16 @@ public class Kernel : Sys.Kernel
 
         if (addresses != null)
         {
-            Serial.WriteString("[Test] Got ");
-            Serial.WriteNumber((ulong)addresses.Count);
-            Serial.WriteString(" address(es):\n");
+            Log.WriteString("[Test] Got ");
+            Log.WriteNumber((ulong)addresses.Count);
+            Log.WriteString(" address(es):\n");
 
             bool allCloudflare = true;
             for (int i = 0; i < addresses.Count; i++)
             {
-                Serial.WriteString("[Test]   ");
-                Serial.WriteString(addresses[i].ToString());
-                Serial.WriteString("\n");
+                Log.WriteString("[Test]   ");
+                Log.WriteString(addresses[i].ToString());
+                Log.WriteString("\n");
 
                 ImmutableArray<byte> bytes = addresses[i].Parts;
                 bool isOneOneOneOne = bytes[0] == 1 && bytes[1] == 1 && bytes[2] == 1 && bytes[3] == 1;
@@ -1016,7 +1016,7 @@ public class Kernel : Sys.Kernel
         }
         else
         {
-            Serial.WriteString("[Test] DNS resolution timed out or failed\n");
+            Log.WriteString("[Test] DNS resolution timed out or failed\n");
             // Don't fail the test on timeout - network may not be available in test environment
             Assert.True(true, "DNS query sent (timeout may occur in isolated test environment)");
         }

--- a/tests/Kernels/Cosmos.Kernel.Tests.Pci/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Pci/Kernel.cs
@@ -1,5 +1,5 @@
 using System;
-using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.System.Diagnostics;
 using Cosmos.Kernel.HAL.Pci;
 using Cosmos.TestRunner.Framework;
 using Sys = Cosmos.Kernel.System;
@@ -37,7 +37,7 @@ public class Kernel : Sys.Kernel
 
     protected override void BeforeRun()
     {
-        Serial.WriteString("[Pci] BeforeRun() reached!\n");
+        Log.WriteString("[Pci] BeforeRun() reached!\n");
 
         TR.Start("PCI Subsystem Tests", expectedTests: ExpectedTestCount);
 
@@ -63,7 +63,7 @@ public class Kernel : Sys.Kernel
 
         TR.Finish();
 
-        Serial.WriteString("\n[Tests Complete - System Halting]\n");
+        Log.WriteString("\n[Tests Complete - System Halting]\n");
     }
 
     protected override void Run() => Stop();

--- a/tests/Kernels/Cosmos.Kernel.Tests.Power/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Power/Kernel.cs
@@ -1,5 +1,5 @@
 using System;
-using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.System.Diagnostics;
 using Cosmos.Kernel.HAL;
 using Cosmos.TestRunner.Framework;
 using Sys = Cosmos.Kernel.System;
@@ -19,9 +19,9 @@ public class Kernel : Sys.Kernel
     {
         int skip = TR.GetSkipCount();
 
-        Serial.WriteString("[Power Tests] BeforeRun() reached, skip=");
-        Serial.WriteNumber((uint)skip);
-        Serial.WriteString("\n");
+        Log.WriteString("[Power Tests] BeforeRun() reached, skip=");
+        Log.WriteNumber((uint)skip);
+        Log.WriteString("\n");
 
         TR.Start("Power Tests", expectedTests: 5);
 
@@ -44,14 +44,14 @@ public class Kernel : Sys.Kernel
         // Test #4: Reboot. Fires on skip=0, replays as already-passed otherwise.
         if (skip == 0)
         {
-            Serial.WriteString("[Power Tests] About to invoke Power.Reboot() — QEMU should exit\n");
+            Log.WriteString("[Power Tests] About to invoke Power.Reboot() — QEMU should exit\n");
             TR.RunDestructive(
                 "Reboot_FiresAndExits",
                 () => Sys.Power.Reboot(),
                 "Power.Reboot() returned without rebooting");
             // Only reached if Reboot didn't fire.
             TR.Finish();
-            Serial.WriteString("[Power Tests] FATAL: reached post-Reboot epilogue\n");
+            Log.WriteString("[Power Tests] FATAL: reached post-Reboot epilogue\n");
             return;
         }
         TR.Run("Reboot_FiresAndExits", () => { });
@@ -59,14 +59,14 @@ public class Kernel : Sys.Kernel
         // Test #5: Shutdown. Fires on skip=1, replays as already-passed otherwise.
         if (skip == 1)
         {
-            Serial.WriteString("[Power Tests] About to invoke Power.Shutdown() — QEMU should exit\n");
+            Log.WriteString("[Power Tests] About to invoke Power.Shutdown() — QEMU should exit\n");
             TR.RunDestructive(
                 "Shutdown_FiresAndExits",
                 () => Sys.Power.Shutdown(),
                 "Power.Shutdown() returned without powering off");
             // Only reached if Shutdown didn't fire.
             TR.Finish();
-            Serial.WriteString("[Power Tests] FATAL: reached post-Shutdown epilogue\n");
+            Log.WriteString("[Power Tests] FATAL: reached post-Shutdown epilogue\n");
             return;
         }
         TR.Run("Shutdown_FiresAndExits", () => { });

--- a/tests/Kernels/Cosmos.Kernel.Tests.Threading/Cosmos.Kernel.Tests.Threading.csproj
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Threading/Cosmos.Kernel.Tests.Threading.csproj
@@ -5,6 +5,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <!-- White-box suite over the experimental scheduler seam (COSMOS0001). -->
+    <NoWarn>$(NoWarn);COSMOS0001</NoWarn>
   </PropertyGroup>
 
   <!-- Core kernel packages (using project references for development) -->

--- a/tests/Kernels/Cosmos.Kernel.Tests.Threading/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Threading/Kernel.cs
@@ -8,6 +8,7 @@ using Cosmos.Kernel.System.Timer;
 using Cosmos.TestRunner.Framework;
 using Sys = Cosmos.Kernel.System;
 using Monitor = System.Threading.Monitor;
+using SchedThread = Cosmos.Kernel.Core.Scheduler.Thread;
 using SysThread = System.Threading.Thread;
 using TR = Cosmos.TestRunner.Framework.TestRunner;
 
@@ -16,7 +17,7 @@ namespace Cosmos.Kernel.Tests.Threading;
 public class Kernel : Sys.Kernel
 {
     /// <summary>Total number of tests announced to the test runner for this suite.</summary>
-    private const int ExpectedTestCount = 58;
+    private const int ExpectedTestCount = 73;
 
     /// <summary>Lock/unlock increment iterations each worker thread performs in the lock and spinlock contention tests.</summary>
     private const int LockIterationsPerThread = 100;
@@ -65,6 +66,31 @@ public class Kernel : Sys.Kernel
     private const int ThreadStaticsWaitMs = 100;
     /// <summary>Delay (ms) between increments in each multiple-threads worker iteration.</summary>
     private const int WorkerStepDelayMs = 50;
+
+    /// <summary>Duration (ms) of each CPU-share measurement window in the scheduling-policy tests.</summary>
+    private const int PolicyMeasureMs = 1500;
+    /// <summary>Interval (ms) between the spinner-progress samples of the quantum-preemption test.</summary>
+    private const int PreemptSampleIntervalMs = 100;
+    /// <summary>Iteration mask deciding how often a measured spinner re-checks its stop flag.</summary>
+    private const ulong SpinStopCheckMask = 0xFFF;
+    /// <summary>Stride tickets given to the favored spinner of the proportional-share tests.</summary>
+    private const long HighTickets = 400;
+    /// <summary>Stride tickets given to the other spinner (the Stride default).</summary>
+    private const long LowTickets = 100;
+    // The two policies are separated by one ratio, applied from both sides:
+    // the 4x-ticket spinner must clear it under Stride, and neither spinner may
+    // reach it under Round-Robin. 3/2 sits in the gap with margin on both
+    // arches — measured A/B was 1.92 (arm64 TCG) to 2.20 (x64) under Stride,
+    // and 0.88 to 1.13 under Round-Robin whatever priority was requested.
+    // Stride's ideal is 4x; the OnThreadYield pass floor erodes it to ~2x.
+    /// <summary>Numerator of the share ratio separating the two policies.</summary>
+    private const ulong PolicySkewNumerator = 3;
+    /// <summary>Denominator of the share ratio separating the two policies.</summary>
+    private const ulong PolicySkewDenominator = 2;
+    /// <summary>Number of probe threads in the Round-Robin FIFO-order test.</summary>
+    private const int FifoWorkerCount = 3;
+    /// <summary>Run-queue index far beyond any population this suite creates; must read as null.</summary>
+    private const int OutOfRangeQueueIndex = 200;
 
     /// <summary>Barge-probe result: the releaser's TryAcquire outcome has not been recorded yet.</summary>
     private const int BargeResultPending = -1;
@@ -162,6 +188,26 @@ public class Kernel : Sys.Kernel
         TR.Run("Delegate_Comparison", TestDelegateComparison);
         TR.Run("Delegate_Chaining_Pipeline", TestDelegateChaining);
         TR.Run("Delegate_EventPattern_Multicast", TestDelegateEventPattern);
+
+        // Scheduling-policy tests: the default Stride behavior, a live switch
+        // to the user-style Round-Robin policy (RoundRobinScheduler.cs), the
+        // Round-Robin semantics, and the switch back. Kept last: they replace
+        // the installed policy, so nothing else should run between the swaps.
+        TR.Run("RoundRobin_Hooks_ReadyTail_PickHead", TestRoundRobinHooksFifoOrder);
+        TR.Run("RoundRobin_Hooks_DoubleReady_QueuesOnce", TestRoundRobinHooksReadyIsIdempotent);
+        TR.Run("RoundRobin_Hooks_QuantumAccounting", TestRoundRobinHooksQuantumAccounting);
+        TR.Run("RoundRobin_Hooks_BlockYieldExit", TestRoundRobinHooksBlockAndYield);
+        TR.Run("Scheduler_BootPolicy_IsStride", TestBootPolicyIsStride);
+        TR.Run("Stride_ProportionalShare_FollowsTickets", TestStrideProportionalShare);
+        TR.Run("SetScheduler_InstallsRoundRobinPolicy", TestSetSchedulerInstallsRoundRobin);
+        TR.Run("RoundRobin_ThreadRuns_UnderNewPolicy", TestThreadRunsUnderRoundRobin);
+        TR.Run("RoundRobin_DispatchesEveryThread", TestRoundRobinDispatchesEveryThread);
+        TR.Run("RoundRobin_QuantumExpiry_PreemptsSpinner", TestRoundRobinQuantumPreemption);
+        TR.Run("RoundRobin_EqualPriorities_ShareEvenly", TestRoundRobinEqualShare);
+        TR.Run("RoundRobin_SetPriority_DoesNotSkewShares", TestRoundRobinIgnoresPriority);
+        TR.Run("RoundRobin_RunQueue_ExposesReadyThreads", TestRoundRobinRunQueueDiagnostics);
+        TR.Run("RoundRobin_BlockedThread_LeavesRunQueue", TestRoundRobinBlockedLeavesQueue);
+        TR.Run("SetScheduler_RestoresStrideDefault", TestSetSchedulerRestoresStride);
 
         // Finish test suite
         TR.Finish();
@@ -1347,5 +1393,674 @@ public class Kernel : Sys.Kernel
 
         Assert.Equal(2, eventFireCount, "Both event handlers should fire");
         Assert.Equal("hello", lastEventData, "First handler should receive the event payload");
+    }
+
+    // ==================== Scheduling-Policy Tests ====================
+    // Stride is the boot default; RoundRobinScheduler.cs implements the
+    // plugging guide's Round-Robin sketch over the public seam, exactly as a
+    // user kernel would. The cells below validate Stride's proportional
+    // share, the live Stride -> Round-Robin switch, Round-Robin's semantics
+    // (FIFO first-runs, quantum preemption, equal shares, priority ignored,
+    // run-queue membership), and the switch back. Both swaps happen at
+    // quiescent points — every worker of the previous cells has exited — so
+    // no thread is parked or queued across the policy change.
+
+    private static RoundRobinScheduler? s_roundRobin;
+
+    // Two measured CPU-bound spinners (the proportional-share/equal-share cells)
+    private static volatile bool _spinGo;
+    private static volatile bool _spinStop;
+    private static volatile bool _spinAReady, _spinBReady;
+    private static volatile bool _spinADone, _spinBDone;
+    private static SchedThread? _spinAThread, _spinBThread;
+    // Written by each worker before its volatile done flag; read by main after it.
+    private static ulong _spinACount, _spinBCount;
+    private static long _observedPriorityA, _observedPriorityB;
+
+    private static SchedThread? CurrentSchedulerThread()
+    {
+        return SchedulerManager.GetCpuState(SchedulerManager.GetCurrentCpuId())!.CurrentThread;
+    }
+
+    /// <summary>
+    /// True when <paramref name="thread"/> currently sits in the installed
+    /// policy's run queue, via the read-only diagnostics hooks. While main is
+    /// executing this scan, every other runnable thread is Ready, so a
+    /// spinning worker must be queued and a parked one must not.
+    /// </summary>
+    private static bool RunQueueHolds(SchedThread? thread)
+    {
+        if (thread == null)
+        {
+            return false;
+        }
+
+        IScheduler? scheduler = SchedulerManager.Current;
+        PerCpuState? state = SchedulerManager.GetCpuState(SchedulerManager.GetCurrentCpuId());
+        if (scheduler == null || state == null)
+        {
+            return false;
+        }
+
+        // One mask over the whole scan: the count and the per-index reads each
+        // mask individually, so between them the tick could rotate the queue
+        // and move the target past an index already visited. Nesting the
+        // policy's own guards inside this one is harmless.
+        using (SchedulerManager.MaskInterrupts())
+        {
+            int count = scheduler.GetRunQueueCount(state);
+            for (int i = 0; i < count; i++)
+            {
+                if (ReferenceEquals(scheduler.GetRunQueueThread(state, i), thread))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static void MeasuredSpinWorkerA()
+    {
+        _spinAThread = CurrentSchedulerThread();
+        _spinAReady = true;
+        while (!_spinGo)
+        {
+            // wait for main to apply priorities and open the measurement window
+        }
+
+        ulong count = 0;
+        while (true)
+        {
+            count++;
+            if ((count & SpinStopCheckMask) == 0 && _spinStop)
+            {
+                break;
+            }
+        }
+
+        _spinACount = count;
+        _spinADone = true;
+    }
+
+    private static void MeasuredSpinWorkerB()
+    {
+        _spinBThread = CurrentSchedulerThread();
+        _spinBReady = true;
+        while (!_spinGo)
+        {
+            // wait for main to apply priorities and open the measurement window
+        }
+
+        ulong count = 0;
+        while (true)
+        {
+            count++;
+            if ((count & SpinStopCheckMask) == 0 && _spinStop)
+            {
+                break;
+            }
+        }
+
+        _spinBCount = count;
+        _spinBDone = true;
+    }
+
+    /// <summary>
+    /// Runs the two CPU-bound spinners for <see cref="PolicyMeasureMs"/> with
+    /// the given priorities applied through <see cref="SchedulerManager.SetPriority"/>,
+    /// leaving their loop counts in _spinACount/_spinBCount and the priorities
+    /// the policy reported (read while both spinners were alive) in
+    /// _observedPriorityA/_observedPriorityB.
+    /// </summary>
+    private static void RunTwoSpinnersMeasured(long priorityA, long priorityB)
+    {
+        _spinGo = false;
+        _spinStop = false;
+        _spinAReady = _spinBReady = false;
+        _spinADone = _spinBDone = false;
+        _spinAThread = _spinBThread = null;
+        _spinACount = _spinBCount = 0;
+        _observedPriorityA = _observedPriorityB = 0;
+
+        SysThread workerA = new(MeasuredSpinWorkerA);
+        SysThread workerB = new(MeasuredSpinWorkerB);
+        workerA.Start();
+        workerB.Start();
+
+        for (int i = 0; i < FlagPollRetries && !(_spinAReady && _spinBReady); i++)
+        {
+            TimerManager.Wait(FlagPollIntervalMs);
+        }
+
+        uint cpuId = SchedulerManager.GetCurrentCpuId();
+        if (_spinAThread != null && _spinBThread != null)
+        {
+            // SetPriority runs under a spinlock only (see the plugging guide's
+            // kernel constraints); mask the tick around it ourselves.
+            using (SchedulerManager.MaskInterrupts())
+            {
+                SchedulerManager.SetPriority(cpuId, _spinAThread, priorityA);
+                SchedulerManager.SetPriority(cpuId, _spinBThread, priorityB);
+            }
+
+            // Capture what the policy reports while the threads are alive:
+            // OnThreadExit drops the bookkeeping GetPriority reads.
+            _observedPriorityA = SchedulerManager.GetPriority(_spinAThread);
+            _observedPriorityB = SchedulerManager.GetPriority(_spinBThread);
+        }
+
+        _spinGo = true;
+        TimerManager.Wait(PolicyMeasureMs);
+        _spinStop = true;
+
+        for (int i = 0; i < FlagPollRetries && !(_spinADone && _spinBDone); i++)
+        {
+            TimerManager.Wait(FlagPollIntervalMs);
+        }
+        TimerManager.Wait(ExitGraceWaitMs);
+
+        Serial.WriteString("[PolicyTest] policy=");
+        Serial.WriteString(SchedulerManager.Current?.Name ?? "none");
+        Serial.WriteString(" prioA=");
+        Serial.WriteNumber(priorityA);
+        Serial.WriteString(" prioB=");
+        Serial.WriteNumber(priorityB);
+        Serial.WriteString(" countA=");
+        Serial.WriteNumber((long)_spinACount);
+        Serial.WriteString(" countB=");
+        Serial.WriteNumber((long)_spinBCount);
+        Serial.WriteString("\n");
+    }
+
+    private static void TestBootPolicyIsStride()
+    {
+        IScheduler? current = SchedulerManager.Current;
+        Assert.True(current != null, "a scheduling policy must be installed at boot");
+        Assert.Equal("Stride", current!.Name, "the boot default policy should be Stride");
+    }
+
+    private static void TestStrideProportionalShare()
+    {
+        RunTwoSpinnersMeasured(HighTickets, LowTickets);
+
+        Assert.True(_spinAReady && _spinBReady, "both measured spinners should start");
+        Assert.True(_spinADone && _spinBDone, "both measured spinners should finish the window");
+        Assert.True(_observedPriorityA == HighTickets && _observedPriorityB == LowTickets,
+            "Stride should report the tickets set through SetPriority");
+        Assert.True(_spinACount > 0 && _spinBCount > 0,
+            "both spinners must make progress under Stride (proportional share, not starvation)");
+        Assert.True(_spinACount * PolicySkewDenominator >= _spinBCount * PolicySkewNumerator,
+            "a 4x ticket edge must yield a clearly larger (>= 1.5x) CPU share under Stride");
+    }
+
+    private static void TestSetSchedulerInstallsRoundRobin()
+    {
+        s_roundRobin = new RoundRobinScheduler();
+
+        // Mask the tick across the swap so nothing can observe the window
+        // between ShutdownCpu (old policy) and InitializeCpu (new policy).
+        using (SchedulerManager.MaskInterrupts())
+        {
+            SchedulerManager.SetScheduler(s_roundRobin);
+        }
+
+        Assert.True(ReferenceEquals(SchedulerManager.Current, s_roundRobin),
+            "SchedulerManager.Current should be the installed Round-Robin instance");
+        Assert.Equal("RoundRobin", SchedulerManager.Current!.Name,
+            "the installed policy should report its own name");
+
+        PerCpuState? state = SchedulerManager.GetCpuState(SchedulerManager.GetCurrentCpuId());
+        Assert.True(state != null && state.SchedulerData is RoundRobinCpuData,
+            "InitializeCpu should attach fresh Round-Robin per-CPU data");
+        if (state != null)
+        {
+            Assert.Equal(0, s_roundRobin!.GetRunQueueCount(state),
+                "the incoming policy should start from an empty run queue");
+        }
+    }
+
+    private static volatile bool _policyProbeRan;
+
+    private static void PolicyProbeWorker()
+    {
+        _policyProbeRan = true;
+    }
+
+    private static void RunPolicyProbeWorker()
+    {
+        _policyProbeRan = false;
+        SysThread probe = new(PolicyProbeWorker);
+        probe.Start();
+
+        for (int i = 0; i < FlagPollRetries && !_policyProbeRan; i++)
+        {
+            TimerManager.Wait(FlagPollIntervalMs);
+        }
+        TimerManager.Wait(ExitGraceWaitMs);
+    }
+
+    private static void TestThreadRunsUnderRoundRobin()
+    {
+        RunPolicyProbeWorker();
+        Assert.True(_policyProbeRan,
+            "a thread created under the Round-Robin policy must be scheduled and run");
+    }
+
+    // ===== Round-Robin hooks driven directly (deterministic) =====
+    // FIFO order is a property of the policy's run structure, and observing it
+    // through real dispatch is racy: a worker preempted anywhere inside
+    // InvokeCurrentThreadStart's preamble is re-queued at the TAIL by
+    // OnThreadYield, so the order threads reach their delegate is not the
+    // order they became ready. These cells drive the hooks on a synthetic
+    // PerCpuState instead — the policy keeps all its state in the data slots,
+    // so a throwaway instance over throwaway Thread objects exercises the real
+    // logic with no timer, no dispatch and no timing assumption at all.
+
+    private static void TestRoundRobinHooksFifoOrder()
+    {
+        RoundRobinScheduler policy = new();
+        PerCpuState state = new();
+        policy.InitializeCpu(state);
+
+        SchedThread first = new();
+        SchedThread second = new();
+        SchedThread third = new();
+        policy.OnThreadCreate(state, first);
+        policy.OnThreadCreate(state, second);
+        policy.OnThreadCreate(state, third);
+
+        policy.OnThreadReady(state, first);
+        policy.OnThreadReady(state, second);
+        policy.OnThreadReady(state, third);
+
+        Assert.Equal(FifoWorkerCount, policy.GetRunQueueCount(state),
+            "each readied thread should be queued once");
+        Assert.True(ReferenceEquals(policy.GetRunQueueThread(state, 0), first)
+            && ReferenceEquals(policy.GetRunQueueThread(state, 1), second)
+            && ReferenceEquals(policy.GetRunQueueThread(state, 2), third),
+            "OnThreadReady must enqueue at the tail, preserving ready order");
+
+        Assert.True(ReferenceEquals(policy.PickNext(state), first),
+            "PickNext must dequeue the head (first ready runs first)");
+        Assert.True(ReferenceEquals(policy.PickNext(state), second),
+            "PickNext must continue in FIFO order");
+        Assert.True(ReferenceEquals(policy.PickNext(state), third),
+            "PickNext must continue in FIFO order");
+        Assert.True(policy.PickNext(state) == null,
+            "an empty run queue must pick nothing (the mechanism runs idle)");
+    }
+
+    private static void TestRoundRobinHooksReadyIsIdempotent()
+    {
+        RoundRobinScheduler policy = new();
+        PerCpuState state = new();
+        policy.InitializeCpu(state);
+
+        SchedThread thread = new();
+        policy.OnThreadCreate(state, thread);
+
+        policy.OnThreadReady(state, thread);
+        policy.OnThreadReady(state, thread);
+
+        Assert.Equal(1, policy.GetRunQueueCount(state),
+            "a thread readied twice must not occupy two queue slots (it would get double turns)");
+    }
+
+    private static void TestRoundRobinHooksQuantumAccounting()
+    {
+        RoundRobinScheduler policy = new();
+        PerCpuState state = new();
+        policy.InitializeCpu(state);
+
+        SchedThread running = new();
+        SchedThread waiting = new();
+        policy.OnThreadCreate(state, running);
+        policy.OnThreadCreate(state, waiting);
+        policy.OnThreadReady(state, waiting);
+
+        // The quantum spans two ticks, so the first must not preempt.
+        bool midQuantum = policy.OnTick(state, running, SchedulerManager.DefaultQuantumNs);
+        bool atExpiry = policy.OnTick(state, running, SchedulerManager.DefaultQuantumNs);
+
+        Assert.False(midQuantum, "a half-spent quantum must not request a reschedule");
+        Assert.True(atExpiry, "quantum expiry with another thread waiting must request a reschedule");
+        Assert.Equal(2UL * SchedulerManager.DefaultQuantumNs, running.TotalRuntime,
+            "OnTick must charge the elapsed time to the running thread");
+
+        // Sole runnable thread: expiry grants a fresh slice in place rather
+        // than bouncing through the idle thread and back.
+        policy.PickNext(state);
+        SchedThread alone = new();
+        policy.OnThreadCreate(state, alone);
+        bool aloneAtExpiry = policy.OnTick(state, alone, RoundRobinScheduler.QuantumNs);
+
+        Assert.False(aloneAtExpiry,
+            "quantum expiry with an empty run queue must not request a pointless switch");
+    }
+
+    private static void TestRoundRobinHooksBlockAndYield()
+    {
+        RoundRobinScheduler policy = new();
+        PerCpuState state = new();
+        policy.InitializeCpu(state);
+
+        SchedThread parked = new();
+        SchedThread other = new();
+        policy.OnThreadCreate(state, parked);
+        policy.OnThreadCreate(state, other);
+        policy.OnThreadReady(state, parked);
+        policy.OnThreadReady(state, other);
+
+        policy.OnThreadBlocked(state, parked);
+
+        Assert.Equal(1, policy.GetRunQueueCount(state),
+            "a blocked thread must leave the run queue");
+        Assert.True(ReferenceEquals(policy.GetRunQueueThread(state, 0), other),
+            "blocking must remove the blocked thread, not its neighbour");
+
+        // A preempted-but-still-runnable thread goes to the tail, behind the
+        // thread that was already waiting — that rotation is Round-Robin.
+        policy.OnThreadYield(state, parked);
+        Assert.True(ReferenceEquals(policy.GetRunQueueThread(state, 0), other)
+            && ReferenceEquals(policy.GetRunQueueThread(state, 1), parked),
+            "OnThreadYield must re-enqueue at the tail");
+
+        policy.OnThreadExit(state, other);
+        Assert.Equal(1, policy.GetRunQueueCount(state),
+            "an exited thread must leave the run queue");
+        Assert.True(other.SchedulerData == null,
+            "OnThreadExit must drop the thread's bookkeeping");
+    }
+
+    // ===== Round-Robin live dispatch =====
+    private static volatile int _fifoRecorded;
+
+    private static void FifoWorker()
+    {
+        using (SchedulerManager.MaskInterrupts())
+        {
+            _fifoRecorded++;
+        }
+    }
+
+    private static void TestRoundRobinDispatchesEveryThread()
+    {
+        _fifoRecorded = 0;
+
+        // Liveness, not order: FIFO bounds every thread's wait at
+        // quantum * queue depth, so all three must reach their delegate.
+        // The exact order they get there is asserted deterministically in the
+        // hook cells above, where no dispatch preamble can perturb it.
+        SysThread w0 = new(FifoWorker);
+        SysThread w1 = new(FifoWorker);
+        SysThread w2 = new(FifoWorker);
+        w0.Start();
+        w1.Start();
+        w2.Start();
+
+        for (int i = 0; i < FlagPollRetries && _fifoRecorded < FifoWorkerCount; i++)
+        {
+            TimerManager.Wait(FlagPollIntervalMs);
+        }
+        TimerManager.Wait(ExitGraceWaitMs);
+
+        Assert.Equal(FifoWorkerCount, _fifoRecorded,
+            "Round-Robin must dispatch every ready thread (no starvation)");
+    }
+
+    // ===== Round-Robin quantum preemption =====
+    private static volatile bool _preemptStop;
+    private static volatile bool _preemptDone;
+    private static volatile uint _preemptCounter;
+
+    private static void PreemptProbeSpinner()
+    {
+        while (!_preemptStop)
+        {
+            _preemptCounter++;
+        }
+        _preemptDone = true;
+    }
+
+    private static void TestRoundRobinQuantumPreemption()
+    {
+        _preemptStop = false;
+        _preemptDone = false;
+        _preemptCounter = 0;
+
+        SysThread spinner = new(PreemptProbeSpinner);
+        spinner.Start();
+
+        // The spinner never blocks, so every sample below requires the tick
+        // to preempt it at quantum expiry and rotate main back in — merely
+        // reaching the asserts proves FIFO's bounded latency for main.
+        TimerManager.Wait(PreemptSampleIntervalMs);
+        uint sample1 = _preemptCounter;
+        TimerManager.Wait(PreemptSampleIntervalMs);
+        uint sample2 = _preemptCounter;
+        TimerManager.Wait(PreemptSampleIntervalMs);
+        uint sample3 = _preemptCounter;
+
+        _preemptStop = true;
+        for (int i = 0; i < FlagPollRetries && !_preemptDone; i++)
+        {
+            TimerManager.Wait(FlagPollIntervalMs);
+        }
+        TimerManager.Wait(ExitGraceWaitMs);
+
+        Assert.True(_preemptDone, "the preempted spinner should observe stop and exit");
+        Assert.True(sample1 != sample2 && sample2 != sample3,
+            "the spinner must keep progressing between main-thread samples (quantum rotation)");
+    }
+
+    private static void TestRoundRobinEqualShare()
+    {
+        RunTwoSpinnersMeasured(LowTickets, LowTickets);
+
+        Assert.True(_spinADone && _spinBDone, "both measured spinners should finish the window");
+        Assert.True(_spinACount > 0 && _spinBCount > 0,
+            "both spinners must make progress under Round-Robin");
+        Assert.True(_spinACount * PolicySkewDenominator < _spinBCount * PolicySkewNumerator
+            && _spinBCount * PolicySkewDenominator < _spinACount * PolicySkewNumerator,
+            "equal-quantum turns must yield shares within the 1.5x band under Round-Robin");
+    }
+
+    private static void TestRoundRobinIgnoresPriority()
+    {
+        RunTwoSpinnersMeasured(HighTickets, LowTickets);
+
+        Assert.True(_spinADone && _spinBDone, "both measured spinners should finish the window");
+        Assert.True(_observedPriorityA == 0 && _observedPriorityB == 0,
+            "Round-Robin defines no priorities, so GetPriority should report 0 for both");
+        Assert.True(_spinACount * PolicySkewDenominator < _spinBCount * PolicySkewNumerator
+            && _spinBCount * PolicySkewDenominator < _spinACount * PolicySkewNumerator,
+            "a 4x priority request must not push Round-Robin past the share ratio Stride clears");
+    }
+
+    // ===== Round-Robin run-queue diagnostics =====
+    private static volatile bool _gateRelease;
+    private static volatile bool _gateAStarted, _gateBStarted, _gateCStarted;
+    private static SchedThread? _gateAThread, _gateBThread, _gateCThread;
+
+    private static void GateWorkerA()
+    {
+        _gateAThread = CurrentSchedulerThread();
+        _gateAStarted = true;
+        while (!_gateRelease)
+        {
+            // stay runnable so main can observe us in the run queue
+        }
+    }
+
+    private static void GateWorkerB()
+    {
+        _gateBThread = CurrentSchedulerThread();
+        _gateBStarted = true;
+        while (!_gateRelease)
+        {
+            // stay runnable so main can observe us in the run queue
+        }
+    }
+
+    private static void GateWorkerC()
+    {
+        _gateCThread = CurrentSchedulerThread();
+        _gateCStarted = true;
+        while (!_gateRelease)
+        {
+            // stay runnable so main can observe us in the run queue
+        }
+    }
+
+    private static void TestRoundRobinRunQueueDiagnostics()
+    {
+        _gateRelease = false;
+        _gateAStarted = _gateBStarted = _gateCStarted = false;
+        _gateAThread = _gateBThread = _gateCThread = null;
+
+        SysThread a = new(GateWorkerA);
+        SysThread b = new(GateWorkerB);
+        SysThread c = new(GateWorkerC);
+        a.Start();
+        b.Start();
+        c.Start();
+
+        for (int i = 0; i < FlagPollRetries && !(_gateAStarted && _gateBStarted && _gateCStarted); i++)
+        {
+            TimerManager.Wait(FlagPollIntervalMs);
+        }
+        Assert.True(_gateAStarted && _gateBStarted && _gateCStarted, "all gate spinners should start");
+
+        IScheduler scheduler = SchedulerManager.Current!;
+        PerCpuState state = SchedulerManager.GetCpuState(SchedulerManager.GetCurrentCpuId())!;
+
+        // Main is running, so all three spinners are Ready and must be queued.
+        Assert.True(scheduler.GetRunQueueCount(state) >= FifoWorkerCount,
+            "the run queue should hold the three spinning workers");
+        Assert.True(RunQueueHolds(_gateAThread) && RunQueueHolds(_gateBThread) && RunQueueHolds(_gateCThread),
+            "each spinning worker should be visible through the diagnostics hooks");
+        Assert.True(scheduler.GetRunQueueThread(state, OutOfRangeQueueIndex) == null,
+            "an out-of-range run-queue index must read as null");
+
+        _gateRelease = true;
+        for (int i = 0; i < FlagPollRetries
+            && (RunQueueHolds(_gateAThread) || RunQueueHolds(_gateBThread) || RunQueueHolds(_gateCThread)); i++)
+        {
+            TimerManager.Wait(FlagPollIntervalMs);
+        }
+        TimerManager.Wait(ExitGraceWaitMs);
+
+        Assert.True(!RunQueueHolds(_gateAThread) && !RunQueueHolds(_gateBThread) && !RunQueueHolds(_gateCThread),
+            "exited workers must leave the run queue");
+    }
+
+    // ===== Round-Robin blocked-thread queue membership =====
+    private static Cosmos.Kernel.Core.Scheduler.Mutex? _blockProbeMutex;
+    private static volatile bool _blockWorkerStarted;
+    private static volatile bool _blockWorkerThrough;
+    private static volatile bool _blockRelease;
+    private static SchedThread? _blockWorkerThread;
+
+    private static void BlockProbeWorker()
+    {
+        _blockWorkerThread = CurrentSchedulerThread();
+        _blockWorkerStarted = true;
+        _blockProbeMutex!.Acquire();   // parks: main holds the mutex
+        _blockWorkerThrough = true;
+        while (!_blockRelease)
+        {
+            // stay runnable so main can observe us back in the run queue
+        }
+        _blockProbeMutex.Release();
+    }
+
+    private static void TestRoundRobinBlockedLeavesQueue()
+    {
+        _blockProbeMutex = new Cosmos.Kernel.Core.Scheduler.Mutex();
+        _blockWorkerStarted = false;
+        _blockWorkerThrough = false;
+        _blockRelease = false;
+        _blockWorkerThread = null;
+
+        _blockProbeMutex.Acquire();   // uncontended: taken immediately
+
+        SysThread worker = new(BlockProbeWorker);
+        worker.Start();
+
+        for (int i = 0; i < FlagPollRetries && !_blockWorkerStarted; i++)
+        {
+            TimerManager.Wait(FlagPollIntervalMs);
+        }
+        Assert.True(_blockWorkerStarted, "the block-probe worker should start");
+        if (_blockWorkerThread == null)
+        {
+            // Asserts don't throw in this framework; bail before dereferencing,
+            // and release so the parked worker can't leak into the next cell.
+            _blockRelease = true;
+            _blockProbeMutex.Release();
+            return;
+        }
+
+        for (int i = 0; i < FlagPollRetries
+            && _blockWorkerThread!.State != Cosmos.Kernel.Core.Scheduler.ThreadState.Blocked; i++)
+        {
+            TimerManager.Wait(FlagPollIntervalMs);
+        }
+        Assert.True(_blockWorkerThread!.State == Cosmos.Kernel.Core.Scheduler.ThreadState.Blocked,
+            "the worker should park on the held mutex");
+        Assert.False(RunQueueHolds(_blockWorkerThread),
+            "a mutex-parked thread must leave the Round-Robin run queue");
+
+        _blockProbeMutex.Release();   // hand-off wakes the parked worker
+
+        for (int i = 0; i < FlagPollRetries && !_blockWorkerThrough; i++)
+        {
+            TimerManager.Wait(FlagPollIntervalMs);
+        }
+        Assert.True(_blockWorkerThrough, "the woken worker should acquire the handed-off mutex");
+        Assert.True(RunQueueHolds(_blockWorkerThread),
+            "a woken, spinning thread must re-enter the Round-Robin run queue");
+
+        _blockRelease = true;
+        for (int i = 0; i < FlagPollRetries && RunQueueHolds(_blockWorkerThread); i++)
+        {
+            TimerManager.Wait(FlagPollIntervalMs);
+        }
+        TimerManager.Wait(ExitGraceWaitMs);
+    }
+
+    private static void TestSetSchedulerRestoresStride()
+    {
+        // Restoring the boot default needs Core's internal StrideScheduler
+        // type (this suite is InternalsVisibleTo); a user kernel installs its
+        // policy once at boot and never swaps back. The swap leaves the
+        // remaining lifecycle (Finish/AfterRun) on the stock policy.
+
+        // Quiescence is a hard precondition in THIS direction: Stride reads
+        // its data slots with GetSchedulerData<T>, a hard cast, so a thread
+        // created under Round-Robin that were still alive here would fault
+        // Stride's next hook on it. Every Round-Robin worker above exited
+        // (each cell waits for it), which empties the run queue; the running
+        // main thread still carries the StrideThreadData it booted with.
+        PerCpuState preSwapState = SchedulerManager.GetCpuState(SchedulerManager.GetCurrentCpuId())!;
+        Assert.Equal(0, SchedulerManager.Current!.GetRunQueueCount(preSwapState),
+            "no Round-Robin thread may survive into the restored Stride policy");
+
+        Cosmos.Kernel.Core.Scheduler.Stride.StrideScheduler stride = new();
+        using (SchedulerManager.MaskInterrupts())
+        {
+            SchedulerManager.SetScheduler(stride);
+        }
+
+        Assert.True(ReferenceEquals(SchedulerManager.Current, stride),
+            "SchedulerManager.Current should be the restored Stride instance");
+        Assert.Equal("Stride", SchedulerManager.Current!.Name,
+            "the restored policy should report the Stride name");
+
+        RunPolicyProbeWorker();
+        Assert.True(_policyProbeRan,
+            "a thread created after restoring Stride must be scheduled and run");
     }
 }

--- a/tests/Kernels/Cosmos.Kernel.Tests.Threading/RoundRobinScheduler.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Threading/RoundRobinScheduler.cs
@@ -1,0 +1,307 @@
+using System.Collections.Generic;
+using Cosmos.Kernel.Core.Scheduler;
+using Thread = Cosmos.Kernel.Core.Scheduler.Thread;
+
+namespace Cosmos.Kernel.Tests.Threading;
+
+/// <summary>
+/// Round-Robin scheduling policy implemented the way a user kernel would:
+/// entirely over the public scheduler seam (<see cref="IScheduler"/>,
+/// <see cref="SchedulerManager"/>, the <see cref="SchedulerExtensible.SchedulerData"/>
+/// slots), with no access to Cosmos.Kernel.Core internals. It follows the
+/// Round-Robin sketch in docs/articles/dev/scheduler-plugging.md: a FIFO run
+/// queue per CPU, a remaining-quantum counter per thread, fixed-quantum
+/// preemption in <see cref="OnTick"/>, and <see cref="PickNext"/> dequeuing
+/// the head.
+/// </summary>
+public sealed class RoundRobinScheduler : IScheduler
+{
+    /// <summary>
+    /// Fixed time slice per turn: two scheduler ticks, so the charge in
+    /// <see cref="OnTick"/> has to survive an intermediate tick instead of
+    /// expiring trivially on every one.
+    /// </summary>
+    public const ulong QuantumNs = 2 * SchedulerManager.DefaultQuantumNs;
+
+    public string Name => "RoundRobin";
+
+    // ========== Lifecycle ==========
+
+    public void InitializeCpu(PerCpuState cpuState)
+    {
+        cpuState.SchedulerData = new RoundRobinCpuData();
+    }
+
+    public void ShutdownCpu(PerCpuState cpuState)
+    {
+        cpuState.SchedulerData = null;
+    }
+
+    // ========== Thread Lifecycle ==========
+
+    public void OnThreadCreate(PerCpuState cpuState, Thread thread)
+    {
+        thread.SchedulerData = new RoundRobinThreadData { RemainingNs = QuantumNs };
+    }
+
+    public void OnThreadReady(PerCpuState cpuState, Thread thread)
+    {
+        RoundRobinCpuData? cpuData = CpuDataOf(cpuState);
+        if (cpuData == null)
+        {
+            return;
+        }
+
+        // Nothing survives a park: a woken thread starts a fresh slice.
+        ThreadDataOf(thread)?.RemainingNs = QuantumNs;
+
+        EnqueueTail(cpuData, thread);
+    }
+
+    public void OnThreadBlocked(PerCpuState cpuState, Thread thread)
+    {
+        RoundRobinCpuData? cpuData = CpuDataOf(cpuState);
+        if (cpuData == null)
+        {
+            return;
+        }
+
+        RemoveFromQueue(cpuData, thread);
+    }
+
+    public void OnThreadYield(PerCpuState cpuState, Thread thread)
+    {
+        RoundRobinCpuData? cpuData = CpuDataOf(cpuState);
+        if (cpuData == null)
+        {
+            return;
+        }
+
+        ThreadDataOf(thread)?.RemainingNs = QuantumNs;
+
+        EnqueueTail(cpuData, thread);
+    }
+
+    public void OnThreadExit(PerCpuState cpuState, Thread thread)
+    {
+        RoundRobinCpuData? cpuData = CpuDataOf(cpuState);
+        if (cpuData != null)
+        {
+            RemoveFromQueue(cpuData, thread);
+        }
+
+        thread.SchedulerData = null;
+    }
+
+    // ========== Scheduling Decisions ==========
+
+    public Thread? PickNext(PerCpuState cpuState)
+    {
+        RoundRobinCpuData? cpuData = CpuDataOf(cpuState);
+        if (cpuData == null || cpuData.RunQueue.Count == 0)
+        {
+            return null;
+        }
+
+        Thread head = cpuData.RunQueue[0];
+        cpuData.RunQueue.RemoveAt(0);
+        return head;
+    }
+
+    public void OnPickFailed(PerCpuState cpuState, Thread thread)
+    {
+        RoundRobinCpuData? cpuData = CpuDataOf(cpuState);
+        if (cpuData == null)
+        {
+            return;
+        }
+
+        // The pick was not honored: put the thread back at the head so the
+        // FIFO order it had already earned is preserved.
+        if (!QueueHolds(cpuData, thread))
+        {
+            cpuData.RunQueue.Insert(0, thread);
+        }
+    }
+
+    public bool OnTick(PerCpuState cpuState, Thread current, ulong elapsedNs)
+    {
+        RoundRobinCpuData? cpuData = CpuDataOf(cpuState);
+        if (cpuData == null || current == null)
+        {
+            return false;
+        }
+
+        current.TotalRuntime += elapsedNs;
+
+        RoundRobinThreadData? threadData = ThreadDataOf(current);
+        if (threadData == null)
+        {
+            // Foreign bookkeeping (a thread created under the previously
+            // installed policy) or a thread that already exited: rotate it at
+            // tick granularity whenever another thread is waiting.
+            return cpuData.RunQueue.Count > 0;
+        }
+
+        threadData.RemainingNs = elapsedNs >= threadData.RemainingNs
+            ? 0
+            : threadData.RemainingNs - elapsedNs;
+
+        if (threadData.RemainingNs > 0)
+        {
+            return false;
+        }
+
+        if (cpuData.RunQueue.Count == 0)
+        {
+            // Sole runnable thread: grant a fresh slice in place instead of
+            // bouncing through the idle thread and back.
+            threadData.RemainingNs = QuantumNs;
+            return false;
+        }
+
+        return true;
+    }
+
+    // ========== Load Balancing (dormant until SMP) ==========
+
+    public uint SelectCpu(Thread thread, uint currentCpu, uint cpuCount)
+    {
+        // One FIFO per CPU and no load metric worth consulting: keep the
+        // thread where it is, which also honors ThreadFlags.Pinned.
+        return currentCpu;
+    }
+
+    public void OnThreadMigrate(Thread thread, PerCpuState fromState, PerCpuState toState)
+    {
+        RoundRobinCpuData? fromData = CpuDataOf(fromState);
+        RoundRobinCpuData? toData = CpuDataOf(toState);
+        if (fromData == null || toData == null)
+        {
+            return;
+        }
+
+        RemoveFromQueue(fromData, thread);
+        EnqueueTail(toData, thread);
+    }
+
+    public void Balance(PerCpuState cpuState, PerCpuState[] allCpuStates)
+    {
+        // FIFO order carries no cross-CPU invariant to rebalance; placement
+        // stays wherever SelectCpu (which honors Pinned) put the thread.
+    }
+
+    // ========== Dynamic Reconfiguration ==========
+
+    public void SetPriority(PerCpuState cpuState, Thread thread, long priority)
+    {
+        // Round-Robin has no priorities: every thread gets the same fixed
+        // quantum, so the request is deliberately ignored.
+    }
+
+    public long GetPriority(Thread thread)
+    {
+        return 0;
+    }
+
+    // ========== Diagnostics ==========
+
+    public int GetRunQueueCount(PerCpuState cpuState)
+    {
+        // The SchedulerInfo facade calls the diagnostics hooks from thread
+        // context; guard them against the tick ourselves, per the plugging guide.
+        using (SchedulerManager.MaskInterrupts())
+        {
+            RoundRobinCpuData? cpuData = CpuDataOf(cpuState);
+            return cpuData?.RunQueue.Count ?? 0;
+        }
+    }
+
+    public Thread? GetRunQueueThread(PerCpuState cpuState, int index)
+    {
+        using (SchedulerManager.MaskInterrupts())
+        {
+            RoundRobinCpuData? cpuData = CpuDataOf(cpuState);
+            if (cpuData == null || index < 0 || index >= cpuData.RunQueue.Count)
+            {
+                return null;
+            }
+
+            return cpuData.RunQueue[index];
+        }
+    }
+
+    // ========== Private Helpers ==========
+
+    // GetSchedulerData<T> casts, so on a policy that gets installed on a live
+    // kernel it would throw in interrupt context for threads still carrying
+    // the previous policy's bookkeeping (the boot main thread keeps its
+    // StrideThreadData across the swap). Read the slots with 'as' instead:
+    // foreign data degrades to "absent", which every hook already tolerates.
+    private static RoundRobinCpuData? CpuDataOf(PerCpuState cpuState)
+    {
+        return cpuState.SchedulerData as RoundRobinCpuData;
+    }
+
+    private static RoundRobinThreadData? ThreadDataOf(Thread thread)
+    {
+        return thread.SchedulerData as RoundRobinThreadData;
+    }
+
+    private static bool QueueHolds(RoundRobinCpuData cpuData, Thread thread)
+    {
+        for (int i = 0; i < cpuData.RunQueue.Count; i++)
+        {
+            if (ReferenceEquals(cpuData.RunQueue[i], thread))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void EnqueueTail(RoundRobinCpuData cpuData, Thread thread)
+    {
+        // Presence guard: ReadyThread can fire for a thread the interrupt
+        // exit will also re-queue (the idle thread's block/resurrect churn in
+        // Mutex.Acquire), and a double entry would grant double turns.
+        if (!QueueHolds(cpuData, thread))
+        {
+            cpuData.RunQueue.Add(thread);
+        }
+    }
+
+    private static void RemoveFromQueue(RoundRobinCpuData cpuData, Thread thread)
+    {
+        // List<T>.Remove/Contains route through EqualityComparer<T>.Default,
+        // which needs runtime helpers the kernel does not provide; scan with
+        // ReferenceEquals and use RemoveAt.
+        for (int i = 0; i < cpuData.RunQueue.Count; i++)
+        {
+            if (ReferenceEquals(cpuData.RunQueue[i], thread))
+            {
+                cpuData.RunQueue.RemoveAt(i);
+                return;
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Per-CPU Round-Robin bookkeeping: the FIFO run queue, pre-sized to the
+/// registry limit so the scheduler paths never grow it (no allocation in
+/// interrupt context).
+/// </summary>
+public sealed class RoundRobinCpuData
+{
+    public List<Thread> RunQueue { get; } = new(Thread.MaxThreadCount);
+}
+
+/// <summary>
+/// Per-thread Round-Robin bookkeeping: what is left of the current time slice.
+/// </summary>
+public sealed class RoundRobinThreadData
+{
+    public ulong RemainingNs { get; set; }
+}

--- a/tests/Kernels/Cosmos.Kernel.Tests.TypeCasting/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.TypeCasting/Kernel.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.System.Diagnostics;
 using Cosmos.TestRunner.Framework;
 using Sys = Cosmos.Kernel.System;
 using TR = Cosmos.TestRunner.Framework.TestRunner;
@@ -11,7 +11,7 @@ public class Kernel : Sys.Kernel
 {
     protected override void BeforeRun()
     {
-        Serial.WriteString("[TypeCasting Tests] Starting test suite\n");
+        Log.WriteString("[TypeCasting Tests] Starting test suite\n");
         TR.Start("TypeCasting Tests", expectedTests: 17);
 
         // Class hierarchy type checks (RhTypeCast_IsInstanceOfClass)
@@ -51,7 +51,7 @@ public class Kernel : Sys.Kernel
         TR.Run("FilterAndCatchResume", TestFilterAndCatchResume);
         TR.Run("TryCatch_ConsoleWriteLineExMessage", TestTryCatchConsoleWriteLineExMessage);
 
-        Serial.WriteString("[TypeCasting Tests] All tests completed\n");
+        Log.WriteString("[TypeCasting Tests] All tests completed\n");
         TR.Finish();
     }
 

--- a/tests/Kernels/Cosmos.Kernel.Tests.Virtio/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.Virtio/Kernel.cs
@@ -1,5 +1,5 @@
 using System;
-using Cosmos.Kernel.Core.IO;
+using Cosmos.Kernel.System.Diagnostics;
 using Cosmos.Kernel.HAL.Devices.Input;
 using Cosmos.Kernel.HAL.Devices.Network;
 using Cosmos.Kernel.HAL.Devices.Virtio;
@@ -57,7 +57,7 @@ public class Kernel : Sys.Kernel
 
     protected override void BeforeRun()
     {
-        Serial.WriteString("[Virtio] BeforeRun() reached!\n");
+        Log.WriteString("[Virtio] BeforeRun() reached!\n");
 
         TR.Start("Virtio Device Tests", expectedTests: ExpectedTestCount);
 
@@ -85,7 +85,7 @@ public class Kernel : Sys.Kernel
 
         TR.Finish();
 
-        Serial.WriteString("\n[Tests Complete - System Halting]\n");
+        Log.WriteString("\n[Tests Complete - System Halting]\n");
     }
 
     protected override void Run() => Stop();
@@ -119,9 +119,9 @@ public class Kernel : Sys.Kernel
             return;
         }
 
-        Serial.WriteString("[Test] Transport: ");
-        Serial.WriteString(s_net.Transport.TransportName);
-        Serial.WriteString("\n");
+        Log.WriteString("[Test] Transport: ");
+        Log.WriteString(s_net.Transport.TransportName);
+        Log.WriteString("\n");
 
         string expected = s_isPciCell ? PciTransportName : MmioTransportName;
         Assert.Equal(expected, s_net.Transport.TransportName);
@@ -178,9 +178,9 @@ public class Kernel : Sys.Kernel
             }
         }
 
-        Serial.WriteString("[Test] MAC: ");
-        Serial.WriteString(mac.ToString());
-        Serial.WriteString("\n");
+        Log.WriteString("[Test] MAC: ");
+        Log.WriteString(mac.ToString());
+        Log.WriteString("\n");
 
         Assert.True(anyNonZero, "MAC address read from device config should not be all zeros");
     }


### PR DESCRIPTION
Last work stream of the pre-release API audit: #447 built the tracking tooling and #452 documented the surface it declared, but neither decided what belongs on that surface in the first place. This branch states the policy and makes the tree match it. Stacked on `feat/canvas3d` (#454).

## Problem

Visibility was the extension mechanism. `public` meant "another assembly in this repo needed it", so the packages shipped their whole implementation as API:

- `Cosmos.Kernel.Core` and `Cosmos.Kernel.HAL` exposed drivers, PCI, ports, the native bridges, the metadata readers and the NativeAOT convention hooks — all of it reachable, none of it intended as a contract.
- Kernels reached across rings to get work done. The test kernels wrote to `Core.Serial` directly, DevKernel sat on Core and HAL types, and nothing marked which of those calls were supposed to survive a refactor.
- Extension points and accidents were indistinguishable. The scheduler policy interface and a PCI register struct were equally public, so a consumer had no way to tell which one carried a promise.
- Public fields and settable state leaked invariants (`rxBuffer`, the packet classes, assorted state setters), which freezes them at release whether or not that was ever the intent.

Tracking a surface that nobody had decided on would only have frozen the accident.

## Fix

Three rules, written into [Public API Tracking](docs/articles/dev/public-api.md) and applied across the tree:

1. **One supported ring.** `Cosmos.Kernel.System` is what kernels program against — tracked, documented, frozen at release, with deprecation cycles applying there and only there. Contract types its own signatures expose ride along: the device interfaces in `HAL.Interfaces`, the VFS contracts in `HAL`, and the platform interfaces in `Core` (`IPortIO`, `ICpuOps`, `IPowerOps`, `IInterruptController`).
2. **Chosen experimental seams.** Extension points are opened deliberately under `[Experimental]`: usable now, no compatibility promise, promoted by dropping the attribute. Referencing one is a build error until the consumer suppresses its diagnostic ID, which is the acknowledgement. `COSMOS0001` is the scheduler policy seam, `COSMOS0002` the packet seam.
3. **Everything else is internal.** First-party assemblies and the white-box test kernels reach internals through `InternalsVisibleTo`; anyone else goes through `[UnsafeAccessor]` and accepts that internals move.

The enforcement test is mechanical rather than a matter of taste: `examples/DevKernel` must compile with no `InternalsVisibleTo` grant. If DevKernel needs a symbol, the symbol becomes public or earns a `Cosmos.Kernel.System` facade; if it does not, it stays internal. That forced the facades this branch adds — logging, memory, scheduler stats and feature switches — and the ports of DevKernel, the black-box test kernels and the test framework onto them.

API tracking now extends past System to `Core`, `HAL` and `HAL.Interfaces`, with `RS0016`/`RS0017` promoted to build errors, so any surface movement lands in the PR as a `PublicAPI.Unshipped.txt` diff.

**Validating the seam.** A seam with one implementation proves nothing, so the scheduler seam gets a second policy: `RoundRobinScheduler` lives in the Threading suite written the way a user kernel would write it, public surface only, no Core internals. It found a real bug — `UpdateGlobalPass` divided a `Stopwatch` tick delta by a nanosecond quantum, so global virtual time ran several times fast on x64 and slow on ARM64, and the anti-starvation floor in `OnThreadYield` then snapped every runnable thread up to `GlobalPass`. Stride was not proportional at all; the four-times-tickets thread got an equal share. Fixed here, along with a bound on the catch-up delta and the pre-sizing that keeps `InsertByPass` from allocating inside the tick.

## Verification

Policy behaviour, measured as the loop count of two CPU-bound spinners over a fixed window. One ratio separates the two policies from both sides — the four-times-tickets thread must clear 1.5x under Stride, and neither thread may reach it under Round-Robin:

| Policy | Tickets | x64 | ARM64 |
|---|---|---|---|
| Stride | 400 : 100 | 2.07 – 2.20 | 1.92 – 2.13 |
| Round-Robin | 100 : 100 | 0.88 – 1.13 | 1.00 – 1.06 |
| Round-Robin | 400 : 100 | 0.89 – 1.13 | 0.95 – 1.00 |

Suites run locally on this branch:

| Suite | x64 | ARM64 |
|---|---|---|
| Threading | 73/73 | 73/73 |
| Runtime | 103/103 | — |
| GarbageCollector | 45/45 | — |
| Timer | 24/24 | — |

The Threading cells split by what they can prove. The run-structure invariants — tail enqueue, head pick, quantum accounting, block, yield, exit — drive the hooks directly on a throwaway `PerCpuState`, so they need no timer and cannot flake. Only what genuinely needs a running kernel is measured live, and the live half deliberately does not assert dispatch order: a thread preempted inside its dispatch preamble goes to the tail, so the order threads reach their delegate is not the order they became ready.

Internalizing the HAL took `TimerDevice` with it and cost the Timer suite its build (three CS0122, no tests executed). It is a white-box suite over that base class and the six others like it already carried the grant, so it gets one too — that is the last commit here, and the 24/24 above is with it.
