### PR TITLE
 Report the last-GC snapshot through GCMemoryInfo

### DIFF
--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Info.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.Info.cs
@@ -371,9 +371,20 @@ public static unsafe partial class GarbageCollector
     }
 
     /// <summary>
-    /// Populate a lightweight memory info snapshot.
-    /// Provide a best-effort implementation of RhGetMemoryInfo based on the GC state.
+    /// Computes every heap-wide metric from the current state of the GC, parsing the
+    /// segments, the free lists and the handle store at call time.
+    /// <para>
+    /// This is a live reading, not a snapshot unlike <see cref="GC.GetGCMemoryInfo()"/>.
+    /// Use it for memory monitor or a diagnostic dump.
+    /// </para>
     /// </summary>
+    /// <remarks>
+    /// Best-effort: these are the closest equivalents this collector can offer to the metrics
+    /// the runtime GC reports.
+    /// </remarks>
+    /// <seealso cref="GetLastGCMemoryInfo">
+    /// Use <see cref="GetLastGCMemoryInfo"/> in the general case, this method is specialized.
+    /// </seealso>
     public static SimpleMemoryInfo GetSimpleMemoryInfo()
     {
         SimpleMemoryInfo info = default;
@@ -392,6 +403,28 @@ public static unsafe partial class GarbageCollector
         info.CondemnedGeneration = GetCondemnedGeneration();
 
         return info;
+    }
+
+    /// <summary>
+    /// Returns the heap-wide metrics took at the end of the last collection.
+    /// Equivalent to <see cref="GC.GetGCMemoryInfo()"/>.
+    /// <para>
+    /// These are the values <see cref="GC.GetGCMemoryInfo()"/> reports.
+    /// It follow what the BCL promises for every member of <see cref="GCMemoryInfo"/>.
+    /// All fields are zero until the first collection.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// Best-effort: these are the closest equivalents this collector can offer to the metrics
+    /// the runtime GC reports.
+    /// </remarks>
+    /// <seealso cref="GetSimpleMemoryInfo">
+    /// Call <see cref="GetSimpleMemoryInfo"/> instead to recompute the same metrics from
+    /// the live state of the heap.
+    /// </seealso>
+    public static SimpleMemoryInfo GetLastGCMemoryInfo()
+    {
+        return s_lastGCMemoryInfo;
     }
 
     /// <summary>
@@ -549,6 +582,15 @@ public static unsafe partial class GarbageCollector
     {
         totalCollections = s_totalCollections;
         totalObjectsFreed = s_totalObjectsFreed;
+    }
+
+    /// <summary>
+    /// Captures the live metrics as the new last-collection snapshot. Called once per
+    /// collection, at the very end of <see cref="Collect"/>.
+    /// </summary>
+    internal static void RecordLastGCMemoryInfo()
+    {
+        s_lastGCMemoryInfo = GetSimpleMemoryInfo();
     }
 
 }

--- a/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.cs
+++ b/src/Cosmos.Kernel.Core/Memory/GarbageCollector/GarbageCollector.cs
@@ -223,6 +223,14 @@ public static unsafe partial class GarbageCollector
     private static ulong s_lastGen0FragmentationAfter;
 
     /// <summary>
+    /// Heap-wide metrics as they stood at the end of the last collection.
+    /// This is what <see cref="GCMemoryInfo"/> reports.
+    /// Stays zeroed until the first collection runs.
+    /// Matches what the runtime reports before its first GC.
+    /// </summary>
+    private static SimpleMemoryInfo s_lastGCMemoryInfo;
+
+    /// <summary>
     /// Cumulative total of all bytes ever allocated through the GC.
     /// Increments on every allocation, never decrements.
     /// Used by <c>RhGetTotalAllocatedBytes</c> / <c>GC.GetTotalAllocatedBytes()</c>.
@@ -376,6 +384,10 @@ public static unsafe partial class GarbageCollector
 
             s_totalCollections++;
             s_totalObjectsFreed += freedCount;
+
+            // Freeze the heap-wide metrics reported by GCMemoryInfo. Recorded after the
+            // counters above so the snapshot carries the index of this very collection.
+            RecordLastGCMemoryInfo();
 
             Serial.WriteString("[GC] Freed ");
             Serial.WriteNumber((uint)freedCount);

--- a/src/Cosmos.Kernel.Core/Runtime/GC.cs
+++ b/src/Cosmos.Kernel.Core/Runtime/GC.cs
@@ -58,7 +58,10 @@ internal static unsafe class GC
         fixed (byte* pRawData = &rawData)
         {
             var data = (GCMemoryInfoDataStruct*)pRawData;
-            GarbageCollector.SimpleMemoryInfo info = GarbageCollector.GetSimpleMemoryInfo();
+
+            // I did the mistake once, the doc clearly specify that the memory info should not change bettewin GC.
+            // It's not writen in the public API, it's writen in System.Private.CoreLib
+            GarbageCollector.SimpleMemoryInfo info = GarbageCollector.GetLastGCMemoryInfo();
 
             // the ration 0.5 is arbitrary, should be change in the future
             data->_highMemoryLoadThresholdBytes = (long)(PageAllocator.RamSize / 2);

--- a/tests/Kernels/Cosmos.Kernel.Tests.GarbageCollector/Kernel.cs
+++ b/tests/Kernels/Cosmos.Kernel.Tests.GarbageCollector/Kernel.cs
@@ -24,7 +24,7 @@ public class Kernel : Sys.Kernel
         Serial.WriteString("[GarbageCollector] BeforeRun() reached!\n");
         Serial.WriteString("[GarbageCollector] Starting tests...\n");
 
-        TR.Start("GarbageCollector Tests", expectedTests: 45);
+        TR.Start("GarbageCollector Tests", expectedTests: 46);
 
         // Garbage Collection Tests
         TR.Run("GC_IsEnabled", TestGCIsEnabled);
@@ -71,6 +71,7 @@ public class Kernel : Sys.Kernel
         TR.Run("GC_Info_GetObjectGeneration", TestGCInfoGetObjectGeneration);
         TR.Run("GC_Info_GCSegmentSizeAndPercent", TestGCInfoGCSegmentSizeAndPercent);
         TR.Run("GC_Info_RhGetMemoryInfoWiring", TestGCInfoRhGetMemoryInfoWiring);
+        TR.Run("GC_Info_MemoryInfoFrozenBetweenCollections", TestGCInfoMemoryInfoFrozenBetweenCollections);
         TR.Run("GC_Variables", TestGCVariables);
 
         // TLAB (Thread-Local Allocation Buffer) Tests
@@ -1272,28 +1273,29 @@ public class Kernel : Sys.Kernel
     private static void TestGCInfoRhGetMemoryInfoWiring()
     {
         // System.GC.GetGCMemoryInfo() routes through RhGetMemoryInfo, which fills a
-        // GCMemoryInfoData struct from CoreGC.GetSimpleMemoryInfo() plus the
+        // GCMemoryInfoData struct from CoreGC.GetLastGCMemoryInfo() plus the
         // per-generation last-collect snapshots. The struct layout must match exactly.
         //
-        // Order matters: GC.GetGCMemoryInfo() allocates a GCMemoryInfoData class instance
-        // before populating it, which can consume a free-list block and shift FragmentedBytes.
-        // Read the runtime snapshot first, then take the direct snapshot — both then reflect
-        // the post-allocation heap state and must agree.
+        // Both sides read the same frozen snapshot, so the order of these two calls no
+        // longer matters: the GCMemoryInfoData instance that GC.GetGCMemoryInfo() allocates
+        // may still consume a free-list block, but that cannot shift the reported values.
+        CoreGC.Collect();
+
         GCMemoryInfo runtimeInfo = GC.GetGCMemoryInfo();
-        CoreGC.SimpleMemoryInfo direct = CoreGC.GetSimpleMemoryInfo();
+        CoreGC.SimpleMemoryInfo direct = CoreGC.GetLastGCMemoryInfo();
 
         Assert.Equal((long)direct.HeapSizeBytes, runtimeInfo.HeapSizeBytes,
-            "GC.Info: GCMemoryInfo.HeapSizeBytes must mirror GetSimpleMemoryInfo");
+            "GC.Info: GCMemoryInfo.HeapSizeBytes must mirror GetLastGCMemoryInfo");
         Assert.Equal((long)direct.FragmentedBytes, runtimeInfo.FragmentedBytes,
-            "GC.Info: GCMemoryInfo.FragmentedBytes must mirror GetSimpleMemoryInfo");
+            "GC.Info: GCMemoryInfo.FragmentedBytes must mirror GetLastGCMemoryInfo");
         Assert.Equal((long)direct.TotalCommittedBytes, runtimeInfo.TotalCommittedBytes,
-            "GC.Info: GCMemoryInfo.TotalCommittedBytes must mirror GetSimpleMemoryInfo");
+            "GC.Info: GCMemoryInfo.TotalCommittedBytes must mirror GetLastGCMemoryInfo");
         Assert.Equal((long)direct.MemoryLoadBytes, runtimeInfo.MemoryLoadBytes,
-            "GC.Info: GCMemoryInfo.MemoryLoadBytes must mirror GetSimpleMemoryInfo");
+            "GC.Info: GCMemoryInfo.MemoryLoadBytes must mirror GetLastGCMemoryInfo");
         Assert.Equal((long)direct.PromotedBytes, runtimeInfo.PromotedBytes,
-            "GC.Info: GCMemoryInfo.PromotedBytes must mirror GetSimpleMemoryInfo");
+            "GC.Info: GCMemoryInfo.PromotedBytes must mirror GetLastGCMemoryInfo");
         Assert.Equal((long)direct.PinnedObjectsCount, runtimeInfo.PinnedObjectsCount,
-            "GC.Info: GCMemoryInfo.PinnedObjectsCount must mirror GetSimpleMemoryInfo");
+            "GC.Info: GCMemoryInfo.PinnedObjectsCount must mirror GetLastGCMemoryInfo");
         Assert.Equal((long)direct.CollectionIndex, runtimeInfo.Index,
             "GC.Info: GCMemoryInfo.Index must equal CollectionIndex");
         Assert.Equal(direct.CondemnedGeneration, runtimeInfo.Generation,
@@ -1314,6 +1316,48 @@ public class Kernel : Sys.Kernel
             "GC.Info: GenerationInfo[0].FragmentationBeforeBytes must mirror GetLastGenFragmentationBefore(0)");
         Assert.Equal((long)CoreGC.GetLastGenFragmentationAfter(0), runtimeInfo.GenerationInfo[0].FragmentationAfterBytes,
             "GC.Info: GenerationInfo[0].FragmentationAfterBytes must mirror GetLastGenFragmentationAfter(0)");
+    }
+
+    private static void TestGCInfoMemoryInfoFrozenBetweenCollections()
+    {
+        // GCMemoryInfo describes the heap as of the last collection, so allocating must not
+        // move any of its values: only the next collection may. Regression guard for the
+        // live readings that used to be reported through RhGetMemoryInfo.
+        CoreGC.Collect();
+
+        GCMemoryInfo before = GC.GetGCMemoryInfo();
+
+        // This changes the live heap: it consumes free-list blocks to refill TLABs, which is
+        // exactly what used to shift FragmentedBytes between two reads.
+        AllocateGarbage(40, 256);
+
+        GCMemoryInfo after = GC.GetGCMemoryInfo();
+
+        // A heap-pressure collection may have run on its own during the allocations above;
+        // the freeze only has to hold as long as no collection happened in between.
+        if (before.Index == after.Index)
+        {
+            Assert.Equal(before.FragmentedBytes, after.FragmentedBytes,
+                "GC.Info: FragmentedBytes must not change without a collection");
+            Assert.Equal(before.HeapSizeBytes, after.HeapSizeBytes,
+                "GC.Info: HeapSizeBytes must not change without a collection");
+            Assert.Equal(before.TotalCommittedBytes, after.TotalCommittedBytes,
+                "GC.Info: TotalCommittedBytes must not change without a collection");
+            Assert.Equal(before.MemoryLoadBytes, after.MemoryLoadBytes,
+                "GC.Info: MemoryLoadBytes must not change without a collection");
+        }
+
+        // This GC only has generation 0, so the heap-wide fragmentation is by construction
+        // the fragmentation gen0 was left with by the last collection.
+        Assert.Equal(after.GenerationInfo[0].FragmentationAfterBytes, after.FragmentedBytes,
+            "GC.Info: FragmentedBytes must equal GenerationInfo[0].FragmentationAfterBytes");
+
+        // A collection is what publishes new values.
+        CoreGC.Collect();
+
+        GCMemoryInfo collected = GC.GetGCMemoryInfo();
+        Assert.True(collected.Index > after.Index,
+            "GC.Info: Index must advance after a collection");
     }
 
     private static void TestGCVariables()


### PR DESCRIPTION
Fix https://github.com/valentinbreiz/nativeaot-patcher/pull/296

I writed GetLastGCMemoryInfo for GC.GetGCMemoryInfo. GetSimpleMemoryInfo did not change.
I rewrote summary to clarify the methods.

Claude wrote the test. A check exist in the test to avoid false data if the GC run by it self.

NB: i did this because the current implementation do not follow the doc of private lib 